### PR TITLE
Hide delete option in media mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,16 @@ The **Styling** tab provides a visual editor for colors and border radius.
 
 ## Delete setup
 
+> [!IMPORTANT]
+> Delete is not available in `source_mode: media`. In media mode the option is hidden in the thumbnail menu and disabled in the editor — media-source items (Frigate, network shares, etc.) don't map to filesystem paths the shell command can delete.
+
 > [!TIP]
 > To enable delete actions, configure a shell command in Home Assistant and provide the service name in the card editor under **General → Delete service**.
 
-Optional delete options are also available in the editor:
+Optional delete options (YAML only — not currently exposed in the editor):
 
-- Confirm before deleting
-- Allow bulk delete
+- `delete_confirm: false` — skip the confirmation dialog
+- `allow_bulk_delete: true` — enable multi-select bulk delete
 
 > [!NOTE]
 > Delete is intended for files inside `/config/www/`. Frigate media sources do not support delete actions.

--- a/camera-gallery-card.js
+++ b/camera-gallery-card.js
@@ -4745,13 +4745,23 @@ class CameraGalleryCard extends LitElement {
 
     let effectiveAllowDelete = allow_delete;
     let effectiveAllowBulkDelete = allow_bulk_delete;
+    let effectiveDeleteService = delete_service;
 
     if (wantsDelete && !delete_service) {
       effectiveAllowBulkDelete = false;
       effectiveAllowDelete = false;
     }
 
-    if (delete_service && !/^[a-z0-9_]+\.[a-z0-9_]+$/i.test(delete_service)) {
+    // Delete only works when items map to filesystem paths — media-source
+    // URIs (Frigate, network shares, etc.) can't be deleted by the shell
+    // command, so clear delete-related keys in pure media mode.
+    if (source_mode === "media") {
+      effectiveAllowDelete = false;
+      effectiveAllowBulkDelete = false;
+      effectiveDeleteService = "";
+    }
+
+    if (effectiveDeleteService && !/^[a-z0-9_]+\.[a-z0-9_]+$/i.test(effectiveDeleteService)) {
       throw new Error(
         "camera-gallery-card: 'delete_service' must be 'domain.service'"
       );
@@ -4810,7 +4820,7 @@ class CameraGalleryCard extends LitElement {
       bar_opacity,
       bar_position,
       delete_confirm,
-      delete_service: delete_service || "",
+      delete_service: effectiveDeleteService || "",
       entities: (source_mode === "sensor" || source_mode === "combined") ? sensorEntitiesClean : [],
       entity: (source_mode === "sensor" || source_mode === "combined") ? sensorEntitiesClean[0] || "" : "",
       entity_filter_map,
@@ -9130,21 +9140,26 @@ class CameraGalleryCardEditor extends HTMLElement {
                 </details>
               </div>
 
-              <div class="row">
+              <div class="row ${mediaModeOn ? "row-disabled" : ""}">
                 <div class="lbl">Delete service</div>
                 <div class="hint">
-                  ${svgIcon('mdi:help-circle-outline', 14)}
-                  <a
-                    href="https://github.com/TheScubadiver/camera-gallery-card?tab=readme-ov-file#delete-setup"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    How to configure the shell command
-                  </a>
+                  ${mediaModeOn ? `
+                    ${svgIcon('mdi:information-outline', 14)}
+                    <span>Delete is not available in <strong>Media folders</strong> mode. Media-source items don't map to filesystem paths the shell command can delete — switch the source above to enable.</span>
+                  ` : `
+                    ${svgIcon('mdi:help-circle-outline', 14)}
+                    <a
+                      href="https://github.com/TheScubadiver/camera-gallery-card?tab=readme-ov-file#delete-setup"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      How to configure the shell command
+                    </a>
+                  `}
                 </div>
 
                 <div class="selectwrap">
-                  <select class="select ${deleteOk ? "" : "invalid"}" id="delservice">
+                  <select class="select ${deleteOk ? "" : "invalid"}" id="delservice" ${mediaModeOn ? "disabled" : ""}>
                     ${
                       deleteChoices.length
                         ? `<option value=""></option>` +
@@ -9813,6 +9828,14 @@ class CameraGalleryCardEditor extends HTMLElement {
 
         .row:hover {
           border-color: var(--ed-row-border);
+        }
+
+        .row-disabled {
+          opacity: 0.6;
+        }
+
+        .row-disabled .lbl {
+          color: var(--ed-text2);
         }
 
         .row-head {
@@ -11264,9 +11287,19 @@ if (oldPanel && tmp.firstElementChild) {
     });
 
     this.shadowRoot.querySelectorAll("[data-src]").forEach((btn) => {
-      btn.addEventListener("click", () =>
-        this._set("source_mode", btn.dataset.src)
-      );
+      btn.addEventListener("click", () => {
+        const next = btn.dataset.src;
+        if (next === "media") {
+          const cleaned = { ...this._config };
+          delete cleaned.delete_service;
+          delete cleaned.shell_command;
+          delete cleaned.allow_delete;
+          delete cleaned.allow_bulk_delete;
+          delete cleaned.delete_confirm;
+          this._config = this._stripAlwaysTrueKeys(cleaned);
+        }
+        this._set("source_mode", next);
+      });
     });
 
     const browseBtn = $("browse-media-folders");


### PR DESCRIPTION
## Summary

- **Editor**: when `source_mode` is `media`, the Delete service control is now visible but disabled, with an inline explanation pointing back to the source toggle. Previously it was interactive but non-functional.
- **Runtime**: `setConfig` now clears `delete_service`, `allow_delete`, and `allow_bulk_delete` when `source_mode !== "sensor"`, so YAML doesn't carry stale "delete is configured" state.
- **Editor (toggle)**: switching the source mode away from sensor strips delete-related keys from the editor's local config so they don't linger in the YAML view.
- **README**: added an `[!IMPORTANT]` callout at the top of the Delete setup section stating delete is sensor-only, and corrected the line that claimed `delete_confirm` / `allow_bulk_delete` are exposed in the editor (they're YAML only).

## Why

I configured `delete_service` per the README in `source_mode: media` and never saw the Delete option in the long-press thumbnail menu. Tracing it: `_thumbCanDelete()` and `_deleteSingle()` both hard-gate on `source_mode === "sensor"`, and `_toFsPath()` only knows how to map `/local/...` and `/config/www/...` — `media-source://...` URIs and signed `/api/...` URLs have no general filesystem mapping the shell command can act on. So delete genuinely can't reuse the existing pipeline in media mode.

Rather than implement a media-mode delete pipeline (which would need provider-specific logic — Frigate's API for Frigate, path-mapping for the local provider, and would still leave most providers undeletable), this PR makes the existing limitation visible in the UI and YAML.

Out of scope: actually supporting delete in media mode. Happy to follow up on that as a separate PR if you'd like — and happy to bump `CARD_VERSION` / add a CHANGELOG entry for this fix if you want it folded into a release, just let me know what version.

## Test plan

- [x] Sensor mode with configured `delete_service` still shows Delete in the long-press menu
- [x] Media mode shows only Download in the long-press menu
- [x] Editor in media mode: Delete service row visible but the dropdown is disabled, the row is muted, and the hint text explains why
- [x] Toggling source from sensor → media in the editor removes delete keys from the YAML view
- [x] HACS validation passes
