### PR TITLE
Respect HA time_format for thumbnail timestamps

### DIFF
--- a/camera-gallery-card.js
+++ b/camera-gallery-card.js
@@ -1185,6 +1185,21 @@ class CameraGalleryCard extends LitElement {
     return undefined;
   }
 
+  // Mirrors HA's useAmPm: respects hass.locale.time_format ("12" | "24" |
+  // "language" | "system"), falling back to a probe of the resolved locale.
+  _useAmPm() {
+    const tf = this._hass?.locale?.time_format;
+    if (tf === "24") return false;
+    if (tf === "12") return true;
+    try {
+      const probeLocale = tf === "language" ? this._locale() : undefined;
+      const sample = new Date().toLocaleString(probeLocale);
+      return /AM|PM/i.test(sample);
+    } catch (_) {
+      return false;
+    }
+  }
+
   _pathHasClass(path = [], cls = "") {
     return path.some((el) => el?.classList?.contains(cls));
   }
@@ -3793,6 +3808,7 @@ class CameraGalleryCard extends LitElement {
       const time = new Intl.DateTimeFormat(locale, {
         hour: "2-digit",
         minute: "2-digit",
+        hour12: this._useAmPm(),
       }).format(dt);
 
       return `${date} • ${time}`;
@@ -3831,6 +3847,7 @@ class CameraGalleryCard extends LitElement {
       return new Intl.DateTimeFormat(this._locale(), {
         hour: "2-digit",
         minute: "2-digit",
+        hour12: this._useAmPm(),
       }).format(new Date(ms));
     } catch (_) {
       return "";


### PR DESCRIPTION
## Summary

Currently the thumbnail timestamp (e.g. on the bottom-sheet menu and date/time labels) ignores the user's Home Assistant **Time format** preference and renders whatever the resolved locale defaults to. Users who have HA set to 24h see `03:51 PM` instead of `15:51`.

This PR reads `hass.locale.time_format` and threads `hour12` through the two `Intl.DateTimeFormat` call sites that produce time-of-day output:

- `_formatDateTime` (used by the thumbnail menu subtitle and selected-item label)
- `_formatTimeFromMs` (used by per-item time pills)

A new `_useAmPm()` helper mirrors HA frontend's [`useAmPm`](https://github.com/home-assistant/frontend/blob/dev/src/common/datetime/use_am_pm.ts):

- `"12"` → `hour12: true`
- `"24"` → `hour12: false`
- `"language"` / `"system"` → probe `new Date().toLocaleString(...)` for `AM`/`PM` and decide from there

This is the same pattern HA itself uses, and the same pattern the popular [swiss-army-knife-card](https://github.com/AmoebeLabs/swiss-army-knife-card/blob/main/src/frontend_mods/datetime/use_am_pm.js) vendors verbatim. Other cards (Bubble-Card, ha-heatmap-card) use a simpler `=== "12"` check, which silently breaks for `"language"`/`"system"` users — this PR uses the correct full implementation.

No new dependencies, no build step changes, single-file edit. Date naming (month/day) was already locale-aware via `hass.locale.language`; this PR only addresses the time portion.

## Test plan

- [x] HA configured with **Time format: 24-hour** → thumbnail timestamps render as `15:51`
- [x] Switching HA to **Time format: 12-hour (AM/PM)** → timestamps render as `3:51 PM`
- [x] **Time format: Auto (system/language)** → matches the user's browser/locale convention
- [x] Verify in both `source_mode: sensor` and `source_mode: media`
