### PR TITLE
Fix _micErrorTimer leak in disconnectedCallback

### DIFF
--- a/camera-gallery-card.js
+++ b/camera-gallery-card.js
@@ -418,10 +418,12 @@ class CameraGalleryCard extends LitElement {
     if (this._liveQuickSwitchTimer) clearTimeout(this._liveQuickSwitchTimer);
     if (this._navHideT) clearTimeout(this._navHideT);
     if (this._bulkHintTimer) clearTimeout(this._bulkHintTimer);
+    if (this._micErrorTimer) clearTimeout(this._micErrorTimer);
 
     this._liveQuickSwitchTimer = null;
     this._navHideT = null;
     this._bulkHintTimer = null;
+    this._micErrorTimer = null;
 
     this._clearPreviewVideoHostPlayback();
 


### PR DESCRIPTION
  ## What
  Clears `_micErrorTimer` in `disconnectedCallback`.

  ## Why
  When a mic error occurs, an 8-second timer is started to auto-clear the error message.
  If the card is removed from the dashboard while this timer is still running, it keeps
  ticking in memory, preventing garbage collection of the card instance.

  ## How
  Added `clearTimeout` + `null` for `_micErrorTimer` in `disconnectedCallback`, consistent
  with how `_liveQuickSwitchTimer`, `_navHideT` and `_bulkHintTimer` are already handled.