### PR TITLE
ci: add PR-title check via pull_request_target trigger

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,53 @@
+name: PR title
+
+# `amannn/action-semantic-pull-request` makes an authenticated API call to
+# read the PR; on a fork-originated `pull_request` the GITHUB_TOKEN's scope
+# is too narrow and the action 404s. The action's documented fix is to run
+# under `pull_request_target` instead, which executes in the upstream's
+# context with a token that can read the PR — but `pull_request_target`
+# reads workflows from the base branch, so this file has to be on `main`
+# before it can lint anything.
+#
+# Safety: this workflow does NOT check out PR code or run any contributor
+# scripts. It only reads the PR title from the event payload via an Action
+# and exits. The well-known `pull_request_target` security risk only
+# applies when a workflow runs untrusted PR code with elevated tokens.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: Check PR title is conventional
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            style
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: |
+            The PR title subject must start with a lowercase letter and not end with a period.
+            Example: "feat: add multi-camera live view".


### PR DESCRIPTION
## Summary

Adds the missing PR-title workflow using the proper trigger so future cross-repo PRs get linted by `amannn/action-semantic-pull-request` instead of (only) the inline regex fallback.

In #36 we tried the action under `pull_request` and it 404'd — that's documented behavior, not a bug. The action requires `pull_request_target` for fork PRs, which in turn requires the workflow to live on `main` before it can lint anything (the trigger reads workflow definitions from the base branch). So this PR introduces it; from the next PR onward, the action will fire.

The existing inline regex in `ci.yml` stays as a fallback for now — same logic, no API calls, no privileged token. Once we trust the action on a few PRs, a follow-up can delete the inline check.

## Companion fix needed (no code, repo settings only)

The first `Release` workflow run on `main` after #36 merged failed at the `actions/create-github-app-token` step:

```
Error: error:1E08010C:DECODER routines::unsupported
```

That's a Node/OpenSSL "private key format unrecognized" error. The fix is to re-add the `RELEASE_BOT_PRIVATE_KEY` secret with the full `.pem` contents — most common cause is missing the `-----BEGIN/END-----` lines, line endings being mangled to CRLF, or the value being pasted as a single-line escaped string. Steps:

1. Repo → Settings → Secrets and variables → Actions → Secrets tab.
2. Click `RELEASE_BOT_PRIVATE_KEY` → "Update secret".
3. In a plain text editor, open the original `.pem` you downloaded from the GitHub App. Copy **everything** including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----`, with normal LF line endings.
4. Paste, save.

If the `.pem` is lost, regenerate one from the GitHub App's settings page → "Private keys" → "Generate a private key", then repeat steps 1–4.

After updating the secret, you can re-run the failed workflow from the **Actions** tab → click the failed run → "Re-run all jobs" — or just push a small commit and the next release workflow run will pick up the new secret.

There's also a deprecation warning about `Input 'app-id' has been deprecated`. That's cosmetic and doesn't affect anything; can be migrated to `client-id` in a future cleanup PR.

## Test plan

- [ ] CI's inline regex check passes on this PR (covers fork PR via `pull_request`).
- [ ] After merge, on the next fork-originated PR, the `PR title` workflow fires via `pull_request_target` and the action runs without 404'ing.
- [ ] After fixing the `RELEASE_BOT_PRIVATE_KEY` secret, the `Release` workflow's `release-please` job succeeds and opens the first release PR.