### PR TITLE
chore(ci): consolidate dependabot dev-tooling into one weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,23 +12,17 @@ updates:
       prefix: chore
       include: scope
     groups:
-      rollup:
+      # Bundle all dev-tooling minor + patch updates into a single weekly PR.
+      # Major bumps fall through to individual PRs so they get a closer look.
+      # Production deps (lit) are not in this group, so they always get an
+      # individual PR for careful review — they affect the shipped bundle.
+      dev-tooling:
+        dependency-type: development
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
-          - "rollup"
-          - "@rollup/*"
-      eslint:
-        patterns:
-          - "eslint"
-          - "@eslint/*"
-          - "eslint-*"
-          - "typescript-eslint"
-      typescript:
-        patterns:
-          - "typescript"
-          - "tslib"
-      lit:
-        patterns:
-          - "lit"
+          - "*"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary

Cuts dependabot's PR noise from ~7 per week to ~1–2 by bundling all dev-tooling minor/patch bumps into a single PR.

**Before:** rollup, eslint, typescript, lit each had their own group; everything else (chokidar, concurrently, dotenv, globals, husky, lint-staged, prettier) got an individual PR per bump.

**After:** one `dev-tooling` group that catches every devDep minor + patch update. Major bumps still get individual PRs (so they actually get reviewed). Production deps (lit) stay un-grouped because changes to what ships in the bundle deserve a separate look.

## Test plan

- [ ] Next Monday's dependabot run produces at most one consolidated dev-tooling PR plus any individual major-bump or `lit` PRs.
- [ ] Existing weekly schedule, prefix, timezone all unchanged.