### PR TITLE
chore(ci): remove inline PR-title check (action covers it now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,36 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-title:
-    name: Check PR title is conventional
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      # The PR title is in the event payload — no API call needed. Doing this
-      # inline avoids depending on a third-party action whose v6 upgrade
-      # broke under cross-repo PRs (404s) and whose v5 path is unmaintained.
-      - name: Check PR title
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if [[ ! "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|style|test|build|ci|chore|revert)(\(.+\))?\!?:\ [a-z].+[^.]$ ]]; then
-            cat <<EOF
-          ::error::PR title "$PR_TITLE" is not a valid conventional commit.
-
-          Format: <type>(<optional scope>)!?: <subject>
-            type:    feat | fix | perf | refactor | docs | style | test | build | ci | chore | revert
-            subject: starts with a lowercase letter, no trailing period
-
-          Examples:
-            feat: add multi-camera live view
-            fix(editor): align thumbnail strip side padding
-            feat!: drop support for source_mode "files" alias
-          EOF
-            exit 1
-          fi
-          echo "PR title OK: $PR_TITLE"
-
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

The PR-title check was duplicated: `ci.yml` had an inline regex on `pull_request`, and `pr-title.yml` had `amannn/action-semantic-pull-request` on `pull_request_target`. Both ran on every PR, producing two `Check PR title is conventional` statuses.

The inline regex was a transition fallback — `pull_request_target` reads workflows from `main`, so the PR introducing `pr-title.yml` couldn't run it on itself. That bridge is no longer needed; the action is on main and has run cleanly on #43, #44, #47.

This PR removes the inline check.

## Test plan

- [ ] After merge, PRs show **one** `Check PR title is conventional` status (the one from `pr-title.yml`), not two.

## Note for branch protection

The required-checks list in the `main` ruleset has `Check PR title is conventional` listed. That status is now produced solely by the `PR title` workflow (the new file we added in #42), still under the same display name — so the required check resolves correctly. No branch-protection change needed.