### PR TITLE
docs: rewrite contributor guide and auto-update README version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,115 +1,212 @@
 # Contributing
 
-Thanks for contributing to camera-gallery-card.
+Thanks for contributing to camera-gallery-card. This guide walks you through the full flow — from cloning the repo to seeing your change in a released version — and lists the tooling and conventions you'll run into along the way.
 
-This guide covers the local dev loop, commit conventions, and how the release pipeline works so you know what to expect after your PR is merged.
+## Quick reference
 
-## Local development setup
+```bash
+# one-time setup
+git clone https://github.com/<your-username>/camera-gallery-card.git
+cd camera-gallery-card
+npm install
+cp .env.example .env   # set HA_HOST and HA_DEV_PATH
 
-The dev workflow rsyncs the rebuilt bundle into HA's `/config/www/dev/` and registers a small loader as a Lovelace resource that auto-reloads when the file changes.
+# every change
+git switch -c fix/some-bug                  # or feat/...
+npm run dev                                 # rebuilds + rsyncs to HA on save
+# ... edit src/index.js, watch the dashboard auto-reload ...
+npm run check                               # typecheck + lint + format + build
+git add -A && git commit -m "fix: short description"
+git push -u origin fix/some-bug
+gh pr create --base main                    # or open via the GitHub UI
+```
 
-### Prerequisites
+The PR title is what matters — it must be a [conventional commit](#commit-and-pr-title-format) (e.g. `fix: prevent timer leak`). It becomes the squash-merge commit on `main`, and the release pipeline reads it to decide the next version and generate the changelog.
 
-- Node.js (see [`.nvmrc`](.nvmrc) — currently 20)
-- HA Advanced SSH & Web Terminal add-on (the basic one has no rsync)
-- SSH key auth, ideally with a host alias in `~/.ssh/config`
+## The full flow, end to end
 
-### Setup
+### 1. Fork the repo
 
-Create the target dir on HA, owned by your SSH user:
+Click **Fork** in the top-right of [TheScubaDiver/camera-gallery-card](https://github.com/TheScubaDiver/camera-gallery-card). You'll get your own copy at `https://github.com/<your-username>/camera-gallery-card`.
+
+### 2. Clone your fork and add upstream as a remote
+
+```bash
+git clone https://github.com/<your-username>/camera-gallery-card.git
+cd camera-gallery-card
+git remote add upstream https://github.com/TheScubaDiver/camera-gallery-card.git
+```
+
+### 3. One-time local setup
+
+Install dependencies. This also installs the husky pre-commit hook automatically (via the `prepare` script in `package.json`).
+
+```bash
+npm install
+```
+
+Set up your `.env` for the dev loop (next step). Copy the example file and fill in your HA host and target path:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env`:
+
+```
+HA_HOST=hassio@homeassistant.local       # or an SSH alias from ~/.ssh/config
+HA_DEV_PATH=/config/www/dev/             # absolute path on HA, must end with /
+```
+
+On HA, create the target directory once with the right ownership (otherwise rsync will fail):
 
 ```bash
 ssh my-ha 'sudo mkdir -p /config/www/dev && sudo chown -R $(whoami): /config/www/dev'
 ```
 
-Then locally:
+In your HA dashboard, go to **Settings → Dashboards → ⋮ → Resources** and add a JavaScript Module pointing to one of:
+
+- `/local/dev/loader-hot.js` — dashboard auto-reloads when the bundle changes (recommended)
+- `/local/dev/loader.js` — manual reload
+
+Important: **disable any existing `/hacsfiles/camera-gallery-card/...` resource** while you're developing. Lovelace only honors one resource per custom-element name; if both are active you'll get unpredictable behavior.
+
+### 4. Create a branch
+
+Branch off `main` in your fork. Use a descriptive name that hints at the change. The conventional pattern matches the commit type:
 
 ```bash
-npm install
-cp .env.example .env   # set HA_HOST and HA_DEV_PATH
-npm run push
+git fetch upstream
+git switch -c fix/mic-error-timer-leak upstream/main
+# or
+git switch -c feat/multi-camera-picker upstream/main
 ```
 
-In HA, add a Lovelace resource at Settings → Dashboards → ⋮ → Resources:
-
-- Type: JavaScript Module
-- URL: `/local/dev/loader.js` for manual reloads, or `/local/dev/loader-hot.js` for auto reload
-
-Remove any existing `/hacsfiles/camera-gallery-card/...` resource. Only one entry per custom element name will work.
-
-### Develop
+### 5. Run the dev loop
 
 ```bash
 npm run dev
 ```
 
-Two watchers run side-by-side: Rollup watches `src/` and rebuilds `dist/camera-gallery-card.js` on every save; `scripts/dev/push.mjs --watch` watches that bundle file and rsyncs it to HA. With `loader-hot.js`, the dashboard reloads itself a couple of seconds after the bundle changes on disk.
+This runs two watchers side-by-side:
 
-Other useful scripts:
+1. **Rollup** watches `src/` and rebuilds `dist/camera-gallery-card.js` whenever you save.
+2. **`scripts/dev/push.mjs --watch`** watches the rebuilt bundle and rsyncs it (along with the dev loaders) to your HA at `$HA_HOST:$HA_DEV_PATH`.
 
-| Script              | What it does                                            |
-| ------------------- | ------------------------------------------------------- |
-| `npm run dev`       | The main dev loop: build watch + auto-rsync to HA.      |
-| `npm run build:watch` | Just Rollup watch — builds locally, no rsync. Rare.   |
-| `npm run push`      | One-shot rsync of the current bundle and dev loaders.   |
-| `npm run push:watch` | Rsync on every bundle change. Used internally by `dev`. |
-| `npm run build`     | One-shot production build.                              |
+With `loader-hot.js`, your dashboard reloads itself a couple of seconds after each save. Edit `src/index.js`, save, watch the change appear live in HA.
 
-### How it works
+Stop with Ctrl-C. Both watchers shut down together.
 
-`loader.js` registers as a stable URL but imports `camera-gallery-card.js?v=<timestamp>` on each page load, so the browser cache and service worker can't serve stale code. `loader-hot.js` adds a 2-second poll on `Last-Modified` and calls `location.reload()` when it changes.
-
-The rsync logic lives in [`scripts/dev/push.mjs`](scripts/dev/push.mjs) — it loads `.env` via [`dotenv`](https://github.com/motdotla/dotenv), validates `HA_HOST` and `HA_DEV_PATH`, and runs `rsync` directly. `--watch` adds a [`chokidar`](https://github.com/paulmillr/chokidar) watcher on the bundle file.
-
-### Troubleshooting
-
-- **`Cannot find .env file` from Node.** Run `cp .env.example .env` and fill in `HA_HOST` / `HA_DEV_PATH`.
-- **Card doesn't update after a change.** Browser or service-worker cache. The dev loaders sidestep this; if you wired up a different resource URL, force-reload with Ctrl/Cmd-Shift-R or use `loader-hot.js`. Also check Lovelace → Resources for a stale `/hacsfiles/camera-gallery-card/...` entry — only one resource per custom-element tag will work, so leave just `/local/dev/loader.js` (or `loader-hot.js`) while developing.
-- **rsync says "permission denied" or "no such directory".** Run the SSH command from the [Setup](#setup) section first to create the target dir with the right ownership.
-- **rsync isn't found / Windows.** The dev loop uses `rsync` and `ssh`. On Windows, run it under WSL.
-
-## Before opening a PR
+### 6. Verify locally before pushing
 
 ```bash
 npm run check
 ```
 
-That runs typecheck, lint, format check, and build — exactly what CI runs. If any step fails locally, CI will fail too.
+This is the same set of steps CI runs on your PR — type-check, lint, prettier check, build, and bundle drift guard. If anything fails locally it'll fail on CI, so fix it now.
 
-If you touched `src/`, also commit the rebuilt `dist/camera-gallery-card.js` alongside your source changes. CI rejects PRs where the committed bundle is out of sync with `src/`.
+If you touched anything in `src/`, **commit the rebuilt `dist/camera-gallery-card.js` alongside your source changes**. The drift guard rejects PRs where the committed bundle doesn't match what `npm run build` produces from `src/`.
 
-### Pre-commit hook
+### 7. Commit
 
-`npm install` sets up [husky](https://typicode.github.io/husky/) automatically (via the `prepare` script). On every commit, [lint-staged](https://github.com/lint-staged/lint-staged) runs `eslint --fix` and `prettier --write` on the staged files only — fast, scoped, and the auto-fixed files are folded back into the same commit. If you ever need to bypass the hook (e.g. a WIP commit), use `git commit --no-verify`.
+The pre-commit hook (husky + lint-staged) runs `eslint --fix` and `prettier --write` on staged files automatically — auto-fixes are folded into the same commit. If you ever need to bypass the hook (e.g. for a WIP commit you'll squash later), use `git commit --no-verify`.
 
-## Commit and PR conventions
+Commit messages on your branch don't have to be conventional commits — only the **PR title** does, because that's what becomes the squash-merge commit on `main`. Keep your branch commits as granular as you like; nobody sees them on `main`.
 
-This repo uses [Conventional Commits](https://www.conventionalcommits.org/) for one specific reason: [release-please](https://github.com/googleapis/release-please) reads them to decide the next version and to generate the changelog.
+### 8. Push and open a PR
 
-PRs land via **squash merge**. Whatever you put in the PR title becomes the conventional commit on `main`, so the title is what matters. CI enforces that the PR title is conventional.
-
-### PR title format
-
-```
-<type>(<optional scope>): <subject>
+```bash
+git push -u origin <your-branch-name>
+gh pr create --repo TheScubaDiver/camera-gallery-card --base main
 ```
 
-Common types and what they trigger:
+Or use the GitHub UI link printed by `git push`.
 
-| Type       | Use for                                | Bumps version?        |
-|------------|----------------------------------------|-----------------------|
-| `feat`     | new user-visible feature               | minor (e.g. 2.6 → 2.7) |
-| `fix`      | bug fix                                | patch (e.g. 2.6.0 → 2.6.1) |
+**The PR title is critical** — see [Commit and PR title format](#commit-and-pr-title-format). CI rejects PRs whose title isn't a conventional commit. The PR title becomes the squash-merge commit message on `main`, which is what release-please reads to decide whether to bump major / minor / patch.
+
+A good PR description includes:
+
+- **What** changed and **why** (1–3 sentences).
+- A **test plan** (a checkbox list of what you verified — including any HA-side testing).
+- **Screenshots** if it's a visual change.
+- **Reference issues** if applicable (`Closes #123`).
+
+### 9. Iterate on review
+
+CI runs on every push to your PR branch:
+
+- **Check PR title is conventional** — runs the [PR-title workflow](.github/workflows/pr-title.yml) against your title.
+- **build** — runs `npm run check` (typecheck, lint, format, build, drift guard).
+- **validate** — runs HACS structural validation.
+
+If any of these fail, fix and push again. Each push re-runs CI automatically.
+
+A maintainer (currently @TheScubaDiver and @ErikBavenstrand) is auto-requested as reviewer. Address any feedback by pushing more commits.
+
+### 10. Merge
+
+A maintainer **squash-merges** your PR. The squash commit on `main` uses your PR title as its message. This is the only path PRs land — branch protection blocks regular merge and rebase.
+
+After merge, your branch on the fork is auto-deleted. The merge commit triggers the **Release workflow** (next section).
+
+### 11. release-please opens (or updates) a release PR
+
+On every push to `main`, the [Release workflow](.github/workflows/release.yml) runs `release-please-action`, which:
+
+1. Reads the new conventional-commit message.
+2. Decides whether to bump major (breaking change), minor (`feat`), patch (`fix` / `perf`), or do nothing (`chore`, `docs`, `ci`, `refactor`, etc).
+3. Opens (or updates) a single PR titled something like `chore(main): release 2.7.0` that bumps `package.json` and regenerates `CHANGELOG.md`.
+4. A follow-up job in the same workflow rebuilds `dist/camera-gallery-card.js` so the release commit ships a bundle whose `CARD_VERSION` matches the bumped version.
+
+**Where to look:** the **Pull requests** tab on the upstream repo. The release PR will be open and labeled `autorelease: pending`. CI runs on it like any other PR.
+
+If your PR was a `chore`/`ci`/`docs`/`refactor`, no release PR is opened — those types don't trigger a version bump. Your change will be included in the *next* release that's triggered by a `feat` or `fix`.
+
+### 12. Maintainer ships the release
+
+When a maintainer is ready, they squash-merge the release PR. release-please then:
+
+1. Tags `vX.Y.Z` on `main`.
+2. Creates a GitHub Release at that tag.
+3. Attaches `dist/camera-gallery-card.js` as a release asset.
+
+HACS picks up the new release automatically — users on tagged installs get it via the release asset, users on the default branch get the bundle that's already committed to `main`.
+
+**Where to look:** the **Releases** sidebar on the repo. A new release should appear within ~30 seconds of the release PR merging. The asset (`camera-gallery-card.js`) should be listed as a downloadable file.
+
+## Commit and PR title format
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/). PR titles must match:
+
+```
+<type>(<optional scope>)!?: <subject>
+```
+
+| Type       | Use for                                | Triggers              |
+| ---------- | -------------------------------------- | --------------------- |
+| `feat`     | new user-visible feature               | minor bump (2.6 → 2.7) |
+| `fix`      | bug fix                                | patch bump (2.6.0 → 2.6.1) |
 | `perf`     | performance improvement                | patch                 |
-| `refactor` | code restructuring, no behavior change | no                    |
-| `docs`     | README / CONTRIBUTING / comments only  | no                    |
-| `test`     | tests only                             | no                    |
-| `build`    | build system, dependencies             | no                    |
-| `ci`       | CI workflow changes                    | no                    |
-| `chore`    | other maintenance                      | no                    |
-| `revert`   | revert a previous commit               | depends on what's reverted |
+| `refactor` | code restructuring, no behavior change | no release            |
+| `docs`     | README / CONTRIBUTING / comments only  | no release            |
+| `test`     | tests only                             | no release            |
+| `build`    | build system, dependencies             | no release            |
+| `ci`       | CI workflow changes                    | no release            |
+| `chore`    | other maintenance                      | no release            |
+| `revert`   | revert a previous commit               | depends               |
 
-A breaking change is signaled by either `feat!:` / `fix!:` (the `!` after the type) or a `BREAKING CHANGE:` footer in the PR body. That triggers a major bump.
+**Breaking changes** trigger a major bump. Signal them with either `!` after the type (`feat!:`) or a `BREAKING CHANGE:` footer in the PR body.
+
+### Subject rules
+
+- Lowercase first letter — `feat: add multi-camera live view`, not `feat: Add ...`.
+- Imperative mood — `add`, not `added` or `adds`.
+- No trailing period.
+- Under ~72 characters.
+
+### Scope (optional)
+
+Use a scope when it helps readers find the change in the changelog: `editor`, `live`, `media`, `sensor`, `deps`, etc. Scopes aren't enforced — leave it blank if nothing fits.
 
 ### Examples
 
@@ -123,37 +220,61 @@ chore(deps): bump rollup from 4.24.0 to 4.25.0
 feat!: drop support for source_mode "files" alias
 ```
 
-### Scope (optional)
+## Useful npm scripts
 
-Use a scope when it helps readers find the change in the changelog: `editor`, `live`, `media`, `sensor`, `deps`, etc. Scopes aren't enforced — leave blank if nothing fits.
+| Script                | What it does                                                          |
+| --------------------- | --------------------------------------------------------------------- |
+| `npm run dev`         | The main dev loop: build watch + auto-rsync to HA.                    |
+| `npm run build`       | One-shot production build (terser-minified, no source map).           |
+| `npm run build:watch` | Just Rollup watch — builds locally, no rsync. Rare.                   |
+| `npm run push`        | One-shot rsync of the current bundle and dev loaders.                 |
+| `npm run push:watch`  | Rsync on every bundle change. Used internally by `npm run dev`.       |
+| `npm run check`       | Typecheck + lint + format check + build. Same as CI.                  |
+| `npm run lint`        | ESLint only.                                                          |
+| `npm run lint:fix`    | ESLint with `--fix`.                                                  |
+| `npm run format`      | Prettier `--write`.                                                   |
+| `npm run format:check`| Prettier `--check`.                                                   |
+| `npm run typecheck`   | `tsc --noEmit`.                                                       |
+| `npm run clean`       | Delete `dist/`.                                                       |
 
-### Subject
+## How the dev loaders work
 
-- Lowercase first letter (`feat: add ...`, not `feat: Add ...`).
-- Imperative mood (`add`, not `added` or `adds`).
-- No trailing period.
-- Keep it under ~72 characters.
+`dev/loader.js` registers as a stable URL but dynamically imports `camera-gallery-card.js?v=<timestamp>` on each page load — that bypasses both the browser cache and HA's service worker, which would otherwise serve stale code.
 
-## How releases work
+`dev/loader-hot.js` does the same plus a 2-second poll on the bundle's `Last-Modified` header. When the file changes (after rsync), it calls `location.reload()`. Polling pauses when the tab is hidden so it's idle in the background.
 
-You don't tag releases manually. The pipeline does it.
-
-1. PRs merge into `main` with conventional-commit titles.
-2. On every push to `main`, the `Release` workflow runs `release-please-action`. It opens (or updates) a single **release PR** titled `chore(main): release X.Y.Z` that bumps `package.json` and regenerates `CHANGELOG.md`. A follow-up job in the same workflow run rebuilds `camera-gallery-card.js` on the release PR's branch, so the release commit ships a bundle whose `CARD_VERSION` matches the bumped version.
-3. When a maintainer is ready to ship, they review the release PR and **squash-merge** it.
-4. release-please tags `vX.Y.Z` and creates the GitHub Release. The same workflow then attaches the committed `camera-gallery-card.js` from the tagged commit as a release asset (no rebuild — the asset is byte-identical to what's on `main`).
-5. HACS picks up the new release automatically — both for users on tagged installs (latest release) and users on the default branch (the bundle is already committed to `main`).
-
-### Manual release (escape hatch)
-
-If something breaks the automated pipeline, a maintainer can dispatch the `Release` workflow manually from the Actions tab. Same release-please logic, just triggered by hand.
-
-### Breaking changes
-
-Major bumps happen **only** when a commit on the way to `main` includes `!` after the type or a `BREAKING CHANGE:` footer. Otherwise everything stays in the same major line.
+Both loaders get rsynced to HA alongside the bundle. The rsync logic lives in [`scripts/dev/push.mjs`](scripts/dev/push.mjs) — it loads `.env` via [`dotenv`](https://github.com/motdotla/dotenv), validates `HA_HOST` and `HA_DEV_PATH`, and runs `rsync`. `--watch` adds a [`chokidar`](https://github.com/paulmillr/chokidar) watcher.
 
 ## Linting, formatting, types
 
-- `npm run lint` — ESLint flat config (`eslint.config.js`). `no-console` is a warning; only `console.info`, `console.warn`, `console.error` are allowed.
-- `npm run format` / `npm run format:check` — Prettier.
-- `npm run typecheck` — `tsc --noEmit` on the JS sources via `allowJs`.
+- **ESLint** flat config (`eslint.config.js`). `no-console` is a warning; only `console.info`, `console.warn`, `console.error` are allowed. The legacy `src/index.js` blob is intentionally exempt from strict rules until it's broken into focused modules.
+- **Prettier** for formatting. `src/index.js` is exempt (see `.prettierignore`).
+- **TypeScript** in noEmit mode for type-checking the JS sources via `allowJs`. Strict settings.
+
+## Troubleshooting
+
+- **`Cannot find .env file`**: run `cp .env.example .env` and fill in `HA_HOST` / `HA_DEV_PATH`.
+- **rsync says "permission denied" or "no such directory"**: run the SSH `mkdir`+`chown` command from [step 3](#3-one-time-local-setup) once. The target directory has to exist and be owned by your SSH user.
+- **rsync isn't found / Windows**: the dev loop uses `rsync` and `ssh`. On Windows, run it under WSL.
+- **Card doesn't update in the browser after a change**: cache. The dev loaders sidestep this; if you wired up a different resource URL, hard-refresh with Ctrl/Cmd-Shift-R or switch to `loader-hot.js`. Also check Lovelace → Resources for a stale `/hacsfiles/camera-gallery-card/...` entry — only one resource per custom-element tag works, so leave just `/local/dev/loader.js` (or `loader-hot.js`) while developing.
+- **`drift guard` CI step fails**: you changed `src/` but didn't commit the rebuilt bundle. Run `npm run build` and commit `dist/camera-gallery-card.js`.
+- **PR-title check fails**: your title isn't a [conventional commit](#commit-and-pr-title-format). Edit it on the GitHub PR page; the check re-runs automatically.
+
+## Maintainer notes
+
+After merging a PR, the **Release** workflow run on `main` is what to watch. It either:
+
+- Opens or updates a release PR (most common — your change is grouped with everything else since the last release).
+- Does nothing (your change was a `chore`/`ci`/`docs`/etc. that doesn't trigger a bump — totally fine).
+
+If the workflow run fails, click into the failed job to diagnose. Common causes:
+
+- **Token errors** (`error:1E08010C:DECODER routines::unsupported`, `Bad credentials`): the `RELEASE_BOT_PRIVATE_KEY` secret or `RELEASE_BOT_CLIENT_ID` variable on the upstream repo is misconfigured.
+- **Drift guard fails on the release PR**: the rebuild-bundle step in `release.yml` should have caught this — investigate why it didn't run.
+
+When merging the release PR, double-check:
+
+1. The proposed version number matches what you'd expect from the commits since the last release.
+2. The CHANGELOG.md diff in the release PR lists every PR you intended to ship.
+3. CI is green on the release PR.
+4. The version in the README's "Current version" line was bumped (release-please updates it via `extra-files` in `release-please-config.json`, using the `<!-- x-release-please-start-version -->` markers around the version literal).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Custom **Home Assistant Lovelace card** for browsing camera media in a clean **timeline-style gallery** with preview player, object filters, optional live view, and a built-in visual editor.
 
-**Current version:** `v2.6.0`
+**Current version:** `v<!-- x-release-please-start-version -->2.6.0<!-- x-release-please-end -->`
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/1c71ada8-98bb-435e-bbc6-b6974186c2e0" width="30%" />

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,12 @@
         { "type": "build", "section": "Build System", "hidden": true },
         { "type": "ci", "section": "CI", "hidden": true },
         { "type": "chore", "section": "Chores", "hidden": true }
+      ],
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "README.md"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Two related docs changes:

### CONTRIBUTING.md — end-to-end contributor flow

Restructures the guide around a numbered 12-step walkthrough that takes a contributor from "I want to fix a bug" all the way to "the fix shipped in v2.7.1": fork → clone → setup → branch → dev loop → local check → commit → push → open PR → CI → maintainer merge → release-please opens release PR → release ships. Each step says what to do, what to expect, and where to look on the GitHub UI.

Adds a quick-reference code block at the top for returning contributors, a troubleshooting section covering the drift guard and PR-title failure modes, and a maintainer-notes section with what to watch in the Release workflow after a merge and what to double-check before merging the release PR.

### README "Current version" line — now auto-updated

The `**Current version:** v2.6.0` line in the README would silently drift behind every release if nobody remembered to update it. Wrapped the version literal in the release-please marker comments and added README.md to the package's `extra-files`, so release-please updates the line automatically as part of every release PR.

The marker comments (`<!-- x-release-please-start-version -->`...`<!-- x-release-please-end -->`) are invisible in rendered markdown.

## Test plan

- [ ] Render CONTRIBUTING.md on GitHub — links and tables look right.
- [ ] Render README.md on GitHub — version line still shows as `v2.6.0` (the comments don't render).
- [ ] On the next release PR, release-please should update the README version literal in the same PR that bumps `package.json` and `CHANGELOG.md`.