### PR TITLE
fix: use release-please inline marker on README version line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,4 +277,4 @@ When merging the release PR, double-check:
 1. The proposed version number matches what you'd expect from the commits since the last release.
 2. The CHANGELOG.md diff in the release PR lists every PR you intended to ship.
 3. CI is green on the release PR.
-4. The version in the README's "Current version" line was bumped (release-please updates it via `extra-files` in `release-please-config.json`, using the `<!-- x-release-please-start-version -->` markers around the version literal).
+4. The version in the README's "Current version" line was bumped, and **only** that line — release-please's `generic` updater can be greedy about matching `(\d+)\.(\d+)\.(\d+)` patterns when block markers span multiple lines. We use the **inline marker** form (`<!-- x-release-please-version -->` on the same line as the version literal) so only that one line is touched. If you ever add `extra-files` for another file, prefer the inline marker pattern and double-check the next release PR's diff for collateral damage.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Custom **Home Assistant Lovelace card** for browsing camera media in a clean **timeline-style gallery** with preview player, object filters, optional live view, and a built-in visual editor.
 
-**Current version:** `v<!-- x-release-please-start-version -->2.6.0<!-- x-release-please-end -->`
+**Current version:** `v2.6.0` <!-- x-release-please-version -->
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/1c71ada8-98bb-435e-bbc6-b6974186c2e0" width="30%" />


### PR DESCRIPTION
## Summary

Release PR #49 currently shows release-please corrupting the README's Frigate config example:

```diff
- | `frigate_url` | Direct Frigate REST API URL (e.g. `http://192.168.1.x:5000`) |
+ | `frigate_url` | Direct Frigate REST API URL (e.g. `http://2.7.0.x:5000`) |
```

That happened because the previous block-marker form had `<!-- x-release-please-start-version -->` and `<!-- x-release-please-end -->` collapsed onto the same line as the version literal. release-please's parser only treats a line as "block start" if the start marker is alone — with both markers inline, the start handler armed `blockScope` and fell through without ever recognizing the end on the same line. The block effectively "never closed" and `VERSION_REGEX` (`(\d+)\.(\d+)\.(\d+)`, no word-boundary anchors) ran over every subsequent line in the file. `192.168.1` matched, `192.168.1.x:5000` became `2.7.0.x:5000`.

## Fix

Switched to the **inline single-line marker** form, which release-please applies to only the line where the marker sits:

```diff
- **Current version:** `v<!-- x-release-please-start-version -->2.6.0<!-- x-release-please-end -->`
+ **Current version:** `v2.6.0` <!-- x-release-please-version -->
```

Reference: [`src/updaters/generic.ts`](https://github.com/googleapis/release-please/blob/main/src/updaters/generic.ts) lines 19-27 (regex defs) and 155-190 (block-vs-inline parser logic).

The CONTRIBUTING.md maintainer note was also updated to document the inline-marker convention so the next person doesn't make the same mistake.

## Effect on the open release PR #49

When this merges, the `Release` workflow re-runs on `main`, regenerates release PR #49's content from scratch, and the broken IP-address change disappears. The README's "Current version" line will be the only line release-please touches in the README (correctly bumped from `v2.6.0` to `v2.7.0`).

## Test plan

- [ ] After merge: release PR #49's diff includes a one-line README change updating `v2.6.0` → `v2.7.0`, and **no other** README lines.
- [ ] After merge: README still renders correctly on GitHub (the `<!-- ... -->` comment is invisible).