### PR TITLE
ci: auto-sync dist bundle on main, drop drift guard from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,9 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      # Verifies the bundle still builds clean from src/. The committed
+      # dist/camera-gallery-card.js is *not* required to be in sync with src/
+      # on PR branches — sync-bundle.yml handles that automatically after each
+      # push to main, and release.yml handles it on the release PR's branch.
       - name: Build
         run: npm run build
-
-      - name: Verify committed bundle is up to date
-        # release-please's release PRs bump package.json (which changes
-        # CARD_VERSION via __VERSION__), so a fresh build will differ from
-        # the committed bundle until release.yml's sync-bundle-in-release-pr
-        # job rebuilds and commits it. Skip the drift check on those PRs.
-        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
-        run: |
-          if ! git diff --exit-code -- dist/camera-gallery-card.js; then
-            echo "::error::dist/camera-gallery-card.js is out of sync with src/. Run 'npm run build' and commit the result."
-            exit 1
-          fi

--- a/.github/workflows/sync-bundle.yml
+++ b/.github/workflows/sync-bundle.yml
@@ -1,0 +1,72 @@
+name: Sync bundle on main
+
+# Rebuild dist/camera-gallery-card.js after every push to main and commit it
+# back if it drifted. Removes the contributor burden of running `npm run build`
+# alongside every src/ change — they can ship a src-only PR and main stays in
+# sync automatically.
+#
+# Mirrors the release.yml `sync-bundle-in-release-pr` pattern (same App token,
+# same commit-only-if-changed shape) but runs on regular main pushes instead
+# of release-PR opens.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Don't run two of these in parallel — they'd race on the same dist file.
+# Don't cancel in flight either: if a second push lands while we're building,
+# let the first finish and the second will catch up after.
+concurrency:
+  group: sync-bundle-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      # Use the release-bot App token (already provisioned for release.yml) so
+      # the bot's commit triggers downstream workflows. A default GITHUB_TOKEN
+      # commit would be silently suppressed by GitHub.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build bundle
+        run: npm run build
+
+      - name: Commit rebuilt bundle if changed
+        run: |
+          if git diff --exit-code -- dist/camera-gallery-card.js; then
+            echo "Bundle already in sync with src/ — nothing to do."
+            exit 0
+          fi
+          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git add dist/camera-gallery-card.js
+          git commit -m "chore: sync bundle"
+          # If another push to main raced ahead of us, fail loud instead of
+          # overwriting it. The next push will trigger a fresh sync run that
+          # catches up.
+          git push --force-with-lease


### PR DESCRIPTION
## Summary

PR contributors currently have to remember to run `npm run build` and commit the regenerated `dist/camera-gallery-card.js` alongside every `src/` change, or CI fails with the drift-guard error. The pattern usually plays out as two commits per PR (the src change + a "build: update bundle" follow-up). It's confusing for first-time contributors and noise for everyone else.

This PR moves the rebuild off contributors and onto a bot:

- **New workflow `.github/workflows/sync-bundle.yml`** runs on every push to `main`, runs `npm run build`, and commits the result back if `dist/` drifted. Same shape as the existing `release.yml > sync-bundle-in-release-pr` job: same release-bot App token, same concurrency model (`serialize, don't cancel in flight`), same "commit only if changed" guard. The App token rather than `GITHUB_TOKEN` ensures the bot's follow-up commit triggers downstream workflows.
- **Drop the "Verify committed bundle is up to date" step** from `ci.yml`. CI still runs `npm run build` to guarantee the bundle still builds clean from `src/` — it just no longer requires the committed copy to already match.

The `release-please` flow keeps working unchanged: `release.yml > sync-bundle-in-release-pr` still handles the special case where `package.json` version bumps cause `CARD_VERSION` to change inside the release PR's branch (before merge to main).

**Net effect:** contributors only ever touch `src/`. After merge, `main` gets a `chore: sync bundle` follow-up commit from the bot if the bundle drifted. HACS users tracking `main` always get a fresh bundle without any human in the loop.

## Trade-off

Each `src/`-only PR will produce a follow-up `chore: sync bundle` commit on `main` from the release-bot. Slightly noisy in `git log`, never appears on PR branches, fully automated.

## Test plan

- [x] Merge a `src/`-only change without a matching `dist/` commit → CI passes (no drift error).
- [x] After merge, observe the new `Sync bundle on main` workflow run; verify it commits an up-to-date bundle if needed.
- [x] Merge a no-op (e.g., docs-only) PR → workflow runs, finds no drift, exits cleanly without a follow-up commit.
- [x] Open a release-please PR → existing `sync-bundle-in-release-pr` rebuilds the bundle on the release branch (unchanged behavior).