### PR TITLE
fix: live-mode thumbnail, favorite button, hardcoded Dutch + typed config

### DIFF
--- a/src/config/diff.spec.ts
+++ b/src/config/diff.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { configDiff } from "./diff";
+import type { CameraGalleryCardConfig } from "./normalize";
+
+const baseConfig = (overrides: Partial<CameraGalleryCardConfig> = {}): CameraGalleryCardConfig =>
+  ({
+    type: "custom:camera-gallery-card",
+    source_mode: "sensor",
+    entities: ["sensor.foo"],
+    media_sources: [],
+    autoplay: false,
+    auto_muted: true,
+    live_enabled: false,
+    live_auto_muted: true,
+    live_camera_entity: "",
+    live_camera_entities: [],
+    start_mode: "gallery",
+    allow_delete: true,
+    allow_bulk_delete: true,
+    delete_confirm: true,
+    delete_service: "",
+    object_filters: [],
+    object_colors: {},
+    entity_filter_map: {},
+    bar_opacity: 30,
+    bar_position: "top",
+    thumb_size: 86,
+    thumb_bar_position: "bottom",
+    thumb_layout: "horizontal",
+    thumbnail_frame_pct: 0,
+    pill_size: 14,
+    aspect_ratio: "16:9",
+    object_fit: "cover",
+    controls_mode: "overlay",
+    style_variables: "",
+    show_camera_title: true,
+    persistent_controls: false,
+    preview_position: "top",
+    clean_mode: false,
+    preview_close_on_tap: false,
+    max_media: 50,
+    menu_buttons: [],
+    filename_datetime_format: "",
+    folder_datetime_format: "",
+    ...overrides,
+  }) as CameraGalleryCardConfig;
+
+describe("configDiff — first call (prev null)", () => {
+  it("treats first setConfig as a source change", () => {
+    const result = configDiff(null, baseConfig());
+    expect(result.isSourceChange).toBe(true);
+    expect(result.isUiOnly).toBe(false);
+    expect(result.changedKeys).toEqual([]);
+  });
+});
+
+describe("configDiff — source-affecting changes invalidate caches", () => {
+  it("source_mode change is a source change", () => {
+    const prev = baseConfig({ source_mode: "sensor" });
+    const next = baseConfig({ source_mode: "media", media_sources: ["x"] });
+    const result = configDiff(prev, next);
+    expect(result.isSourceChange).toBe(true);
+    expect(result.isUiOnly).toBe(false);
+  });
+
+  it("entities change is a source change", () => {
+    const prev = baseConfig({ entities: ["sensor.a"] });
+    const next = baseConfig({ entities: ["sensor.a", "sensor.b"] });
+    const result = configDiff(prev, next);
+    expect(result.isSourceChange).toBe(true);
+  });
+
+  it("media_sources change is a source change", () => {
+    const prev = baseConfig({ media_sources: ["a"] });
+    const next = baseConfig({ media_sources: ["b"] });
+    expect(configDiff(prev, next).isSourceChange).toBe(true);
+  });
+
+  it("max_media change is a source change", () => {
+    const prev = baseConfig({ max_media: 50 });
+    const next = baseConfig({ max_media: 100 });
+    expect(configDiff(prev, next).isSourceChange).toBe(true);
+  });
+
+  it("delete_service change is a source change", () => {
+    const prev = baseConfig({ delete_service: "" });
+    const next = baseConfig({ delete_service: "shell.delete_file" });
+    expect(configDiff(prev, next).isSourceChange).toBe(true);
+  });
+});
+
+describe("configDiff — UI-only changes skip cache invalidation", () => {
+  it("only thumb_size changed → ui-only", () => {
+    const prev = baseConfig({ thumb_size: 86 });
+    const next = baseConfig({ thumb_size: 100 });
+    const result = configDiff(prev, next);
+    expect(result.isSourceChange).toBe(false);
+    expect(result.isUiOnly).toBe(true);
+  });
+
+  it("multiple ui-only keys all changed → still ui-only", () => {
+    const prev = baseConfig({ thumb_size: 86, bar_opacity: 30 });
+    const next = baseConfig({ thumb_size: 100, bar_opacity: 50 });
+    expect(configDiff(prev, next).isUiOnly).toBe(true);
+  });
+
+  it("ui-only + source key changed → not ui-only, is source change", () => {
+    const prev = baseConfig({ thumb_size: 86, max_media: 50 });
+    const next = baseConfig({ thumb_size: 100, max_media: 100 });
+    const result = configDiff(prev, next);
+    expect(result.isUiOnly).toBe(false);
+    expect(result.isSourceChange).toBe(true);
+  });
+
+  it("unknown key changed → neither ui-only nor source", () => {
+    const prev = baseConfig();
+    const next = baseConfig({ style_variables: "x" });
+    const result = configDiff(prev, next);
+    expect(result.isSourceChange).toBe(false);
+    expect(result.isUiOnly).toBe(false);
+    expect(result.changedKeys).toContain("style_variables");
+  });
+});
+
+describe("configDiff — no changes", () => {
+  it("identical configs report no changes and not ui-only", () => {
+    const prev = baseConfig();
+    const next = baseConfig();
+    const result = configDiff(prev, next);
+    expect(result.changedKeys).toEqual([]);
+    expect(result.isUiOnly).toBe(false);
+    expect(result.isSourceChange).toBe(false);
+  });
+});

--- a/src/config/diff.ts
+++ b/src/config/diff.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure config-diff helpers used by `setConfig` to decide whether the change
+ * affects the data layer (re-fetch + cache invalidation), the UI only
+ * (`requestUpdate` is enough), or both.
+ *
+ * Encoded once instead of three separate methods on the card class.
+ */
+
+import type { CameraGalleryCardConfig } from "./normalize";
+
+type ConfigKey = keyof CameraGalleryCardConfig;
+
+/**
+ * Keys that, when changed, force the data layer to refetch and clear caches.
+ * Stays in sync with PR 8's `MediaSourceClient` invalidation rules — when the
+ * data clients land, they consume this same set.
+ */
+const SOURCE_KEYS = new Set<ConfigKey>([
+  "allow_bulk_delete",
+  "allow_delete",
+  "delete_confirm",
+  "delete_service",
+  "entities",
+  "frigate_url",
+  "max_media",
+  "media_sources",
+  "source_mode",
+  "thumbnail_frame_pct",
+]);
+
+/**
+ * Keys that only affect rendering (no cache invalidation needed). When
+ * *every* changed key is in this set, the card just calls `requestUpdate`.
+ *
+ * Names match the canonical config shape in `structs.ts` — earlier copies of
+ * this list carried `live_cameras` / `live_default_camera`, which never
+ * existed on the canonical config and so were dead weight.
+ */
+const UI_ONLY_KEYS = new Set<ConfigKey>([
+  "bar_opacity",
+  "bar_position",
+  "live_camera_entity",
+  "live_camera_entities",
+  "live_enabled",
+  "object_filters",
+  "clean_mode",
+  "preview_close_on_tap",
+  "preview_position",
+  "pill_size",
+  "thumb_bar_position",
+  "thumb_layout",
+  "thumb_size",
+  "show_camera_title",
+  "controls_mode",
+]);
+
+export interface ConfigDiff {
+  changedKeys: ConfigKey[];
+  isSourceChange: boolean;
+  isUiOnly: boolean;
+}
+
+/**
+ * Compare two values for "config equality". Validated `CameraGalleryCardConfig`
+ * fields are JSON-serialisable (strings, numbers, booleans, arrays, plain
+ * records), so a stringify compare is a precise-enough deep-equality check
+ * without pulling in an `isEqual` dep.
+ */
+const fieldsEqual = <K extends ConfigKey>(
+  prev: CameraGalleryCardConfig,
+  next: CameraGalleryCardConfig,
+  k: K
+): boolean => JSON.stringify(prev[k]) === JSON.stringify(next[k]);
+
+/** All keys present on either side, typed as `ConfigKey`. */
+function unionKeys(prev: CameraGalleryCardConfig, next: CameraGalleryCardConfig): ConfigKey[] {
+  const set = new Set<ConfigKey>();
+  for (const k of Object.keys(prev) as ConfigKey[]) set.add(k);
+  for (const k of Object.keys(next) as ConfigKey[]) set.add(k);
+  return [...set];
+}
+
+/**
+ * Diff two normalized configs. Returns the changed keys, plus the two
+ * "is this a source-affecting change?" / "can we skip cache invalidation?"
+ * flags consumed by the card's setConfig side-effect block.
+ *
+ * `prev = null` (first setConfig call) reports `isSourceChange: true` and
+ * `isUiOnly: false` — the same semantics the legacy `_isSourceConfigChange`
+ * had via the inline `prevConfig ? ... : true` pattern.
+ */
+export function configDiff(
+  prev: CameraGalleryCardConfig | null,
+  next: CameraGalleryCardConfig
+): ConfigDiff {
+  if (!prev) {
+    return { changedKeys: [], isSourceChange: true, isUiOnly: false };
+  }
+
+  const changedKeys = unionKeys(prev, next).filter((k) => !fieldsEqual(prev, next, k));
+
+  const isSourceChange = changedKeys.some((k) => SOURCE_KEYS.has(k));
+  const isUiOnly = changedKeys.length > 0 && changedKeys.every((k) => UI_ONLY_KEYS.has(k));
+
+  return { changedKeys, isSourceChange, isUiOnly };
+}

--- a/src/config/normalize.spec.ts
+++ b/src/config/normalize.spec.ts
@@ -1,0 +1,488 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasLegacyKeys,
+  normalizeConfig,
+  normalizeMediaRoot,
+  normalizeMediaRoots,
+  normalizeSensorEntities,
+} from "./normalize";
+
+// Minimal valid input — sensor mode with one entity and a folder format.
+const minimalSensor = {
+  source_mode: "sensor",
+  entities: ["sensor.foo"],
+  folder_datetime_format: "{YYYY}-{MM}-{DD}",
+};
+
+const minimalMedia = {
+  source_mode: "media",
+  media_sources: ["media-source://media_source/local/foo"],
+  folder_datetime_format: "{YYYY}-{MM}-{DD}",
+};
+
+describe("normalizeSensorEntities", () => {
+  it("trims and dedupes (case-insensitive)", () => {
+    expect(normalizeSensorEntities(["sensor.A", " sensor.a ", "sensor.B"])).toEqual([
+      "sensor.A",
+      "sensor.B",
+    ]);
+  });
+
+  it("accepts a singular value", () => {
+    expect(normalizeSensorEntities("sensor.foo")).toEqual(["sensor.foo"]);
+  });
+
+  it("uses fallbackSingle when listOrSingle is undefined/null/empty-string", () => {
+    expect(normalizeSensorEntities(undefined, "sensor.fallback")).toEqual(["sensor.fallback"]);
+    expect(normalizeSensorEntities(null, "sensor.fallback")).toEqual(["sensor.fallback"]);
+    expect(normalizeSensorEntities("", "sensor.fallback")).toEqual(["sensor.fallback"]);
+  });
+
+  it("does NOT fall back when an empty array is passed (legacy semantics)", () => {
+    expect(normalizeSensorEntities([], "sensor.fallback")).toEqual([]);
+  });
+
+  it("returns [] for nullish/empty", () => {
+    expect(normalizeSensorEntities(null)).toEqual([]);
+    expect(normalizeSensorEntities(undefined)).toEqual([]);
+    expect(normalizeSensorEntities("")).toEqual([]);
+  });
+});
+
+describe("normalizeMediaRoot — canonical prefix handling", () => {
+  it("passes a fully-qualified URI through (collapsing slashes)", () => {
+    expect(normalizeMediaRoot("media-source://media_source/local/foo/")).toBe(
+      "media-source://media_source/local/foo"
+    );
+  });
+
+  it("rewrites bare 'frigate' shortcut into media-source URI", () => {
+    expect(normalizeMediaRoot("frigate/x/y")).toBe("media-source://frigate/x/y");
+  });
+
+  it("rewrites bare path into local media-source URI", () => {
+    expect(normalizeMediaRoot("camera/2024")).toBe("media-source://media_source/camera/2024");
+  });
+
+  it("returns empty string for nullish input", () => {
+    expect(normalizeMediaRoot(null)).toBe("");
+    expect(normalizeMediaRoot("")).toBe("");
+  });
+});
+
+describe("normalizeMediaRoots — array form, dedup, drop empties", () => {
+  it("dedupes case-insensitively", () => {
+    expect(normalizeMediaRoots(["frigate/x", "FRIGATE/x", "frigate/y"])).toEqual([
+      "media-source://frigate/x",
+      "media-source://frigate/y",
+    ]);
+  });
+});
+
+describe("hasLegacyKeys — detect raw input that needs migration", () => {
+  it("detects each legacy key", () => {
+    expect(hasLegacyKeys({ entity: "sensor.x" })).toBe(true);
+    expect(hasLegacyKeys({ media_source: "x" })).toBe(true);
+    expect(hasLegacyKeys({ media_folder_favorites: ["x"] })).toBe(true);
+    expect(hasLegacyKeys({ media_folders_fav: ["x"] })).toBe(true);
+    expect(hasLegacyKeys({ shell_command: "x" })).toBe(true);
+  });
+
+  it("returns false on canonical input", () => {
+    expect(hasLegacyKeys(minimalSensor)).toBe(false);
+  });
+
+  it("returns false on non-objects", () => {
+    expect(hasLegacyKeys(null)).toBe(false);
+    expect(hasLegacyKeys("foo")).toBe(false);
+  });
+});
+
+describe("Legacy key migration", () => {
+  it("migrates `entity` → `entities`", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      entities: undefined,
+      entity: "sensor.foo",
+    });
+    expect(config.entities).toEqual(["sensor.foo"]);
+  });
+
+  it("when both `entity` and `entities` present, `entities` wins", () => {
+    const { config } = normalizeConfig({
+      source_mode: "sensor",
+      folder_datetime_format: "x",
+      entities: ["sensor.a"],
+      entity: "sensor.b",
+    });
+    expect(config.entities).toEqual(["sensor.a"]);
+  });
+
+  it("migrates `media_source` (singular) → `media_sources`", () => {
+    const { config } = normalizeConfig({
+      source_mode: "media",
+      folder_datetime_format: "x",
+      media_source: "frigate/recordings",
+    });
+    expect(config.media_sources).toEqual(["media-source://frigate/recordings"]);
+  });
+
+  it("migrates `media_folder_favorites` → `media_sources`", () => {
+    const { config } = normalizeConfig({
+      source_mode: "media",
+      folder_datetime_format: "x",
+      media_folder_favorites: ["frigate/x"],
+    });
+    expect(config.media_sources).toEqual(["media-source://frigate/x"]);
+  });
+
+  it("migrates `media_folders_fav` → `media_sources`", () => {
+    const { config } = normalizeConfig({
+      source_mode: "media",
+      folder_datetime_format: "x",
+      media_folders_fav: ["frigate/x"],
+    });
+    expect(config.media_sources).toEqual(["media-source://frigate/x"]);
+  });
+
+  it("migrates `shell_command` → `delete_service`", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      shell_command: "shell.delete_file",
+    });
+    expect(config.delete_service).toBe("shell.delete_file");
+  });
+
+  it("`delete_service` wins over `shell_command` when both present", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      delete_service: "ds.new",
+      shell_command: "ds.legacy",
+    });
+    expect(config.delete_service).toBe("ds.new");
+  });
+});
+
+describe("Cross-field rules", () => {
+  it("source_mode auto-infers `media` when only media_sources present", () => {
+    const { config } = normalizeConfig({
+      folder_datetime_format: "x",
+      media_sources: ["frigate/x"],
+    });
+    expect(config.source_mode).toBe("media");
+  });
+
+  it("source_mode auto-infers `sensor` when only entities present", () => {
+    const { config } = normalizeConfig({
+      folder_datetime_format: "x",
+      entities: ["sensor.foo"],
+    });
+    expect(config.source_mode).toBe("sensor");
+  });
+
+  it("explicit source_mode is honoured", () => {
+    const { config } = normalizeConfig({
+      source_mode: "combined",
+      entities: ["sensor.foo"],
+      media_sources: ["frigate/x"],
+      folder_datetime_format: "x",
+    });
+    expect(config.source_mode).toBe("combined");
+  });
+
+  it("sensor mode without entity throws", () => {
+    expect(() => normalizeConfig({ source_mode: "sensor", folder_datetime_format: "x" })).toThrow(
+      /entity.*required.*sensor/
+    );
+  });
+
+  it("media mode without sources throws", () => {
+    expect(() => normalizeConfig({ source_mode: "media", folder_datetime_format: "x" })).toThrow(
+      /required.*media/
+    );
+  });
+
+  it("combined mode without entities throws", () => {
+    expect(() =>
+      normalizeConfig({
+        source_mode: "combined",
+        media_sources: ["frigate/x"],
+        folder_datetime_format: "x",
+      })
+    ).toThrow(/entity.*required.*combined/);
+  });
+
+  it("missing both datetime formats AND no Frigate config throws", () => {
+    expect(() => normalizeConfig({ source_mode: "sensor", entities: ["sensor.foo"] })).toThrow(
+      /folder_datetime_format.*filename_datetime_format/
+    );
+  });
+
+  it("Frigate config makes datetime formats optional", () => {
+    const { config } = normalizeConfig({
+      source_mode: "media",
+      media_sources: ["frigate/x"],
+      // no formats — Frigate event-ids carry the time
+    });
+    expect(config.media_sources).toContain("media-source://frigate/x");
+  });
+});
+
+describe("Delete gating", () => {
+  it("media mode forces delete OFF and clears delete_service", () => {
+    const { config } = normalizeConfig({
+      source_mode: "media",
+      media_sources: ["frigate/x"],
+      folder_datetime_format: "x",
+      allow_delete: true,
+      delete_service: "shell.delete_file",
+    });
+    expect(config.allow_delete).toBe(false);
+    expect(config.allow_bulk_delete).toBe(false);
+    expect(config.delete_service).toBe("");
+  });
+
+  it("sensor mode without delete_service forces delete OFF", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      allow_delete: true,
+      delete_service: "",
+    });
+    expect(config.allow_delete).toBe(false);
+    expect(config.allow_bulk_delete).toBe(false);
+  });
+
+  it("sensor mode with valid delete_service keeps allow_delete true", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      allow_delete: true,
+      delete_service: "shell.delete_file",
+    });
+    expect(config.allow_delete).toBe(true);
+    expect(config.delete_service).toBe("shell.delete_file");
+  });
+
+  it("rejects delete_service that's not in `domain.service` shape", () => {
+    expect(() =>
+      normalizeConfig({
+        ...minimalSensor,
+        delete_service: "not-a-service",
+      })
+    ).toThrow(/invalid config/);
+  });
+});
+
+describe("object_filters loose input shape", () => {
+  it("accepts plain string entries", () => {
+    const { config, customIcons } = normalizeConfig({
+      ...minimalSensor,
+      object_filters: ["person", "car"],
+    });
+    expect(config.object_filters).toEqual(["person", "car"]);
+    expect(customIcons).toEqual({});
+  });
+
+  it("extracts custom icons from `{name: icon}` entries", () => {
+    const { config, customIcons } = normalizeConfig({
+      ...minimalSensor,
+      object_filters: [{ person: "mdi:walk" }, "car"],
+    });
+    expect(config.object_filters).toEqual(["person", "car"]);
+    expect(customIcons).toEqual({ person: "mdi:walk" });
+  });
+
+  it("dedupes case-insensitively, keeps first icon", () => {
+    const { config, customIcons } = normalizeConfig({
+      ...minimalSensor,
+      object_filters: [{ Person: "mdi:walk" }, { PERSON: "mdi:run" }, "person"],
+    });
+    expect(config.object_filters).toEqual(["person"]);
+    expect(customIcons).toEqual({ person: "mdi:walk" });
+  });
+
+  it("silently drops unknown filter names (legacy behaviour)", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      object_filters: ["person", "ufo", "car"],
+    });
+    expect(config.object_filters).toEqual(["person", "car"]);
+  });
+});
+
+describe("entity_filter_map filtering", () => {
+  it("drops entries with unknown filter values", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      entity_filter_map: {
+        "sensor.a": "person",
+        "sensor.b": "ufo",
+        "sensor.c": "car",
+      },
+    });
+    expect(config.entity_filter_map).toEqual({
+      "sensor.a": "person",
+      "sensor.c": "car",
+    });
+  });
+
+  it("lowercases filter values", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      entity_filter_map: { "sensor.a": "PERSON" },
+    });
+    expect(config.entity_filter_map).toEqual({ "sensor.a": "person" });
+  });
+});
+
+describe("Audit fix #4 — numeric clamp ranges as struct refinements", () => {
+  it("rejects out-of-range thumb_size", () => {
+    expect(() => normalizeConfig({ ...minimalSensor, thumb_size: 30 })).toThrow(/invalid config/);
+    expect(() => normalizeConfig({ ...minimalSensor, thumb_size: 300 })).toThrow(/invalid config/);
+  });
+
+  it("error message names the range (not just 'integer')", () => {
+    expect(() => normalizeConfig({ ...minimalSensor, thumb_size: 30 })).toThrow(
+      /thumb_size.*between 40 and 220.*got 30/
+    );
+  });
+
+  it("rejects negative bar_opacity", () => {
+    expect(() => normalizeConfig({ ...minimalSensor, bar_opacity: -1 })).toThrow(/invalid config/);
+  });
+
+  it("rejects max_media outside [1, 500]", () => {
+    expect(() => normalizeConfig({ ...minimalSensor, max_media: 0 })).toThrow(/invalid config/);
+    expect(() => normalizeConfig({ ...minimalSensor, max_media: 1000 })).toThrow(/invalid config/);
+  });
+});
+
+describe("Audit fix #5/#6 — malformed array entries become validation errors", () => {
+  it("rejects live_stream_urls with missing url", () => {
+    expect(() =>
+      normalizeConfig({
+        ...minimalSensor,
+        live_stream_urls: [{ name: "foo" }],
+      })
+    ).toThrow(/invalid config/);
+  });
+
+  it("rejects menu_buttons with missing entity", () => {
+    expect(() =>
+      normalizeConfig({
+        ...minimalSensor,
+        menu_buttons: [{ icon: "mdi:foo" }],
+      })
+    ).toThrow(/invalid config/);
+  });
+});
+
+describe("Audit fix #2/#3 — aspect_ratio + controls_mode strictly enumerated", () => {
+  it("rejects unknown aspect_ratio", () => {
+    expect(() => normalizeConfig({ ...minimalSensor, aspect_ratio: "99:99" })).toThrow(
+      /invalid config/
+    );
+  });
+
+  it("rejects unknown controls_mode", () => {
+    expect(() => normalizeConfig({ ...minimalSensor, controls_mode: "weird" })).toThrow(
+      /invalid config/
+    );
+  });
+});
+
+describe("Defaults are applied", () => {
+  it("fills missing booleans with their DEFAULT_*", () => {
+    const { config } = normalizeConfig(minimalSensor);
+    expect(config.autoplay).toBe(false);
+    expect(config.auto_muted).toBe(true);
+    expect(config.live_auto_muted).toBe(true);
+    expect(config.allow_delete).toBe(false); // gated off — no delete_service in minimal
+  });
+
+  it("fills missing numeric fields with their DEFAULT_*", () => {
+    const { config } = normalizeConfig(minimalSensor);
+    expect(config.bar_opacity).toBe(30);
+    expect(config.thumb_size).toBe(86);
+    expect(config.max_media).toBe(50);
+    expect(config.pill_size).toBe(14);
+  });
+
+  it("fills missing enums with their DEFAULT_*", () => {
+    const { config } = normalizeConfig(minimalSensor);
+    expect(config.aspect_ratio).toBe("16:9");
+    expect(config.object_fit).toBe("cover");
+    expect(config.controls_mode).toBe("overlay");
+    expect(config.bar_position).toBe("top");
+  });
+});
+
+describe("preview_close_on_tap inherits clean_mode by default", () => {
+  it("defaults to true when clean_mode is true and not explicitly set", () => {
+    const { config } = normalizeConfig({ ...minimalSensor, clean_mode: true });
+    expect(config.preview_close_on_tap).toBe(true);
+  });
+
+  it("defaults to false when clean_mode is false", () => {
+    const { config } = normalizeConfig({ ...minimalSensor });
+    expect(config.preview_close_on_tap).toBe(false);
+  });
+
+  it("explicit `preview_close_on_tap: false` wins even when clean_mode is true", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      clean_mode: true,
+      preview_close_on_tap: false,
+    });
+    expect(config.preview_close_on_tap).toBe(false);
+  });
+
+  it("explicit `preview_close_on_tap: true` wins when clean_mode is false", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      preview_close_on_tap: true,
+    });
+    expect(config.preview_close_on_tap).toBe(true);
+  });
+});
+
+describe("entities accepts loose YAML scalar form", () => {
+  it("normalizes a plain `entities: 'sensor.cam'` string into an array", () => {
+    const { config } = normalizeConfig({
+      source_mode: "sensor",
+      folder_datetime_format: "x",
+      entities: "sensor.cam",
+    });
+    expect(config.entities).toEqual(["sensor.cam"]);
+  });
+});
+
+describe("clean_mode legacy alias", () => {
+  it("`preview_click_to_open` aliases `clean_mode` when latter not present", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      preview_click_to_open: true,
+    });
+    expect(config.clean_mode).toBe(true);
+  });
+
+  it("explicit `clean_mode` wins over alias", () => {
+    const { config } = normalizeConfig({
+      ...minimalSensor,
+      clean_mode: false,
+      preview_click_to_open: true,
+    });
+    expect(config.clean_mode).toBe(false);
+  });
+});
+
+describe("Idempotence — running normalize on already-canonical output is a no-op", () => {
+  it("normalizeConfig(normalizeConfig(x).config) === normalizeConfig(x).config", () => {
+    const first = normalizeConfig({
+      ...minimalMedia,
+      object_filters: [{ person: "mdi:walk" }, "car"],
+    });
+    const second = normalizeConfig(first.config);
+    expect(second.config).toEqual(first.config);
+  });
+});

--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -1,0 +1,623 @@
+/**
+ * Config normalization pipeline.
+ *
+ *   raw user YAML (typed `unknown` — only at the module boundary)
+ *     │
+ *     ▼  asInputConfig() — single shape narrow into a typed `InputConfig`.
+ *
+ *   InputConfig
+ *     │
+ *     ├── migrateLegacyKeys()    legacy keys → canonical keys.
+ *     │
+ *     ├── preMigrateConfig()     loose `object_filters` shape unwrap +
+ *     │                          string-field trims + custom-icon side-output.
+ *     ▼
+ *   create(migrated, struct)     shape + range + enum validation, defaults.
+ *     │
+ *     ├── applyCrossFieldRules() source-mode auto-inference, delete gating,
+ *     │                          datetime-format requirement, …
+ *     ▼
+ *   { config: CameraGalleryCardConfig, customIcons }
+ *
+ * Both card and editor call `normalizeConfig()`. The editor additionally
+ * runs `_stripAlwaysTrueKeys` on the result for YAML-output minimization.
+ */
+
+import { create, StructError } from "superstruct";
+import type { Infer } from "superstruct";
+
+import { KNOWN_FILTERS } from "../data/object-filters";
+import { FRIGATE_URI_PREFIX, hasFrigateConfig } from "../util/frigate";
+import { cameraGalleryCardConfigStruct, type CameraGalleryCardConfigStruct } from "./structs";
+
+// ─── Public types ────────────────────────────────────────────
+
+export type CameraGalleryCardConfig = Infer<CameraGalleryCardConfigStruct>;
+
+export interface NormalizedConfig {
+  config: CameraGalleryCardConfig;
+  /** Per-filter icon overrides extracted from the loose `object_filters` shape. */
+  customIcons: Record<string, string>;
+}
+
+/**
+ * One `object_filters` array entry, in the input shape. Either a canonical
+ * filter name (`"person"`) or a single-key object pairing a filter name with
+ * an MDI icon (`{ person: "mdi:walk" }`). The pre-migration step splits this
+ * into a clean `string[]` plus a `customIcons` side-output.
+ */
+export type ObjectFilterEntry = string | Record<string, string>;
+
+/** A single live-stream button entry, in the input shape (validated by struct). */
+export interface LiveStreamUrlEntryInput {
+  url?: string;
+  name?: string;
+}
+
+/** A single menu-button entry, in the input shape (validated by struct). */
+export interface MenuButtonInput {
+  entity?: string;
+  icon?: string;
+  icon_on?: string;
+  color_on?: string;
+  color_off?: string;
+  title?: string;
+  service?: string;
+  state_on?: string;
+}
+
+/**
+ * Loose YAML/storage input shape consumed by `normalizeConfig` / `migrateLegacyKeys`.
+ *
+ * Canonical fields are widened where the user may write looser values
+ * (e.g. `entities: "sensor.cam"` instead of an array). Legacy aliases and a
+ * handful of editor-managed always-true keys are listed too — pre-migration
+ * deletes them.
+ *
+ * The struct (`structs.ts`) is the source of truth for the canonical shape;
+ * `CameraGalleryCardConfig` is its `Infer<>` projection. After validation,
+ * downstream code only sees `CameraGalleryCardConfig` — this `InputConfig`
+ * is internal to the normalization layer.
+ */
+export interface InputConfig {
+  // ─── Identity ──────────────────────────────────────────────
+  type?: string;
+
+  // ─── Source mode ───────────────────────────────────────────
+  source_mode?: string;
+
+  // ─── Sensor source ─────────────────────────────────────────
+  entities?: string[] | string;
+
+  // ─── Media source ──────────────────────────────────────────
+  media_sources?: string[] | string;
+  frigate_url?: string;
+
+  // ─── Datetime parsing ──────────────────────────────────────
+  filename_datetime_format?: string;
+  folder_datetime_format?: string;
+
+  // ─── Playback ──────────────────────────────────────────────
+  autoplay?: boolean;
+  auto_muted?: boolean;
+
+  // ─── Live preview ──────────────────────────────────────────
+  live_enabled?: boolean;
+  live_auto_muted?: boolean;
+  live_camera_entity?: string;
+  live_camera_entities?: string[];
+  live_stream_url?: string;
+  live_stream_name?: string;
+  live_stream_urls?: LiveStreamUrlEntryInput[];
+  live_go2rtc_url?: string;
+  live_go2rtc_stream?: string;
+  start_mode?: string;
+
+  // ─── Delete ────────────────────────────────────────────────
+  allow_delete?: boolean;
+  allow_bulk_delete?: boolean;
+  delete_confirm?: boolean;
+  delete_service?: string;
+
+  // ─── Object filters ────────────────────────────────────────
+  object_filters?: ObjectFilterEntry[] | ObjectFilterEntry | null;
+  object_colors?: Record<string, string>;
+  entity_filter_map?: Record<string, string>;
+
+  // ─── Layout / styling ──────────────────────────────────────
+  bar_opacity?: number;
+  bar_position?: string;
+  thumb_size?: number;
+  thumb_bar_position?: string;
+  thumb_layout?: string;
+  thumbnail_frame_pct?: number;
+  pill_size?: number;
+  aspect_ratio?: string;
+  object_fit?: string;
+  controls_mode?: string;
+  style_variables?: string;
+  show_camera_title?: boolean;
+  persistent_controls?: boolean;
+
+  // ─── Preview ───────────────────────────────────────────────
+  preview_position?: string;
+  clean_mode?: boolean;
+  preview_close_on_tap?: boolean;
+
+  // ─── Misc ──────────────────────────────────────────────────
+  max_media?: number;
+  sync_entity?: string | null;
+  menu_buttons?: MenuButtonInput[];
+
+  // ─── Legacy aliases (rewritten in pre-migrate) ────────────
+  entity?: string;
+  media_source?: string;
+  media_folders_fav?: string[];
+  media_folder_favorites?: string[];
+  shell_command?: string;
+  preview_click_to_open?: boolean;
+
+  // ─── Editor-managed always-true keys (deleted in pre-migrate) ─
+  filter_folders_enabled?: boolean;
+  live_provider?: string;
+  media_folder_filter?: string;
+}
+
+/**
+ * Module-boundary narrow: convert genuinely-untyped YAML input (from the
+ * card's `setConfig` callback) into a typed `InputConfig`. This is the only
+ * `unknown` boundary in the module — it shallow-clones the input so the
+ * pipeline can mutate freely.
+ */
+function asInputConfig(raw: unknown): InputConfig {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return { ...(raw as InputConfig) };
+  }
+  return {};
+}
+
+/** Keys recognized as legacy aliases for canonical fields. */
+const LEGACY_KEYS = [
+  "entity",
+  "media_source",
+  "media_folder_favorites",
+  "media_folders_fav",
+  "shell_command",
+] as const satisfies readonly (keyof InputConfig)[];
+
+export type LegacyKey = (typeof LEGACY_KEYS)[number];
+
+export function hasLegacyKeys(raw: unknown): boolean {
+  const obj = asInputConfig(raw);
+  return LEGACY_KEYS.some((k) => k in obj);
+}
+
+/** Error thrown when validation fails. Preserves the underlying `StructError` as `cause`. */
+export class ConfigValidationError extends Error {
+  override readonly name = "ConfigValidationError";
+  readonly cause: StructError;
+  constructor(message: string, cause: StructError) {
+    super(message);
+    this.cause = cause;
+  }
+}
+
+// ─── Pure helpers ────────────────────────────────────────────
+
+/**
+ * Map `transform` over `arr`, drop empty results, dedupe case-insensitively
+ * (preserving the first-seen casing). Shared between sensor-entity and
+ * media-root normalization since both follow the exact same pattern.
+ */
+function dedupeNormalized(arr: readonly string[], transform: (s: string) => string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
+    const v = transform(raw);
+    if (!v) continue;
+    const k = v.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(v);
+  }
+  return out;
+}
+
+/** Coerce singular/array/nullish input into a string array for `dedupeNormalized`. */
+function asStringArray(input: string[] | string | null | undefined, fallback = ""): string[] {
+  if (Array.isArray(input)) return input;
+  if (input) return [input];
+  return fallback ? [fallback] : [];
+}
+
+/**
+ * Normalize an array-or-singular sensor-entity input into a deduplicated,
+ * trimmed string array. Case-insensitive dedup.
+ */
+function normalizeSensorEntities(
+  input: string[] | string | null | undefined,
+  fallbackSingle = ""
+): string[] {
+  return dedupeNormalized(asStringArray(input, fallbackSingle), (s) => s.trim());
+}
+
+/**
+ * Canonicalize a single media-source root. Adds the `media-source://` and
+ * `media_source/` prefixes when absent; rewrites `frigate/...` shortcuts
+ * into the `media-source://frigate/...` form. Returns `""` for empty input.
+ */
+function normalizeMediaRoot(input: string | null | undefined): string {
+  let v = (input ?? "").trim();
+  if (!v) return "";
+
+  const strip = (s: string): string => s.replace(/^\/+/, "").replace(/\/+$/, "");
+
+  if (v.startsWith("media-source://")) {
+    let rest = v
+      .slice("media-source://".length)
+      .replace(/\/{2,}/g, "/")
+      .replace(/\/+$/g, "");
+    if (rest.startsWith("local/")) rest = `media_source/${rest}`;
+    return `media-source://${rest}`;
+  }
+
+  v = strip(v);
+
+  if (/^frigate(\/|$)/i.test(v)) {
+    const rest = strip(v.replace(/^frigate/i, ""));
+    return rest ? `${FRIGATE_URI_PREFIX}/${rest}` : FRIGATE_URI_PREFIX;
+  }
+
+  v = v.replace(/^media\//, "");
+  return `media-source://media_source/${v}`;
+}
+
+/**
+ * Canonicalize an array-or-singular media-source input. Deduplicates
+ * (case-insensitive) and drops empty entries.
+ */
+function normalizeMediaRoots(input: string[] | string | null | undefined): string[] {
+  return dedupeNormalized(asStringArray(input), normalizeMediaRoot);
+}
+
+// Re-export for tests + future callers; keep public surface stable.
+export { normalizeSensorEntities, normalizeMediaRoot, normalizeMediaRoots };
+
+// ─── Pre-migration ───────────────────────────────────────────
+
+export interface MigratedConfig {
+  /** The migrated input — what the editor stores, or what the card validates next. */
+  migrated: InputConfig;
+  /** True when at least one legacy key was rewritten. */
+  hadLegacyKeys: boolean;
+}
+
+/**
+ * Rewrite legacy-aliased keys to their canonical names. Used by both the
+ * card (as the first step of `normalizeConfig`) and the editor (which
+ * needs the same migrations but preserves the loose `object_filters` shape
+ * to round-trip user icon choices through YAML).
+ *
+ * Idempotent: running it on already-canonical input flips no keys and
+ * reports `hadLegacyKeys: false`.
+ */
+export function migrateLegacyKeys(raw: unknown): MigratedConfig {
+  const out = asInputConfig(raw);
+  let hadLegacyKeys = false;
+
+  // entity → entities
+  if (!Array.isArray(out.entities) && out.entity !== undefined) {
+    out.entities = normalizeSensorEntities(out.entities, out.entity);
+    hadLegacyKeys = true;
+  } else if (out.entities !== undefined) {
+    out.entities = normalizeSensorEntities(out.entities);
+  }
+  if ("entity" in out) {
+    delete out.entity;
+    hadLegacyKeys = true;
+  }
+
+  // media_source / media_folder_favorites / media_folders_fav → media_sources
+  // The legacy aliases coexist with `media_sources`; first non-empty wins.
+  const hasLegacyMedia =
+    "media_source" in out || "media_folders_fav" in out || "media_folder_favorites" in out;
+  const mediaCandidate: string[] | string | null =
+    (Array.isArray(out.media_sources) ? out.media_sources : null) ??
+    (Array.isArray(out.media_folders_fav) ? out.media_folders_fav : null) ??
+    (Array.isArray(out.media_folder_favorites) ? out.media_folder_favorites : null) ??
+    (typeof out.media_source === "string" ? [out.media_source] : null);
+  if (mediaCandidate !== null || out.media_sources !== undefined) {
+    out.media_sources = normalizeMediaRoots(mediaCandidate);
+  }
+  if (hasLegacyMedia) {
+    delete out.media_source;
+    delete out.media_folder_favorites;
+    delete out.media_folders_fav;
+    hadLegacyKeys = true;
+  }
+
+  // shell_command → delete_service (legacy alias; delete_service wins)
+  if (out.delete_service === undefined && typeof out.shell_command === "string") {
+    out.delete_service = out.shell_command;
+  }
+  if ("shell_command" in out) {
+    delete out.shell_command;
+    hadLegacyKeys = true;
+  }
+
+  // preview_click_to_open → clean_mode (legacy alias)
+  if (out.clean_mode === undefined && out.preview_click_to_open !== undefined) {
+    out.clean_mode = !!out.preview_click_to_open;
+  }
+  if ("preview_click_to_open" in out) {
+    delete out.preview_click_to_open;
+    hadLegacyKeys = true;
+  }
+
+  // Editor-managed always-true keys that older YAML may carry. The struct's
+  // top-level `type()` ignores unknowns, but stripping keeps the migrated
+  // input tidy for downstream comparison.
+  for (const k of ["filter_folders_enabled", "live_provider", "media_folder_filter"] as const) {
+    if (k in out) {
+      delete out[k];
+      hadLegacyKeys = true;
+    }
+  }
+
+  return { migrated: out, hadLegacyKeys };
+}
+
+interface PreMigrated {
+  /** The migrated input, ready for `create(..., struct)`. */
+  migrated: InputConfig;
+  /** Custom icon overrides parsed out of `object_filters` entries. */
+  customIcons: Record<string, string>;
+}
+
+/**
+ * Trim an optional string field in-place. If the trimmed value is empty,
+ * `delete` the key (not `obj[key] = undefined` — `exactOptionalPropertyTypes`
+ * distinguishes "absent" from "present but undefined").
+ */
+function trimOptionalString<K extends keyof InputConfig>(
+  obj: InputConfig,
+  key: K,
+  transform: (s: string) => string = (s) => s
+): void {
+  const v = obj[key];
+  if (typeof v !== "string") return;
+  const t = transform(v.trim());
+  if (t === "") {
+    delete obj[key];
+  } else {
+    // Type-safe write: `t` is a string, the field shape includes `string`.
+    (obj[key] as string) = t;
+  }
+}
+
+/**
+ * The card's pre-migration: legacy-key rewrite **plus** loose-shape
+ * unwrapping for `object_filters` and value-filtering for `entity_filter_map`.
+ * Returns the canonical shape the struct expects, and the per-filter custom
+ * icon map separated out for the card to consume.
+ *
+ * Mutates the supplied `InputConfig` in place; it's expected to be a fresh
+ * shallow-clone produced by `asInputConfig()` upstream.
+ */
+function preMigrateConfig(input: InputConfig): PreMigrated {
+  const { migrated: out } = migrateLegacyKeys(input);
+
+  // frigate_url: trim + strip trailing slashes (struct accepts string but
+  // canonical form has no trailing slash).
+  trimOptionalString(out, "frigate_url", (s) => s.replace(/\/+$/, ""));
+
+  // String fields the legacy code coerced via String(...).trim(). Empty
+  // strings drop the key so `optional(...)` struct fields stay absent.
+  trimOptionalString(out, "live_stream_url");
+  trimOptionalString(out, "live_stream_name");
+  trimOptionalString(out, "live_go2rtc_url");
+  trimOptionalString(out, "live_go2rtc_stream");
+  trimOptionalString(out, "sync_entity");
+
+  // Defaulted-to-`""` string fields: trim, never delete.
+  out.live_camera_entity = (out.live_camera_entity ?? "").trim();
+  out.filename_datetime_format = (out.filename_datetime_format ?? "").trim();
+  out.folder_datetime_format = (out.folder_datetime_format ?? "").trim();
+  out.style_variables = (out.style_variables ?? "").trim();
+
+  // live_camera_entities: trim + drop empties.
+  const cams = out.live_camera_entities;
+  if (cams !== undefined) {
+    out.live_camera_entities = Array.isArray(cams)
+      ? cams.map((s: string) => s.trim()).filter((s) => s.length > 0)
+      : [];
+  }
+
+  // object_filters: unwrap the loose `string | {name: icon}` input shape into
+  // a clean string array + a `customIcons` side-output. Unknown filter names
+  // are silently dropped (legacy behaviour preserved — old configs may
+  // reference filters that have since been renamed).
+  const customIcons: Record<string, string> = {};
+  const ofIn = out.object_filters;
+  const ofRaw: ObjectFilterEntry[] = Array.isArray(ofIn) ? ofIn : ofIn ? [ofIn] : [];
+  const ofOut: string[] = [];
+  const ofSeen = new Set<string>();
+
+  for (const item of ofRaw) {
+    let name = "";
+    let icon = "";
+    if (typeof item === "string") {
+      name = item.toLowerCase().trim();
+    } else {
+      const entries = Object.entries(item);
+      const first = entries[0];
+      if (first) {
+        name = first[0].toLowerCase().trim();
+        icon = first[1];
+      }
+    }
+    if (!name || ofSeen.has(name) || !KNOWN_FILTERS.has(name)) continue;
+    ofSeen.add(name);
+    ofOut.push(name);
+    if (icon) customIcons[name] = icon;
+  }
+  out.object_filters = ofOut;
+
+  // entity_filter_map: filter to known filter names (silent-drop legacy values).
+  if (out.entity_filter_map) {
+    const cleaned: Record<string, string> = {};
+    for (const [entityId, rawFilter] of Object.entries(out.entity_filter_map)) {
+      // `noUncheckedIndexedAccess` widens the value type, so guard explicitly.
+      if (typeof rawFilter !== "string") continue;
+      const e = entityId.trim();
+      const f = rawFilter.toLowerCase().trim();
+      if (!e || !f || !KNOWN_FILTERS.has(f)) continue;
+      cleaned[e] = f;
+    }
+    out.entity_filter_map = cleaned;
+  }
+
+  return { migrated: out, customIcons };
+}
+
+// ─── Cross-field rules ───────────────────────────────────────
+
+/**
+ * Auto-infer `source_mode` when the user left it blank: media-only configs
+ * default to `"media"`, everything else defaults to `"sensor"`. An explicit
+ * non-empty `source_mode` is always honoured.
+ */
+function inferSourceMode(
+  explicit: boolean,
+  validated: CameraGalleryCardConfig
+): CameraGalleryCardConfig["source_mode"] {
+  if (explicit) return validated.source_mode;
+  const hasMedia = validated.media_sources.length > 0;
+  const hasSensors = validated.entities.length > 0;
+  return hasMedia && !hasSensors ? "media" : "sensor";
+}
+
+/**
+ * `preview_close_on_tap` defaults to `true` when `clean_mode: true`, `false`
+ * otherwise — but only when the user didn't set it explicitly. The struct
+ * defaults the field to `false` unconditionally, so this rule kicks in when
+ * the user didn't set it.
+ */
+function applyPreviewCloseOnTapDefault(
+  explicit: boolean,
+  config: CameraGalleryCardConfig
+): CameraGalleryCardConfig {
+  if (explicit) return config;
+  return { ...config, preview_close_on_tap: config.clean_mode };
+}
+
+/**
+ * Apply mode-aware delete gating:
+ *   - Pure `media` mode can't delete (URIs aren't filesystem paths).
+ *   - Sensor/combined modes need a `delete_service` for delete to work; if
+ *     missing, both `allow_delete` and `allow_bulk_delete` are forced off.
+ */
+function applyDeleteGating(config: CameraGalleryCardConfig): CameraGalleryCardConfig {
+  if (config.source_mode === "media") {
+    return {
+      ...config,
+      allow_delete: false,
+      allow_bulk_delete: false,
+      delete_service: "",
+    };
+  }
+  if (config.allow_delete && !config.delete_service) {
+    return { ...config, allow_delete: false, allow_bulk_delete: false };
+  }
+  return config;
+}
+
+/**
+ * Mode-specific required-field checks. Throws a descriptive Error so the
+ * card error overlay surfaces the user's mistake.
+ */
+function assertRequiredFields(config: CameraGalleryCardConfig): void {
+  const { source_mode, entities, media_sources } = config;
+
+  if (source_mode === "sensor" && !entities.length) {
+    throw new Error(
+      "camera-gallery-card: 'entity' or 'entities' is required in source_mode: sensor"
+    );
+  }
+  if (source_mode === "combined") {
+    if (!entities.length) {
+      throw new Error(
+        "camera-gallery-card: 'entity' or 'entities' is required in source_mode: combined"
+      );
+    }
+    if (!media_sources.length) {
+      throw new Error(
+        "camera-gallery-card: 'media_source' or 'media_sources' is required in source_mode: combined"
+      );
+    }
+  }
+  if (source_mode === "media" && !media_sources.length) {
+    throw new Error(
+      "camera-gallery-card: 'media_source' OR 'media_sources' is required in source_mode: media"
+    );
+  }
+
+  if (
+    !config.folder_datetime_format &&
+    !config.filename_datetime_format &&
+    !hasFrigateConfig({
+      frigate_url: config.frigate_url,
+      media_sources: config.media_sources,
+    })
+  ) {
+    throw new Error(
+      "camera-gallery-card: 'folder_datetime_format' or 'filename_datetime_format' is required so files can be grouped by date"
+    );
+  }
+}
+
+// ─── Public entry ────────────────────────────────────────────
+
+/**
+ * Validate and normalize raw card config (from YAML / Lovelace storage) into
+ * the canonical `CameraGalleryCardConfig` shape, plus the per-filter custom
+ * icon map.
+ *
+ * Throws `ConfigValidationError` (subclass of `Error`) for shape violations,
+ * and a plain `Error` for cross-field rule violations.
+ */
+export function normalizeConfig(raw: unknown): NormalizedConfig {
+  // Capture which keys were *explicitly set* before pre-migration mutates
+  // the input — the cross-field rules need to know "user said X" vs
+  // "field defaulted in".
+  const input = asInputConfig(raw);
+  const explicitSourceMode =
+    typeof input.source_mode === "string" && input.source_mode.trim() !== "";
+  const explicitPreviewCloseOnTap = "preview_close_on_tap" in input;
+
+  const { migrated, customIcons } = preMigrateConfig(input);
+
+  let validated: CameraGalleryCardConfig;
+  try {
+    validated = create(migrated, cameraGalleryCardConfigStruct);
+  } catch (err) {
+    if (err instanceof StructError) {
+      throw new ConfigValidationError(
+        `camera-gallery-card: invalid config — ${err.path.join(".") || "<root>"}: ${err.message}`,
+        err
+      );
+    }
+    throw err;
+  }
+
+  validated = {
+    ...validated,
+    source_mode: inferSourceMode(explicitSourceMode, validated),
+  };
+  validated = applyPreviewCloseOnTapDefault(explicitPreviewCloseOnTap, validated);
+  validated = applyDeleteGating(validated);
+
+  assertRequiredFields(validated);
+
+  return { config: validated, customIcons };
+}

--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -1,0 +1,211 @@
+/**
+ * Superstruct validators for `CameraGalleryCardConfig`.
+ *
+ * The struct describes the *canonical* shape — the form `this.config` takes
+ * after normalization. Legacy-key migrations (`entity` → `entities`,
+ * `media_source` → `media_sources`, etc.) and the loose `object_filters`
+ * `string | {name: icon}` input shape live in `./normalize.ts`'s pre-migrate
+ * step, not here, so validation errors reference the canonical shape and
+ * stay readable.
+ *
+ * `defaulted(...)` is used liberally; callers must use `create()` (not
+ * `assert()`) to get defaults applied.
+ */
+
+import {
+  array,
+  boolean,
+  defaulted,
+  enums,
+  integer,
+  object,
+  optional,
+  record,
+  refine,
+  string,
+  type,
+} from "superstruct";
+import type { Struct } from "superstruct";
+
+import {
+  ASPECT_RATIOS,
+  AVAILABLE_OBJECT_FILTERS,
+  BAR_OPACITY_MAX,
+  BAR_OPACITY_MIN,
+  BAR_POSITIONS,
+  CONTROLS_MODES,
+  DEFAULT_ALLOW_BULK_DELETE,
+  DEFAULT_ALLOW_DELETE,
+  DEFAULT_ASPECT_RATIO,
+  DEFAULT_AUTOMUTED,
+  DEFAULT_AUTOPLAY,
+  DEFAULT_BAR_OPACITY,
+  DEFAULT_BAR_POSITION,
+  DEFAULT_CONTROLS_MODE,
+  DEFAULT_DELETE_CONFIRM,
+  DEFAULT_DELETE_SERVICE,
+  DEFAULT_LIVE_AUTO_MUTED,
+  DEFAULT_LIVE_ENABLED,
+  DEFAULT_MAX_MEDIA,
+  DEFAULT_OBJECT_FIT,
+  DEFAULT_PREVIEW_POSITION,
+  DEFAULT_SOURCE_MODE,
+  DEFAULT_THUMB_BAR_POSITION,
+  DEFAULT_THUMB_LAYOUT,
+  DEFAULT_THUMBNAIL_FRAME_PCT,
+  MAX_MEDIA_MAX,
+  MAX_MEDIA_MIN,
+  OBJECT_FITS,
+  PILL_SIZE_DEFAULT,
+  PILL_SIZE_MAX,
+  PILL_SIZE_MIN,
+  PREVIEW_POSITIONS,
+  SOURCE_MODES,
+  START_MODES,
+  THUMB_BAR_POSITIONS,
+  THUMB_LAYOUTS,
+  THUMB_SIZE,
+  THUMB_SIZE_MAX,
+  THUMB_SIZE_MIN,
+  THUMBNAIL_FRAME_PCT_MAX,
+  THUMBNAIL_FRAME_PCT_MIN,
+} from "../const";
+
+/**
+ * Integer in [min, max]. Numeric range refinement on top of `integer()`.
+ *
+ * Returns a descriptive error string (not `false`) so the message says
+ * "must be between 40 and 220" instead of falling back to the inner
+ * `integer()` type name.
+ */
+const intInRange = (min: number, max: number): Struct<number, null> =>
+  refine(integer(), `int[${min},${max}]`, (v) =>
+    v >= min && v <= max ? true : `must be a number between ${min} and ${max} (got ${v})`
+  );
+
+/** HA service ID `domain.service` (lowercase, digits, underscore); empty string allowed. */
+const serviceId = refine(string(), "service_id", (v) =>
+  v === "" || /^[a-z0-9_]+\.[a-z0-9_]+$/i.test(v)
+    ? true
+    : `must be in 'domain.service' form (got '${v}')`
+);
+
+/**
+ * Single live-stream button entry.
+ *
+ * Stricter than the legacy filter: we require `url` to be a non-empty string.
+ * Malformed entries (no url, wrong type) become validation errors instead of
+ * being silently dropped — users with broken YAML now see a clear error.
+ */
+const nonEmptyString = refine(string(), "non_empty_string", (v) =>
+  v.trim().length > 0 ? true : "must be a non-empty string"
+);
+
+const liveStreamUrlEntry = object({
+  url: nonEmptyString,
+  name: defaulted(string(), ""),
+});
+
+/** Menu button entry — same strictness rationale as `liveStreamUrlEntry`. */
+const menuButton = object({
+  entity: nonEmptyString,
+  icon: nonEmptyString,
+  icon_on: optional(string()),
+  color_on: optional(string()),
+  color_off: optional(string()),
+  title: optional(string()),
+  service: optional(string()),
+  state_on: optional(string()),
+});
+
+/**
+ * Canonical `CameraGalleryCardConfig` shape.
+ *
+ * Every field is either `defaulted()` (always present after `create()`) or
+ * `optional()` (nullable). Cross-field rules — source-mode auto-inference,
+ * delete gating, datetime-format requirement — live in `normalize.ts`, not
+ * here, because superstruct can't conditionally require fields.
+ *
+ * `type()` (not `object()`) at the top level so legacy keys we don't know
+ * about don't trip validation. Pre-migrate strips known legacy keys; any
+ * remaining unknowns get silently ignored. Nested objects (`liveStreamUrlEntry`,
+ * `menuButton`) stay strict so typos in those structures are visible.
+ */
+export const cameraGalleryCardConfigStruct = type({
+  type: defaulted(string(), "custom:camera-gallery-card"),
+
+  // ─── Source mode ───────────────────────────────────────────
+  source_mode: defaulted(enums(SOURCE_MODES), DEFAULT_SOURCE_MODE),
+
+  // ─── Sensor source ─────────────────────────────────────────
+  entities: defaulted(array(string()), []),
+
+  // ─── Media source ──────────────────────────────────────────
+  media_sources: defaulted(array(string()), []),
+  frigate_url: optional(string()),
+
+  // ─── Datetime parsing ──────────────────────────────────────
+  filename_datetime_format: defaulted(string(), ""),
+  folder_datetime_format: defaulted(string(), ""),
+
+  // ─── Playback ──────────────────────────────────────────────
+  autoplay: defaulted(boolean(), DEFAULT_AUTOPLAY),
+  auto_muted: defaulted(boolean(), DEFAULT_AUTOMUTED),
+
+  // ─── Live preview ──────────────────────────────────────────
+  live_enabled: defaulted(boolean(), DEFAULT_LIVE_ENABLED),
+  live_auto_muted: defaulted(boolean(), DEFAULT_LIVE_AUTO_MUTED),
+  live_camera_entity: defaulted(string(), ""),
+  live_camera_entities: defaulted(array(string()), []),
+  live_stream_url: optional(string()),
+  live_stream_name: optional(string()),
+  live_stream_urls: optional(array(liveStreamUrlEntry)),
+  live_go2rtc_url: optional(string()),
+  live_go2rtc_stream: optional(string()),
+  start_mode: defaulted(enums(START_MODES), "gallery"),
+
+  // ─── Delete ────────────────────────────────────────────────
+  allow_delete: defaulted(boolean(), DEFAULT_ALLOW_DELETE),
+  allow_bulk_delete: defaulted(boolean(), DEFAULT_ALLOW_BULK_DELETE),
+  delete_confirm: defaulted(boolean(), DEFAULT_DELETE_CONFIRM),
+  delete_service: defaulted(serviceId, DEFAULT_DELETE_SERVICE),
+
+  // ─── Object filters ────────────────────────────────────────
+  // The loose `string | { name: icon }` input shape is unwrapped in
+  // `normalize.ts`'s pre-migrate step, which splits it into:
+  //   - `object_filters: string[]` (just the canonical names, here)
+  //   - `customIcons: Record<string, string>` (returned alongside the config)
+  object_filters: defaulted(array(enums(AVAILABLE_OBJECT_FILTERS)), []),
+  object_colors: defaulted(record(string(), string()), {}),
+  entity_filter_map: defaulted(record(string(), enums(AVAILABLE_OBJECT_FILTERS)), {}),
+
+  // ─── Layout / styling ──────────────────────────────────────
+  bar_opacity: defaulted(intInRange(BAR_OPACITY_MIN, BAR_OPACITY_MAX), DEFAULT_BAR_OPACITY),
+  bar_position: defaulted(enums(BAR_POSITIONS), DEFAULT_BAR_POSITION),
+  thumb_size: defaulted(intInRange(THUMB_SIZE_MIN, THUMB_SIZE_MAX), THUMB_SIZE),
+  thumb_bar_position: defaulted(enums(THUMB_BAR_POSITIONS), DEFAULT_THUMB_BAR_POSITION),
+  thumb_layout: defaulted(enums(THUMB_LAYOUTS), DEFAULT_THUMB_LAYOUT),
+  thumbnail_frame_pct: defaulted(
+    intInRange(THUMBNAIL_FRAME_PCT_MIN, THUMBNAIL_FRAME_PCT_MAX),
+    DEFAULT_THUMBNAIL_FRAME_PCT
+  ),
+  pill_size: defaulted(intInRange(PILL_SIZE_MIN, PILL_SIZE_MAX), PILL_SIZE_DEFAULT),
+  aspect_ratio: defaulted(enums(ASPECT_RATIOS), DEFAULT_ASPECT_RATIO),
+  object_fit: defaulted(enums(OBJECT_FITS), DEFAULT_OBJECT_FIT),
+  controls_mode: defaulted(enums(CONTROLS_MODES), DEFAULT_CONTROLS_MODE),
+  style_variables: defaulted(string(), ""),
+  show_camera_title: defaulted(boolean(), true),
+  persistent_controls: defaulted(boolean(), false),
+
+  // ─── Preview ───────────────────────────────────────────────
+  preview_position: defaulted(enums(PREVIEW_POSITIONS), DEFAULT_PREVIEW_POSITION),
+  clean_mode: defaulted(boolean(), false),
+  preview_close_on_tap: defaulted(boolean(), false),
+
+  // ─── Misc ──────────────────────────────────────────────────
+  max_media: defaulted(intInRange(MAX_MEDIA_MIN, MAX_MEDIA_MAX), DEFAULT_MAX_MEDIA),
+  sync_entity: optional(string()),
+  menu_buttons: defaulted(array(menuButton), []),
+});
+
+export type CameraGalleryCardConfigStruct = typeof cameraGalleryCardConfigStruct;

--- a/src/const.ts
+++ b/src/const.ts
@@ -5,10 +5,29 @@
  */
 
 // -------- Literal unions for constrained string config values --------
-export type SourceMode = "sensor" | "media" | "combined";
-export type PreviewPosition = "top" | "bottom";
-export type ThumbBarPosition = "top" | "bottom" | "hidden";
-export type ThumbLayout = "horizontal" | "vertical";
+// Allowed-value arrays are `as const` so the struct can validate against them
+// and the literal types fall out of `[number]` indexing — no drift between the
+// runtime checker and the type.
+
+export const SOURCE_MODES = ["sensor", "media", "combined"] as const;
+export const PREVIEW_POSITIONS = ["top", "bottom"] as const;
+export const THUMB_BAR_POSITIONS = ["top", "bottom", "hidden"] as const;
+export const THUMB_LAYOUTS = ["horizontal", "vertical"] as const;
+export const BAR_POSITIONS = ["top", "bottom", "hidden"] as const;
+export const START_MODES = ["gallery", "live"] as const;
+export const OBJECT_FITS = ["cover", "contain"] as const;
+export const CONTROLS_MODES = ["overlay", "fixed"] as const;
+export const ASPECT_RATIOS = ["16:9", "4:3", "1:1"] as const;
+
+export type SourceMode = (typeof SOURCE_MODES)[number];
+export type PreviewPosition = (typeof PREVIEW_POSITIONS)[number];
+export type ThumbBarPosition = (typeof THUMB_BAR_POSITIONS)[number];
+export type ThumbLayout = (typeof THUMB_LAYOUTS)[number];
+export type BarPosition = (typeof BAR_POSITIONS)[number];
+export type StartMode = (typeof START_MODES)[number];
+export type ObjectFit = (typeof OBJECT_FITS)[number];
+export type ControlsMode = (typeof CONTROLS_MODES)[number];
+export type AspectRatio = (typeof ASPECT_RATIOS)[number];
 
 /** Public CSS-variable namespace — every styling API key is `--cgc-*`. */
 export type CssVarKey = `--cgc-${string}`;
@@ -23,6 +42,27 @@ export const THUMBS_ENABLED = true;
 export const THUMB_GAP = 2;
 export const THUMB_RADIUS = 10;
 export const THUMB_SIZE = 86;
+
+// -------- Numeric clamp ranges (used by both the struct and the editor sliders) --------
+// Why these specific ranges:
+//   THUMB_SIZE: under 40px chrome dominates the cell; above 220px the grid
+//     stops fitting on phones in landscape.
+//   PILL_SIZE:  pills double as touch targets — 10px is the smallest readable
+//     dot, 28px is roughly the iOS/Android tap-target ceiling.
+//   MAX_MEDIA:  the gallery virtualizes but each item costs ~10kB of poster
+//     cache; 500 is the point where mobile Safari hits memory pressure.
+//   FRAME_PCT, BAR_OPACITY: percentages, clamp to [0, 100].
+export const THUMB_SIZE_MIN = 40;
+export const THUMB_SIZE_MAX = 220;
+export const PILL_SIZE_MIN = 10;
+export const PILL_SIZE_MAX = 28;
+export const PILL_SIZE_DEFAULT = 14;
+export const MAX_MEDIA_MIN = 1;
+export const MAX_MEDIA_MAX = 500;
+export const THUMBNAIL_FRAME_PCT_MIN = 0;
+export const THUMBNAIL_FRAME_PCT_MAX = 100;
+export const BAR_OPACITY_MIN = 0;
+export const BAR_OPACITY_MAX = 100;
 
 // -------- Sensor poster generation --------
 export const SENSOR_POSTER_CONCURRENCY = 8;
@@ -68,16 +108,32 @@ export const DEFAULT_ALLOW_BULK_DELETE = true;
 export const DEFAULT_ALLOW_DELETE = true;
 export const DEFAULT_AUTOMUTED = true;
 export const DEFAULT_AUTOPLAY = false;
+export const DEFAULT_ASPECT_RATIO = "16:9" satisfies AspectRatio;
 export const DEFAULT_BAR_OPACITY = 30;
+export const DEFAULT_BAR_POSITION = "top" satisfies BarPosition;
+export const DEFAULT_CONTROLS_MODE = "overlay" satisfies ControlsMode;
 export const DEFAULT_BROWSE_TIMEOUT_MS = 10000;
 export const DEFAULT_CLEAN_MODE = false;
 export const DEFAULT_DELETE_CONFIRM = true;
 export const DEFAULT_DELETE_PREFIX = "/config/www/";
+/**
+ * `DEFAULT_DELETE_PREFIX` after normalization: leading slash, no duplicate
+ * slashes, trailing slash. Used by the delete-service shell-command path
+ * builder.
+ */
+export const DELETE_PREFIX_NORMALIZED = ((): string => {
+  const lead = DEFAULT_DELETE_PREFIX.startsWith("/")
+    ? DEFAULT_DELETE_PREFIX
+    : "/" + DEFAULT_DELETE_PREFIX;
+  const noMulti = lead.replace(/\/{2,}/g, "/");
+  return noMulti.endsWith("/") ? noMulti : noMulti + "/";
+})();
 export const DEFAULT_DELETE_SERVICE = "";
 export const DEFAULT_FRIGATE_API_LIMIT = 500;
 export const DEFAULT_LIVE_AUTO_MUTED = true;
 export const DEFAULT_LIVE_ENABLED = false;
 export const DEFAULT_MAX_MEDIA = 50;
+export const DEFAULT_OBJECT_FIT = "cover" satisfies ObjectFit;
 export const DEFAULT_PER_ROOT_MIN_LIMIT = 40;
 export const DEFAULT_PREVIEW_CLOSE_ON_TAP_WHEN_GATED = true;
 export const DEFAULT_PREVIEW_POSITION = "top" satisfies PreviewPosition;

--- a/src/data/datetime-parsing.ts
+++ b/src/data/datetime-parsing.ts
@@ -71,24 +71,19 @@ function build(
 
 // ---------- Format mini-language ----------
 
-const TOKEN_FIELDS: Record<string, DateField> = {
-  YYYY: "year",
-  YY: "year2",
-  MM: "month",
-  DD: "day",
-  HH: "hour",
-  mm: "minute",
-  ss: "second",
-};
-const TOKEN_DIGITS: Record<string, number> = {
-  YYYY: 4,
-  YY: 2,
-  MM: 2,
-  DD: 2,
-  HH: 2,
-  mm: 2,
-  ss: 2,
-};
+/** Token → `(field, digit count)` pair. Single source of truth for the format mini-language. */
+const TOKEN_SPECS = {
+  YYYY: { field: "year", digits: 4 },
+  YY: { field: "year2", digits: 2 },
+  MM: { field: "month", digits: 2 },
+  DD: { field: "day", digits: 2 },
+  HH: { field: "hour", digits: 2 },
+  mm: { field: "minute", digits: 2 },
+  ss: { field: "second", digits: 2 },
+} as const satisfies Record<string, { field: DateField; digits: number }>;
+
+type TokenName = keyof typeof TOKEN_SPECS;
+
 const TOKEN_RE = /(YYYY|YY|MM|DD|HH|mm|ss)/g;
 const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -101,12 +96,10 @@ export function buildFilenameDateRegex(
   let regexStr = "";
   let last = 0;
   for (let m = TOKEN_RE.exec(fmt); m !== null; m = TOKEN_RE.exec(fmt)) {
-    const tok = m[0];
-    const field = TOKEN_FIELDS[tok];
-    const digits = TOKEN_DIGITS[tok];
-    if (!field || !digits) continue;
-    regexStr += escapeRe(fmt.slice(last, m.index)) + `(\\d{${digits}})`;
-    fields.push(field);
+    const tok = m[0] as TokenName;
+    const spec = TOKEN_SPECS[tok];
+    regexStr += escapeRe(fmt.slice(last, m.index)) + `(\\d{${spec.digits}})`;
+    fields.push(spec.field);
     last = m.index + tok.length;
   }
   regexStr += escapeRe(fmt.slice(last));

--- a/src/data/object-filters.spec.ts
+++ b/src/data/object-filters.spec.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import { AVAILABLE_OBJECT_FILTERS } from "../const";
+import {
+  DEFAULT_OBJECT_ICON,
+  FILTER_ALIASES,
+  OBJECT_FILTER_ICONS,
+  filterLabel,
+  filterLabelList,
+  getFilterAliases,
+  itemFilenameForFilter,
+  matchesObjectFilterForFileSensor,
+  objectColor,
+  objectIcon,
+  sensorTextForFilter,
+} from "./object-filters";
+
+describe("filterLabel", () => {
+  it("returns the canonical filter name when known (case-insensitive)", () => {
+    expect(filterLabel("person")).toBe("person");
+    expect(filterLabel("PERSON")).toBe("person");
+    expect(filterLabel(" car ")).toBe("car");
+  });
+
+  it("returns 'selected' for unknown values", () => {
+    expect(filterLabel("ufo")).toBe("selected");
+    expect(filterLabel("")).toBe("selected");
+  });
+});
+
+describe("filterLabelList", () => {
+  it("joins known filters with comma + space", () => {
+    expect(filterLabelList(["person", "car"])).toBe("person, car");
+  });
+
+  it("returns 'selected' for empty input", () => {
+    expect(filterLabelList([])).toBe("selected");
+  });
+
+  it("drops unknowns and returns 'selected' if everything is unknown", () => {
+    expect(filterLabelList(["ufo", "yeti"])).toBe("selected");
+  });
+});
+
+describe("getFilterAliases", () => {
+  it("returns the alias list for a known filter", () => {
+    expect(getFilterAliases("person")).toContain("persoon");
+    expect(getFilterAliases("dog")).toContain("hond");
+    expect(getFilterAliases("car")).toContain("voertuig");
+  });
+
+  it("returns a single-element list for unknown filters", () => {
+    expect(getFilterAliases("ufo")).toEqual(["ufo"]);
+  });
+
+  it("returns empty list for empty input", () => {
+    expect(getFilterAliases("")).toEqual([]);
+    expect(getFilterAliases("  ")).toEqual([]);
+  });
+
+  it("each known filter has at least one alias", () => {
+    for (const f of AVAILABLE_OBJECT_FILTERS) {
+      expect(FILTER_ALIASES[f].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every alias is already lowercase and trimmed (matcher relies on this)", () => {
+    for (const f of AVAILABLE_OBJECT_FILTERS) {
+      for (const alias of FILTER_ALIASES[f]) {
+        expect(alias).toBe(alias.toLowerCase().trim());
+      }
+    }
+  });
+});
+
+describe("objectIcon", () => {
+  it("uses the canonical icon when known", () => {
+    expect(objectIcon("person")).toBe(OBJECT_FILTER_ICONS.person);
+    expect(objectIcon("car")).toBe(OBJECT_FILTER_ICONS.car);
+  });
+
+  it("returns DEFAULT_OBJECT_ICON for unknown", () => {
+    expect(objectIcon("ufo")).toBe(DEFAULT_OBJECT_ICON);
+  });
+
+  it("custom icon overrides the canonical map", () => {
+    expect(objectIcon("person", { person: "mdi:walk" })).toBe("mdi:walk");
+  });
+
+  it("custom override wins even for unknown filter names (user-defined)", () => {
+    expect(objectIcon("ufo", { ufo: "mdi:rocket" })).toBe("mdi:rocket");
+  });
+
+  it("custom fallback is used when neither override nor canonical map matches", () => {
+    expect(objectIcon("ufo", {}, "mdi:magnify")).toBe("mdi:magnify");
+  });
+
+  it("returns empty string for null/empty input", () => {
+    expect(objectIcon(null)).toBe("");
+    expect(objectIcon("")).toBe("");
+  });
+
+  it("each known filter has an icon entry", () => {
+    for (const f of AVAILABLE_OBJECT_FILTERS) {
+      expect(OBJECT_FILTER_ICONS[f]).toMatch(/^mdi:/);
+    }
+  });
+});
+
+describe("objectColor", () => {
+  it("returns the configured color for a filter", () => {
+    expect(objectColor("person", { person: "#ff0000" })).toBe("#ff0000");
+  });
+
+  it("returns currentColor when no color is configured", () => {
+    expect(objectColor("person", {})).toBe("currentColor");
+  });
+
+  it("returns currentColor for null filter", () => {
+    expect(objectColor(null, { person: "#ff0000" })).toBe("currentColor");
+  });
+});
+
+describe("itemFilenameForFilter", () => {
+  it("lower-cases a string input", () => {
+    expect(itemFilenameForFilter("CAMERA_2024.JPG")).toBe("camera_2024.jpg");
+  });
+
+  it("prefers `filename` field on items", () => {
+    expect(itemFilenameForFilter({ filename: "Front.MP4", path: "ignored" })).toBe("front.mp4");
+  });
+
+  it("falls through to `name`, then `basename`, …", () => {
+    expect(itemFilenameForFilter({ name: "Top.jpg" })).toBe("top.jpg");
+    expect(itemFilenameForFilter({ basename: "X" })).toBe("x");
+  });
+
+  it("returns empty string for nullish input", () => {
+    expect(itemFilenameForFilter(null)).toBe("");
+    expect(itemFilenameForFilter(undefined)).toBe("");
+  });
+
+  it("returns empty string when no field is set", () => {
+    expect(itemFilenameForFilter({})).toBe("");
+  });
+});
+
+describe("sensorTextForFilter", () => {
+  it("combines entity_id and friendly_name (lower-cased)", () => {
+    const state = {
+      entity_id: "sensor.kitchen",
+      state: "on",
+      attributes: { friendly_name: "Kitchen Camera" },
+      last_changed: "",
+      last_updated: "",
+      context: { id: "", parent_id: null, user_id: null },
+    };
+    expect(sensorTextForFilter("sensor.kitchen", state)).toBe("sensor.kitchen kitchen camera");
+  });
+
+  it("falls back to `name` when no friendly_name", () => {
+    const state = {
+      entity_id: "sensor.x",
+      state: "on",
+      attributes: { name: "Garage" },
+      last_changed: "",
+      last_updated: "",
+      context: { id: "", parent_id: null, user_id: null },
+    };
+    expect(sensorTextForFilter("sensor.x", state)).toBe("sensor.x garage");
+  });
+
+  it("returns just the entity_id when no state", () => {
+    expect(sensorTextForFilter("sensor.x", null)).toBe("sensor.x");
+  });
+});
+
+describe("matchesObjectFilterForFileSensor", () => {
+  const state = {
+    entity_id: "sensor.front_door",
+    state: "on",
+    attributes: { friendly_name: "Front Doorbell" },
+    last_changed: "",
+    last_updated: "",
+    context: { id: "", parent_id: null, user_id: null },
+  };
+
+  it("matches an alias in the filename", () => {
+    expect(
+      matchesObjectFilterForFileSensor(
+        "snapshots/2024/persoon-event.jpg",
+        "person",
+        "sensor.front_door",
+        state
+      )
+    ).toBe(true);
+  });
+
+  it("matches an alias in the sensor friendly name", () => {
+    const fileSrc = "events/snapshot.jpg";
+    expect(
+      matchesObjectFilterForFileSensor(fileSrc, "visitor", "sensor.bell", {
+        ...state,
+        attributes: { friendly_name: "Bezoeker camera" },
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when no alias matches", () => {
+    expect(matchesObjectFilterForFileSensor("snapshots/cat.jpg", "person", "sensor.x", state)).toBe(
+      false
+    );
+  });
+
+  it("unknown filter falls through as 'no match'", () => {
+    // Single-element alias list with the unknown filter name; very unlikely
+    // to appear in either filename or sensor text.
+    expect(matchesObjectFilterForFileSensor("snapshots/cat.jpg", "ufo", "sensor.x", state)).toBe(
+      false
+    );
+  });
+
+  it("empty filter passes through as `true`", () => {
+    expect(matchesObjectFilterForFileSensor("snapshots/cat.jpg", "", "sensor.x", state)).toBe(true);
+  });
+});

--- a/src/data/object-filters.ts
+++ b/src/data/object-filters.ts
@@ -1,0 +1,189 @@
+/**
+ * Pure helpers for the object-filter pipeline (per-item label, icon, color
+ * lookup; filename/sensor text extraction; per-filter alias matching).
+ *
+ * State-coupled methods on the card (toggling `_objectFilters`,
+ * cache-aware `_objectForSrc`, mode-branching `_matchesObjectFilterValue`)
+ * stay there — they read live card state. The card calls into these pure
+ * helpers for the leaf-level transforms.
+ */
+
+import { AVAILABLE_OBJECT_FILTERS, type ObjectFilter } from "../const";
+import type { HassEntity } from "../types/hass";
+
+/** Default icon when the filter name isn't in `OBJECT_FILTER_ICONS`. */
+export const DEFAULT_OBJECT_ICON = "mdi:shape";
+
+/** Default color when no per-filter color is configured. Matches CSS `currentColor`. */
+const DEFAULT_OBJECT_COLOR = "currentColor";
+
+/**
+ * Per-filter MDI icons. Keyed by `ObjectFilter` so adding a new filter to
+ * `AVAILABLE_OBJECT_FILTERS` forces an icon entry — TypeScript catches it.
+ */
+export const OBJECT_FILTER_ICONS: Readonly<Record<ObjectFilter, string>> = {
+  bicycle: "mdi:bicycle",
+  bird: "mdi:bird",
+  bus: "mdi:bus",
+  car: "mdi:car",
+  cat: "mdi:cat",
+  dog: "mdi:dog",
+  motorcycle: "mdi:motorbike",
+  person: "mdi:account",
+  truck: "mdi:truck",
+  visitor: "mdi:doorbell-video",
+};
+
+/**
+ * Per-filter alias lists, including English + Dutch tokens (the original
+ * card author writes Dutch). Used to match filter intent in filenames and
+ * sensor friendly names. A filter not in this map falls back to its own
+ * canonical name as a single alias.
+ *
+ * **Invariant:** every alias here is already lowercase and trimmed.
+ * `matchesObjectFilterForFileSensor` relies on this — it does not re-normalize
+ * per-match. The structural test in `object-filters.spec.ts` enforces it.
+ */
+export const FILTER_ALIASES: Readonly<Record<ObjectFilter, readonly string[]>> = {
+  bicycle: ["bicycle", "fiets", "fietser", "bike"],
+  bird: ["bird", "vogel", "vogels"],
+  bus: ["bus"],
+  car: ["car", "auto", "autos", "voertuig", "vehicle"],
+  cat: ["cat", "kat", "katten"],
+  dog: ["dog", "hond", "honden"],
+  motorcycle: ["motorcycle", "motor", "motorbike"],
+  person: ["person", "persoon", "personen"],
+  truck: ["truck", "vrachtwagen"],
+  visitor: ["visitor", "visitors", "bezoeker", "bezoekers", "bezoek"],
+};
+
+/** Set form of `AVAILABLE_OBJECT_FILTERS` for O(1) membership checks. */
+export const KNOWN_FILTERS: ReadonlySet<string> = new Set(AVAILABLE_OBJECT_FILTERS);
+
+/** Narrow an arbitrary string to `ObjectFilter` if it matches one of the canonical names. */
+function asObjectFilter(s: string): ObjectFilter | null {
+  return KNOWN_FILTERS.has(s) ? (s as ObjectFilter) : null;
+}
+
+/**
+ * Display label for a filter. Returns the canonical filter name itself when
+ * it's known, otherwise `"selected"` (so the UI shows a generic count).
+ */
+export function filterLabel(value: string): string {
+  return asObjectFilter(value.toLowerCase().trim()) ?? "selected";
+}
+
+/**
+ * Comma-joined display label for a list of filters. Returns `"selected"`
+ * when the list is empty.
+ */
+export function filterLabelList(values: readonly string[]): string {
+  const labels = values.map((x) => filterLabel(x)).filter((x) => x !== "selected");
+  return labels.length ? labels.join(", ") : "selected";
+}
+
+/**
+ * Aliases for a filter name. Unknown names produce a single-element list
+ * containing themselves (so user-defined custom filter names still work in
+ * the matcher), or an empty list for empty input.
+ */
+export function getFilterAliases(filter: string): readonly string[] {
+  const f = filter.toLowerCase().trim();
+  const known = asObjectFilter(f);
+  if (known) return FILTER_ALIASES[known];
+  return f ? [f] : [];
+}
+
+/**
+ * MDI icon for a filter name, with optional per-filter overrides (from the
+ * `object_filters: [{ name: icon }]` config entries) and an optional
+ * fallback when the name isn't in `OBJECT_FILTER_ICONS`.
+ */
+export function objectIcon(
+  obj: string | null,
+  customIcons: Readonly<Record<string, string>> = {},
+  fallback: string = DEFAULT_OBJECT_ICON
+): string {
+  if (!obj) return "";
+  const override = customIcons[obj];
+  if (override) return override;
+  const known = asObjectFilter(obj);
+  return known ? OBJECT_FILTER_ICONS[known] : fallback;
+}
+
+/**
+ * Per-filter colour from the config's `object_colors` map. Returns
+ * `currentColor` when no colour is configured for the filter.
+ */
+export function objectColor(obj: string | null, colors: Readonly<Record<string, string>>): string {
+  if (!obj) return DEFAULT_OBJECT_COLOR;
+  return colors[obj] ?? DEFAULT_OBJECT_COLOR;
+}
+
+/** Common shape for `fileList` items + media-source items used by object filters. */
+export interface FilterableItem {
+  filename?: string;
+  name?: string;
+  basename?: string;
+  path?: string;
+  file?: string;
+  fullpath?: string;
+  src?: string;
+}
+
+/**
+ * Lower-cased filename-ish string for matching. Accepts either a raw URL/ID
+ * string or a `FilterableItem` shape; tries the most-specific field first.
+ */
+export function itemFilenameForFilter(input: string | FilterableItem | null | undefined): string {
+  if (!input) return "";
+  if (typeof input === "string") return input.toLowerCase();
+
+  const candidate =
+    input.filename ??
+    input.name ??
+    input.basename ??
+    input.path ??
+    input.file ??
+    input.fullpath ??
+    input.src ??
+    "";
+  return candidate.toLowerCase();
+}
+
+/**
+ * Lower-cased "what does this sensor look like" string — entity ID plus
+ * `friendly_name` (or `name`) attribute. Used by alias-based matching for
+ * sensor-source items.
+ */
+export function sensorTextForFilter(
+  sensorEntityId: string,
+  sensorState: HassEntity | null | undefined
+): string {
+  const attrs = sensorState?.attributes;
+  const friendly = typeof attrs?.["friendly_name"] === "string" ? attrs["friendly_name"] : "";
+  const name = typeof attrs?.["name"] === "string" ? attrs["name"] : "";
+  const label = (friendly || name).toLowerCase();
+  return `${sensorEntityId.toLowerCase()} ${label}`.trim();
+}
+
+/**
+ * True when *any* alias for the filter appears in either the item's
+ * filename-ish text or the sensor's friendly-name text. Empty alias lists
+ * pass-through as `true` (legacy behaviour: unknown filter doesn't filter
+ * anything out).
+ */
+export function matchesObjectFilterForFileSensor(
+  src: string | FilterableItem | null | undefined,
+  filter: string,
+  sensorEntityId: string,
+  sensorState: HassEntity | null | undefined = null
+): boolean {
+  const aliases = getFilterAliases(filter);
+  if (!aliases.length) return true;
+
+  const sensorText = sensorTextForFilter(sensorEntityId, sensorState);
+  const fileText = itemFilenameForFilter(src);
+
+  return aliases.some((alias) => sensorText.includes(alias) || fileText.includes(alias));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,18 @@ import {
   extractDayKey,
   uniqueDays,
 } from "./data/datetime-parsing";
+import { configDiff } from "./config/diff";
+import { migrateLegacyKeys, normalizeConfig } from "./config/normalize";
+import {
+  filterLabel,
+  filterLabelList,
+  getFilterAliases,
+  itemFilenameForFilter,
+  matchesObjectFilterForFileSensor,
+  objectColor,
+  objectIcon,
+  sensorTextForFilter,
+} from "./data/object-filters";
 import {
   FRIGATE_SNAPSHOTS_ROOT,
   FRIGATE_URI_PREFIX,
@@ -38,8 +50,8 @@ import {
   DEFAULT_BROWSE_TIMEOUT_MS,
   DEFAULT_CLEAN_MODE,
   DEFAULT_DELETE_CONFIRM,
-  DEFAULT_DELETE_PREFIX,
   DEFAULT_DELETE_SERVICE,
+  DELETE_PREFIX_NORMALIZED,
   DEFAULT_FRIGATE_API_LIMIT,
   DEFAULT_LIVE_AUTO_MUTED,
   DEFAULT_LIVE_ENABLED,
@@ -494,7 +506,7 @@ class CameraGalleryCard extends LitElement {
       (x) => this._matchesObjectFilter(x.src) && this._matchesTypeFilter(x.src)
     );
 
-    const cap = this._normMaxMedia(this.config?.max_media);
+    const cap = (this.config?.max_media ?? DEFAULT_MAX_MEDIA);
     const filtered = filteredAll.slice(0, Math.min(cap, filteredAll.length));
 
     if (!filtered.length) {
@@ -716,7 +728,7 @@ class CameraGalleryCard extends LitElement {
 
   _scheduleVisibleMediaWork(selected, filtered, idx, usingMediaSource) {
     const selectedSrc = String(selected || "");
-    const cap = this._normMaxMedia(this.config?.max_media);
+    const cap = (this.config?.max_media ?? DEFAULT_MAX_MEDIA);
     const thumbRenderLimit = this._getThumbRenderLimit(cap, usingMediaSource);
 
     const visibleThumbIds = usingMediaSource
@@ -787,27 +799,6 @@ class CameraGalleryCard extends LitElement {
     });
   }
 
-  _normalizeEntityFilterMap(mapObj) {
-    const out = {};
-    const allowed = new Set(
-      AVAILABLE_OBJECT_FILTERS.map((x) => String(x).toLowerCase())
-    );
-
-    if (!mapObj || typeof mapObj !== "object" || Array.isArray(mapObj)) {
-      return out;
-    }
-
-    for (const [entityId, rawFilter] of Object.entries(mapObj)) {
-      const e = String(entityId || "").trim();
-      const f = String(rawFilter || "").toLowerCase().trim();
-
-      if (!e || !f || !allowed.has(f)) continue;
-      out[e] = f;
-    }
-
-    return out;
-  }
-
   _getAllLiveCameraEntities() {
     const states = this._hass?.states || {};
     const allowed = this.config?.live_camera_entities;
@@ -830,14 +821,6 @@ class CameraGalleryCard extends LitElement {
         const bn = this._friendlyCameraName(b).toLowerCase();
         return an.localeCompare(bn, resolveLocale(this._hass));
       });
-  }
-
-  _configChangedKeys(prev = {}, next = {}) {
-    const keys = new Set([
-      ...Object.keys(prev || {}),
-      ...Object.keys(next || {}),
-    ]);
-    return Array.from(keys).filter((k) => !this._jsonEq(prev?.[k], next?.[k]));
   }
 
   _thumbCanMultipleDelete() {
@@ -1003,148 +986,8 @@ class CameraGalleryCard extends LitElement {
     return this._hasLiveConfig() && this._viewMode === "live";
   }
 
-  _isSourceConfigChange(keys = []) {
-    const sourceKeys = new Set([
-      "allow_bulk_delete",
-      "allow_delete",
-      "delete_confirm",
-      "delete_service",
-      "entities",
-      "entity",
-      "frigate_url",
-      "max_media",
-      "media_source",
-      "media_sources",
-      "source_mode",
-      "thumbnail_frame_pct",
-    ]);
-
-    return keys.some((k) => sourceKeys.has(k));
-  }
-
-  _isUiOnlyConfigChange(keys = []) {
-    if (!keys.length) return false;
-
-    const uiOnlyKeys = new Set([
-      "bar_opacity",
-      "bar_position",
-      "live_camera_entity",
-      "live_cameras",
-      "live_default_camera",
-      "live_enabled",
-      "object_filters",
-      "clean_mode",
-      "preview_close_on_tap",
-      "preview_position",
-      "pill_size",
-      "thumb_bar_position",
-      "thumb_layout",
-      "thumb_size",
-      "show_camera_title",
-      "controls_mode",
-    ]);
-
-    return keys.every((k) => uiOnlyKeys.has(k));
-  }
-
-  _normMaxMedia(v) {
-    const n = Number(String(v ?? "").trim());
-    if (!Number.isFinite(n)) return DEFAULT_MAX_MEDIA;
-    return Math.max(1, Math.min(500, Math.round(n)));
-  }
-
-  _normPrefixHardcoded() {
-    const lead = DEFAULT_DELETE_PREFIX.startsWith("/")
-      ? DEFAULT_DELETE_PREFIX
-      : "/" + DEFAULT_DELETE_PREFIX;
-    const noMulti = lead.replace(/\/{2,}/g, "/");
-    return noMulti.endsWith("/") ? noMulti : noMulti + "/";
-  }
-
-  _normPreviewPosition(v) {
-    const s = String(v || "").toLowerCase().trim();
-    return s === "bottom" ? "bottom" : "top";
-  }
-
-  _normSourceMode(v) {
-    const s = String(v || "").toLowerCase().trim();
-    return s === "media" ? "media" : s === "combined" ? "combined" : "sensor";
-  }
-
-  _normThumbBarPosition(v) {
-    const s = String(v || "").toLowerCase().trim();
-    if (s === "hidden") return "hidden";
-    if (s === "top") return "top";
-    return "bottom";
-  }
-
-  _normThumbLayout(v) {
-    const s = String(v || "").toLowerCase().trim();
-    return s === "vertical" ? "vertical" : "horizontal";
-  }
-
-  _normalizeVisibleObjectFilters(listOrSingle) {
-      const arr = Array.isArray(listOrSingle) ? listOrSingle : (listOrSingle ? [listOrSingle] : []);
-      const out = [];
-      const seen = new Set();
-      this._customIcons = {}; // Tijdelijke opslag voor custom icons
-
-      for (const item of arr) {
-        let name = "";
-        let icon = "";
-
-        if (typeof item === "string") {
-          name = item.toLowerCase().trim();
-        } else if (typeof item === "object" && item !== null) {
-          // Voor de syntax: - pakket: mdi:package
-          const entries = Object.entries(item);
-          if (entries.length > 0) {
-            name = entries[0][0].toLowerCase().trim();
-            icon = entries[0][1];
-          }
-        }
-
-        if (!name || seen.has(name)) continue;
-        seen.add(name);
-        out.push(name);
-        if (icon) this._customIcons[name] = icon; // Sla het icon op
-        
-        if (out.length >= MAX_VISIBLE_OBJECT_FILTERS) break;
-      }
-      return out;
-    }
-
   _sensorEntityList() {
-    const arr = Array.isArray(this.config?.entities) ? this.config.entities : [];
-    const clean = arr.map((x) => String(x || "").trim()).filter(Boolean);
-    if (clean.length) return clean;
-
-    const single = String(this.config?.entity || "").trim();
-    return single ? [single] : [];
-  }
-
-  _sensorNormalizeEntities(listOrSingle, fallbackSingle = "") {
-    const arr = Array.isArray(listOrSingle)
-      ? listOrSingle
-      : listOrSingle
-        ? [listOrSingle]
-        : fallbackSingle
-          ? [fallbackSingle]
-          : [];
-
-    const out = [];
-    const seen = new Set();
-
-    for (const raw of arr) {
-      const v = String(raw ?? "").trim();
-      if (!v) continue;
-      const k = v.toLowerCase();
-      if (seen.has(k)) continue;
-      seen.add(k);
-      out.push(v);
-    }
-
-    return out;
+    return Array.isArray(this.config?.entities) ? this.config.entities : [];
   }
 
   _serviceParts() {
@@ -2311,7 +2154,7 @@ class CameraGalleryCard extends LitElement {
     if (!sp) return;
 
     const fsPath = this._toFsPath(src);
-    const prefix = this._normPrefixHardcoded();
+    const prefix = DELETE_PREFIX_NORMALIZED;
 
     if (!fsPath || !fsPath.startsWith(prefix)) return;
 
@@ -2394,78 +2237,6 @@ class CameraGalleryCard extends LitElement {
     return "";
   }
 
-  _getFilterAliases(filter) {
-    const f = String(filter || "").toLowerCase().trim();
-    if (!f) return [];
-
-    const map = {
-      person: ["person", "persoon", "personen"],
-      visitor: ["visitor", "visitors", "bezoeker", "bezoekers", "bezoek"],
-      dog: ["dog", "hond", "honden"],
-      cat: ["cat", "kat", "katten"],
-      car: ["car", "auto", "autos", "voertuig", "vehicle"],
-      truck: ["truck", "vrachtwagen"],
-      bicycle: ["bicycle", "fiets", "fietser", "bike"],
-      motorcycle: ["motorcycle", "motor", "motorbike"],
-      bird: ["bird", "vogel", "vogels"],
-      bus: ["bus"],
-    };
-
-    return map[f] || [f];
-  }
-
-  _itemFilenameForFilter(itemOrSrc) {
-    if (!itemOrSrc) return "";
-
-    if (typeof itemOrSrc === "string") {
-      return String(itemOrSrc).toLowerCase();
-    }
-
-    return String(
-      itemOrSrc.filename ||
-      itemOrSrc.name ||
-      itemOrSrc.basename ||
-      itemOrSrc.path ||
-      itemOrSrc.file ||
-      itemOrSrc.fullpath ||
-      itemOrSrc.src ||
-      ""
-    ).toLowerCase();
-  }
-
-  _sensorTextForFilter(sensorEntityId, sensorStateObj = null) {
-    const entityId = String(sensorEntityId || "").toLowerCase();
-    const friendly = String(
-      sensorStateObj?.attributes?.friendly_name ||
-      sensorStateObj?.attributes?.name ||
-      ""
-    ).toLowerCase();
-
-    return `${entityId} ${friendly}`.trim();
-  }
-
-  _matchesObjectFilterForFileSensor(
-    srcOrItem,
-    filter,
-    sensorEntityId,
-    sensorStateObj = null
-  ) {
-    const aliases = this._getFilterAliases(filter);
-    if (!aliases.length) return true;
-
-    const sensorText = this._sensorTextForFilter(
-      sensorEntityId,
-      sensorStateObj
-    );
-    const fileText = this._itemFilenameForFilter(srcOrItem);
-
-    return aliases.some((alias) => {
-      const a = String(alias || "").toLowerCase().trim();
-      if (!a) return false;
-
-      return sensorText.includes(a) || fileText.includes(a);
-    });
-  }
 
   _findMatchingSnapshotMediaId(videoId) {
     const src = String(videoId || "").trim();
@@ -2597,13 +2368,22 @@ class CameraGalleryCard extends LitElement {
       return "";
     }
 
-    // Skip poster-capture for the selected video — it's already loading as preview;
-    // double-loading the same MS URL blocks autoplay.
+    // Skip poster-capture for the URL that's currently loading as the preview —
+    // double-loading the same MS URL blocks autoplay on some browsers, and the
+    // preview's `canplay` handler in `_ensurePreviewVideoHostPlayback` enqueues
+    // the poster once the preview itself has the data.
+    //
+    // In live mode the preview shows the live feed instead of the selected
+    // video, so that handler never fires for `selectedUrl` — the selected
+    // thumb would stay blank until the user leaves live mode. Treat the
+    // "preview owns this URL's poster" exemption as not applying in live mode.
+    const previewOwnsSelectedPoster = !this._isLiveActive();
     for (const url of [tThumb, thumbUrl]) {
       if (!url) continue;
       const cached = this._posterCache.get(url);
       if (cached) return cached;
-      if (url !== selectedUrl) this._enqueuePoster(url);
+      const skipForPreview = previewOwnsSelectedPoster && url === selectedUrl;
+      if (!skipForPreview) this._enqueuePoster(url);
       return "";
     }
     return "";
@@ -2680,8 +2460,8 @@ class CameraGalleryCard extends LitElement {
 
   _favKey() {
     const id = [
-      ...(this.config?.entities ?? (this.config?.entity ? [this.config.entity] : [])),
-      ...(this.config?.media_sources ?? (this.config?.media_source ? [this.config.media_source] : [])),
+      ...(this.config?.entities ?? []),
+      ...(this.config?.media_sources ?? []),
     ].sort().join("|");
     return "cgc_favs_" + this._thumbHash(id);
   }
@@ -2835,17 +2615,15 @@ class CameraGalleryCard extends LitElement {
   }
 
   async _msEnsureLoaded() {
-    const roots =
-      Array.isArray(this.config?.media_sources) &&
-      this.config.media_sources.length
-        ? this._msNormalizeRoots(this.config.media_sources)
-        : this._msNormalizeRoots(this.config?.media_source);
+    const roots = Array.isArray(this.config?.media_sources)
+      ? this.config.media_sources
+      : [];
 
     if (!roots.length) return;
 
     // === FRIGATE HTTP API PATH ===
     if (this.config?.frigate_url && roots.some(isFrigateRoot) && !this._ms.frigateApiFailed) {
-      const cap = this._normMaxMedia(this.config?.max_media);
+      const cap = (this.config?.max_media ?? DEFAULT_MAX_MEDIA);
       const key = `frigate_api:${this.config.frigate_url}:${cap}`;
       const sameKey = this._ms.key === key;
       const fresh = sameKey && Date.now() - (this._ms.loadedAt || 0) < 30_000;
@@ -2922,7 +2700,7 @@ class CameraGalleryCard extends LitElement {
     this._ms.loading = true;
 
     try {
-      const visibleCap = this._normMaxMedia(this.config?.max_media);
+      const visibleCap = (this.config?.max_media ?? DEFAULT_MAX_MEDIA);
 
       const internalCap = Math.min(2000, Math.max(visibleCap * 4, 400));
 
@@ -3067,7 +2845,7 @@ class CameraGalleryCard extends LitElement {
 
     const limit = Math.min(
       DEFAULT_FRIGATE_API_LIMIT,
-      Math.max(this._normMaxMedia(this.config?.max_media) * 2, 100)
+      Math.max((this.config?.max_media ?? DEFAULT_MAX_MEDIA) * 2, 100)
     );
 
     // Direct fetch — requires Frigate to allow CORS from the HA origin.
@@ -3128,12 +2906,8 @@ class CameraGalleryCard extends LitElement {
     return false;
   }
 
-  _msKeyFromRoots(rootsArr, fallbackSingle) {
-    const roots =
-      Array.isArray(rootsArr) && rootsArr.length
-        ? this._msNormalizeRoots(rootsArr)
-        : this._msNormalizeRoots(fallbackSingle);
-
+  _msKeyFromRoots(rootsArr) {
+    const roots = Array.isArray(rootsArr) ? rootsArr : [];
     if (!roots.length) return "";
     return roots
       .slice()
@@ -3192,55 +2966,6 @@ class CameraGalleryCard extends LitElement {
     const it = this._ms?.listIndex?.get(id);
     if (!it) return { cls: "", mime: "", title: "", thumb: "" };
     return { cls: it.cls || "", mime: it.mime || "", title: it.title || "", thumb: it.thumb || "" };
-  }
-
-  _msNormalizeRoot(raw) {
-    let v = String(raw || "").trim();
-    if (!v) return "";
-
-    const strip = (s) =>
-      String(s || "").replace(/^\/+/, "").replace(/\/+$/, "");
-
-    if (v.startsWith("media-source://")) {
-      let rest = v
-        .slice("media-source://".length)
-        .replace(/\/{2,}/g, "/")
-        .replace(/\/+$/g, "");
-      if (rest.startsWith("local/")) rest = `media_source/${rest}`;
-      return `media-source://${rest}`;
-    }
-
-    v = strip(v);
-
-    if (/^frigate(\/|$)/i.test(v)) {
-      const rest = strip(v.replace(/^frigate/i, ""));
-      return rest ? `${FRIGATE_URI_PREFIX}/${rest}` : FRIGATE_URI_PREFIX;
-    }
-
-    v = v.replace(/^media\//, "");
-    return `media-source://media_source/${v}`;
-  }
-
-  _msNormalizeRoots(listOrSingle) {
-    const arr = Array.isArray(listOrSingle)
-      ? listOrSingle
-      : listOrSingle
-        ? [listOrSingle]
-        : [];
-
-    const out = [];
-    const seen = new Set();
-
-    for (const raw of arr) {
-      const n = this._msNormalizeRoot(raw);
-      if (!n) continue;
-      const k = String(n).toLowerCase();
-      if (seen.has(k)) continue;
-      seen.add(k);
-      out.push(n);
-    }
-
-    return out;
   }
 
   _msQueueResolve(ids) {
@@ -3660,32 +3385,6 @@ class CameraGalleryCard extends LitElement {
       : [];
   }
 
-  _filterLabel(v) {
-    const s = String(v || "").toLowerCase();
-    if (s === "bicycle") return "bicycle";
-    if (s === "bird") return "bird";
-    if (s === "bus") return "bus";
-    if (s === "car") return "car";
-    if (s === "cat") return "cat";
-    if (s === "dog") return "dog";
-    if (s === "motorcycle") return "motorcycle";
-    if (s === "person") return "person";
-    if (s === "truck") return "truck";
-    if (s === "visitor") return "visitor";
-    return "selected";
-  }
-
-  _filterLabelList(values) {
-    const arr = Array.isArray(values)
-      ? values
-          .map((x) => String(x || "").toLowerCase().trim())
-          .filter(Boolean)
-      : [];
-
-    if (!arr.length) return "selected";
-    return arr.map((v) => this._filterLabel(v)).join(", ");
-  }
-
   _isObjectFilterActive(value) {
     const v = String(value || "").toLowerCase().trim();
     return this._activeObjectFilters().includes(v);
@@ -3726,7 +3425,7 @@ class CameraGalleryCard extends LitElement {
         : null;
 
       return active.some((filter) =>
-        this._matchesObjectFilterForFileSensor(
+        matchesObjectFilterForFileSensor(
           src,
           filter,
           sourceEntity,
@@ -3737,14 +3436,6 @@ class CameraGalleryCard extends LitElement {
 
     const obj = this._objectForSrc(src);
     return !!obj && active.includes(obj);
-  }
-
-  _objectColor(obj) {
-    const colors = this.config?.object_colors;
-    if (obj && colors && typeof colors === "object" && colors[obj]) {
-      return colors[obj];
-    }
-    return "currentColor";
   }
 
   _objectForSrc(src) {
@@ -3760,7 +3451,7 @@ class CameraGalleryCard extends LitElement {
       if (this.config?.source_mode === "sensor") {
         const sourceEntity = this._srcEntityMap?.get(src) || "";
         const sensorStateObj = sourceEntity ? this._hass?.states?.[sourceEntity] : null;
-        sourceText = [this._itemFilenameForFilter(src), this._sensorTextForFilter(sourceEntity, sensorStateObj)].join(" ");
+        sourceText = [itemFilenameForFilter(src), sensorTextForFilter(sourceEntity, sensorStateObj)].join(" ");
       } else {
         const meta = this._msMetaById(src);
         sourceText = [meta?.title, src].join(" ");
@@ -3768,7 +3459,7 @@ class CameraGalleryCard extends LitElement {
       sourceText = sourceText.toLowerCase();
 
       for (const filter of activeFilters) {
-        const aliases = this._getFilterAliases(filter);
+        const aliases = getFilterAliases(filter);
         if (aliases.some(alias => sourceText.includes(alias))) {
           detected = filter;
           break;
@@ -3779,28 +3470,6 @@ class CameraGalleryCard extends LitElement {
       return detected;
     }
 
-  _objectIcon(obj) {
-      if (!obj) return "";
-      
-      if (this._customIcons && this._customIcons[obj]) {
-        return this._customIcons[obj];
-      }
-
-      const icons = {
-        bicycle: "mdi:bicycle",
-        bird: "mdi:bird",
-        bus: "mdi:bus",
-        car: "mdi:car",
-        cat: "mdi:cat",
-        dog: "mdi:dog",
-        motorcycle: "mdi:motorbike",
-        person: "mdi:account",
-        truck: "mdi:truck",
-        visitor: "mdi:doorbell-video",
-      };
-
-      return icons[obj] || "mdi:magnify"; 
-    }
 
   _setObjectFilter(next) {
     const clicked = String(next || "").toLowerCase().trim();
@@ -3915,7 +3584,7 @@ class CameraGalleryCard extends LitElement {
     const sp = this._serviceParts();
     if (!sp) return;
 
-    const prefix = this._normPrefixHardcoded();
+    const prefix = DELETE_PREFIX_NORMALIZED;
     const srcs = Array.from(selectedSrcList || []);
     if (!srcs.length) return;
 
@@ -4123,313 +3792,15 @@ class CameraGalleryCard extends LitElement {
   setConfig(config) {
     const prevConfig = this.config ? { ...this.config } : null;
 
-    const autoplay =
-      config.autoplay !== undefined
-        ? !!config.autoplay
-        : DEFAULT_AUTOPLAY;
-
-    const auto_muted =
-      config.auto_muted !== undefined
-        ? !!config.auto_muted
-        : DEFAULT_AUTOMUTED;
-
-    const live_auto_muted =
-      config.live_auto_muted !== undefined
-        ? !!config.live_auto_muted
-        : DEFAULT_LIVE_AUTO_MUTED;
-
-    const filename_datetime_format = String(
-      config.filename_datetime_format || ""
-    ).trim();
-
-    const folder_datetime_format = String(
-      config.folder_datetime_format || ""
-    ).trim();
-
-    const clamp = (n, a, b) => Math.min(b, Math.max(a, n));
-    const num = (v, d) => {
-      if (v === null || v === undefined) return d;
-      const n = Number(String(v).trim().replace("px", "").replace("%", ""));
-      return Number.isFinite(n) ? n : d;
-    };
-
-    const posRaw = String(config.bar_position ?? "top").toLowerCase().trim();
-    const bar_position =
-      posRaw === "bottom" ? "bottom" : posRaw === "hidden" ? "hidden" : "top";
-
-    const thumb_size = Math.max(
-      40,
-      Math.min(220, num(config.thumb_size, THUMB_SIZE))
-    );
-
-    const thumb_bar_position = this._normThumbBarPosition(
-      config.thumb_bar_position ?? DEFAULT_THUMB_BAR_POSITION
-    );
-
-    const thumb_layout = this._normThumbLayout(
-      config.thumb_layout ?? DEFAULT_THUMB_LAYOUT
-    );
-
-    const bar_opacity = clamp(
-      num(config.bar_opacity, DEFAULT_BAR_OPACITY),
-      0,
-      100
-    );
-
-    const thumbnail_frame_pct = Math.round(
-      clamp(num(config.thumbnail_frame_pct, DEFAULT_THUMBNAIL_FRAME_PCT), 0, 100)
-    );
-
-    const max_media = this._normMaxMedia(config.max_media ?? DEFAULT_MAX_MEDIA);
-
-    let source_mode = this._normSourceMode(
-      config.source_mode ?? DEFAULT_SOURCE_MODE
-    );
-
-    const preview_position = this._normPreviewPosition(
-      config.preview_position ?? DEFAULT_PREVIEW_POSITION
-    );
-
-    const entityRaw = String(config?.entity || "").trim();
-    const sensorEntitiesClean = this._sensorNormalizeEntities(
-      config?.entities,
-      entityRaw
-    );
-
-    const mediaRaw = String(config?.media_source || "").trim();
-    const mediaArrRaw = Array.isArray(config?.media_sources)
-      ? config.media_sources
-      : Array.isArray(config?.media_folders_fav)
-        ? config.media_folders_fav
-        : null;
-
-    const mediaSourcesClean = Array.isArray(mediaArrRaw)
-      ? mediaArrRaw.map((x) => String(x ?? "").trim()).filter(Boolean)
-      : [];
-
-    const visibleObjectFilters = this._normalizeVisibleObjectFilters(
-      config.object_filters ?? DEFAULT_VISIBLE_OBJECT_FILTERS
-    );
-
-    const entity_filter_map = this._normalizeEntityFilterMap(
-      config.entity_filter_map || {}
-    );
-
-    if (
-      config.source_mode === undefined ||
-      config.source_mode === null ||
-      String(config.source_mode).trim() === ""
-    ) {
-      if ((mediaSourcesClean.length || mediaRaw) && !sensorEntitiesClean.length) {
-        source_mode = "media";
-      } else {
-        source_mode = "sensor";
-      }
-    }
-
-    if (source_mode === "sensor") {
-      if (!sensorEntitiesClean.length) {
-        throw new Error(
-          "camera-gallery-card: 'entity' or 'entities' is required in source_mode: sensor"
-        );
-      }
-    } else if (source_mode === "combined") {
-      if (!sensorEntitiesClean.length) {
-        throw new Error(
-          "camera-gallery-card: 'entity' or 'entities' is required in source_mode: combined"
-        );
-      }
-      if (!mediaRaw && !mediaSourcesClean.length) {
-        throw new Error(
-          "camera-gallery-card: 'media_source' or 'media_sources' is required in source_mode: combined"
-        );
-      }
-    } else if (!mediaRaw && !mediaSourcesClean.length) {
-        throw new Error(
-          "camera-gallery-card: 'media_source' OR 'media_sources' is required in source_mode: media"
-      );
-    }
-
-    if (
-      !folder_datetime_format &&
-      !filename_datetime_format &&
-      !hasFrigateConfig({
-        frigate_url: config.frigate_url,
-        media_source: mediaRaw,
-        media_sources: mediaSourcesClean,
-      })
-    ) {
-      throw new Error(
-        "camera-gallery-card: 'folder_datetime_format' or 'filename_datetime_format' is required so files can be grouped by date"
-      );
-    }
-
-    const allow_delete =
-      config.allow_delete !== undefined
-        ? !!config.allow_delete
-        : DEFAULT_ALLOW_DELETE;
-
-    const allow_bulk_delete =
-      config.allow_bulk_delete !== undefined
-        ? !!config.allow_bulk_delete
-        : DEFAULT_ALLOW_BULK_DELETE;
-
-    const delete_service =
-      (config.delete_service && String(config.delete_service).trim()) ||
-      (config.shell_command && String(config.shell_command).trim()) ||
-      DEFAULT_DELETE_SERVICE;
-
-    const delete_confirm =
-      config.delete_confirm !== undefined
-        ? !!config.delete_confirm
-        : DEFAULT_DELETE_CONFIRM;
-
-    const wantsDelete = (source_mode === "sensor" || source_mode === "combined") && allow_delete;
-
-    let effectiveAllowDelete = allow_delete;
-    let effectiveAllowBulkDelete = allow_bulk_delete;
-    let effectiveDeleteService = delete_service;
-
-    if (wantsDelete && !delete_service) {
-      effectiveAllowBulkDelete = false;
-      effectiveAllowDelete = false;
-    }
-
-    // Delete only works when items map to filesystem paths — media-source
-    // URIs (Frigate, network shares, etc.) can't be deleted by the shell
-    // command, so clear delete-related keys in pure media mode.
-    if (source_mode === "media") {
-      effectiveAllowDelete = false;
-      effectiveAllowBulkDelete = false;
-      effectiveDeleteService = "";
-    }
-
-    if (effectiveDeleteService && !/^[a-z0-9_]+\.[a-z0-9_]+$/i.test(effectiveDeleteService)) {
-      throw new Error(
-        "camera-gallery-card: 'delete_service' must be 'domain.service'"
-      );
-    }
-
-    const clean_mode = config.clean_mode !== undefined
-      ? !!config.clean_mode
-      : (config.preview_click_to_open !== undefined ? !!config.preview_click_to_open : DEFAULT_CLEAN_MODE);
-
-    const preview_close_on_tap =
-      config.preview_close_on_tap !== undefined
-        ? !!config.preview_close_on_tap
-        : clean_mode
-          ? DEFAULT_PREVIEW_CLOSE_ON_TAP_WHEN_GATED
-          : false;
-
-    const normalizedMediaRoots =
-      (source_mode === "media" || source_mode === "combined")
-        ? this._msNormalizeRoots(
-            mediaSourcesClean.length ? mediaSourcesClean : mediaRaw
-          )
-        : [];
-
-    const live_enabled =
-      config.live_enabled !== undefined
-        ? !!config.live_enabled
-        : DEFAULT_LIVE_ENABLED;
-
-    const live_camera_entity = String(config.live_camera_entity || "").trim();
-    const live_stream_url = String(config.live_stream_url || "").trim();
-    const live_stream_name = String(config.live_stream_name || "").trim();
-    const live_go2rtc_url = String(config.live_go2rtc_url || "").trim();
-    const frigate_url = String(config.frigate_url || "").trim().replace(/\/+$/, "");
-    const live_stream_urls = Array.isArray(config.live_stream_urls)
-      ? config.live_stream_urls
-          .filter(e => e && typeof e === "object" && String(e.url || "").trim())
-          .map(e => ({ url: String(e.url).trim(), name: String(e.name || "").trim() || null }))
-      : [];
-
-    const live_camera_entities = Array.isArray(config.live_camera_entities)
-      ? config.live_camera_entities.map(String).map((s) => s.trim()).filter(Boolean)
-      : [];
-
-    const style_variables = String(config.style_variables || "").trim();
-
-    const object_fit = config.object_fit === "contain" ? "contain" : "cover";
-
-    const pill_size = Math.max(10, Math.min(28, num(config.pill_size, 14)));
-
-    const nextConfig = {
-      autoplay,
-      auto_muted,
-      live_auto_muted,
-      allow_bulk_delete: effectiveAllowBulkDelete,
-      allow_delete: effectiveAllowDelete,
-      bar_opacity,
-      bar_position,
-      delete_confirm,
-      delete_service: effectiveDeleteService || "",
-      entities: (source_mode === "sensor" || source_mode === "combined") ? sensorEntitiesClean : [],
-      entity: (source_mode === "sensor" || source_mode === "combined") ? sensorEntitiesClean[0] || "" : "",
-      entity_filter_map,
-      filename_datetime_format,
-      live_camera_entities,
-      live_camera_entity,
-      live_enabled,
-      live_stream_url: live_stream_url || null,
-      live_stream_name: live_stream_name || null,
-      live_stream_urls: live_stream_urls.length > 0 ? live_stream_urls : null,
-      live_go2rtc_url: live_go2rtc_url || null,
-      frigate_url: frigate_url || null,
-      max_media,
-      media_source: (source_mode === "media" || source_mode === "combined") ? mediaRaw : "",
-      media_sources: (source_mode === "media" || source_mode === "combined") ? normalizedMediaRoots : [],
-      object_colors: (typeof config.object_colors === "object" && config.object_colors !== null) ? config.object_colors : {},
-      object_filters: visibleObjectFilters,
-      clean_mode,
-      preview_close_on_tap,
-      preview_position,
-      aspect_ratio: ["16:9", "4:3", "1:1"].includes(config.aspect_ratio) ? config.aspect_ratio : "16:9",
-      source_mode,
-      start_mode: config.start_mode === "live" ? "live" : "gallery",
-      style_variables,
-      object_fit,
-      persistent_controls: config.persistent_controls === true,
-      pill_size,
-      thumb_bar_position,
-      thumb_layout,
-      thumb_size,
-      thumbnail_frame_pct,
-      live_go2rtc_stream: String(config.live_go2rtc_stream || "").trim() || null,
-      folder_datetime_format: folder_datetime_format || null,
-      sync_entity: String(config.sync_entity || "").trim() || null,
-      menu_buttons: Array.isArray(config.menu_buttons)
-        ? config.menu_buttons
-            .filter(b => b && typeof b === "object" && b.entity && b.icon)
-            .map(b => ({
-              entity: String(b.entity).trim(),
-              icon: String(b.icon).trim(),
-              icon_on: b.icon_on ? String(b.icon_on).trim() : undefined,
-              color_on: b.color_on ? String(b.color_on).trim() : undefined,
-              color_off: b.color_off ? String(b.color_off).trim() : undefined,
-              title: b.title ? String(b.title).trim() : undefined,
-              service: b.service ? String(b.service).trim() : undefined,
-              state_on: b.state_on ? String(b.state_on).trim() : undefined,
-            }))
-        : [],
-      show_camera_title: config.show_camera_title !== false,
-      controls_mode: ["overlay","fixed"].includes(config.controls_mode)
-        ? config.controls_mode : "overlay",
-    };
+    const { config: nextConfig, customIcons } = normalizeConfig(config);
 
     this.config = nextConfig;
+    this._customIcons = customIcons;
     this._loadFavorites();
     this._startMediaPoll();
 
-    const changedKeys = prevConfig
-      ? this._configChangedKeys(prevConfig, nextConfig)
-      : [];
-    const sourceChange = prevConfig
-      ? this._isSourceConfigChange(changedKeys)
-      : true;
-    const uiOnlyChange = prevConfig
-      ? this._isUiOnlyConfigChange(changedKeys)
-      : false;
+    const { changedKeys, isSourceChange: sourceChange, isUiOnly: uiOnlyChange } =
+      configDiff(prevConfig, nextConfig);
 
     if (this._selectedIndex === undefined) this._selectedIndex = 0;
     if (this._selectedSet == null) this._selectedSet = new Set();
@@ -4440,7 +3811,12 @@ class CameraGalleryCard extends LitElement {
     const visibleSet = new Set(this._getVisibleObjectFilters());
     this._objectFilters = this._objectFilters.filter((x) => visibleSet.has(x));
 
-    const liveEntityChanged = !prevConfig || prevConfig.live_camera_entity !== live_camera_entity || prevConfig.live_stream_url !== config.live_stream_url || JSON.stringify(prevConfig.live_stream_urls) !== JSON.stringify(nextConfig.live_stream_urls);
+    const liveEntityChanged =
+      !prevConfig ||
+      prevConfig.live_camera_entity !== nextConfig.live_camera_entity ||
+      prevConfig.live_stream_url !== nextConfig.live_stream_url ||
+      JSON.stringify(prevConfig.live_stream_urls) !==
+        JSON.stringify(nextConfig.live_stream_urls);
     if (liveEntityChanged) {
       const liveOptions = this._getLiveCameraOptions();
       const validSelected =
@@ -4448,12 +3824,12 @@ class CameraGalleryCard extends LitElement {
         liveOptions.some((x) => x === this._liveSelectedCamera);
       if (!validSelected && liveOptions.length > 0) {
         this._liveSelectedCamera =
-          (live_camera_entity
-            ? live_camera_entity
+          (nextConfig.live_camera_entity
+            ? nextConfig.live_camera_entity
             : liveOptions[0]) || "";
       }
       if (prevConfig) {
-        this._aspectRatio = this._parseAspectRatio(config.aspect_ratio);
+        this._aspectRatio = this._parseAspectRatio(nextConfig.aspect_ratio);
       }
     }
 
@@ -4461,7 +3837,7 @@ class CameraGalleryCard extends LitElement {
       this._previewOpen = this.config.clean_mode ? false : true;
       this._showLivePicker = false;
       this._showLiveQuickSwitch = false;
-      this._aspectRatio = this._parseAspectRatio(config.aspect_ratio);
+      this._aspectRatio = this._parseAspectRatio(nextConfig.aspect_ratio);
       const hasMedia = nextConfig.entities.length > 0 || nextConfig.media_sources.length > 0;
       const startMode = nextConfig.start_mode;
       if (startMode === "live" && nextConfig.live_enabled && nextConfig.live_camera_entity) {
@@ -4520,15 +3896,9 @@ class CameraGalleryCard extends LitElement {
 
     if (this.config.source_mode === "media" || this.config.source_mode === "combined") {
       const prevKey = prevConfig
-        ? this._msKeyFromRoots(
-            prevConfig?.media_sources,
-            prevConfig?.media_source
-          )
+        ? this._msKeyFromRoots(prevConfig.media_sources)
         : "";
-      const nextKey = this._msKeyFromRoots(
-        this.config?.media_sources,
-        this.config?.media_source
-      );
+      const nextKey = this._msKeyFromRoots(this.config.media_sources);
 
       if (!prevConfig || (sourceChange && prevKey !== nextKey)) {
         this._ms.key = "";
@@ -4611,7 +3981,7 @@ class CameraGalleryCard extends LitElement {
         this._matchesObjectFilter(x.src)
       );
 
-      const cap = this._normMaxMedia(this.config?.max_media);
+      const cap = (this.config?.max_media ?? DEFAULT_MAX_MEDIA);
       const filtered = filteredAll.slice(0, Math.min(cap, filteredAll.length));
       const thumbRenderLimit = this._getThumbRenderLimit(cap, usingMediaSource);
 
@@ -4749,7 +4119,7 @@ class CameraGalleryCard extends LitElement {
 
     const noResultsForFilter = !filteredAll.length;
 
-    const cap = this._normMaxMedia(this.config?.max_media);
+    const cap = (this.config?.max_media ?? DEFAULT_MAX_MEDIA);
     const filtered = noResultsForFilter
       ? []
       : filteredAll.slice(0, Math.min(cap, filteredAll.length));
@@ -4864,7 +4234,7 @@ class CameraGalleryCard extends LitElement {
       <div class="gallery-pills-center">
         ${(() => {
           const obj = this._objectForSrc(selected);
-          const icon = obj ? this._objectIcon(obj) : null;
+          const icon = obj ? objectIcon(obj, this._customIcons, "mdi:magnify") : null;
           if (!icon) return html``;
           return html`<div class="gallery-pill live-pill-btn" style="flex-shrink:0;width:calc(var(--cgc-pill-size,14px)*1.6 + 2px);height:calc(var(--cgc-pill-size,14px)*1.6 + 2px);padding:0"><ha-icon icon="${icon}"></ha-icon></div>`;
         })()}
@@ -5043,9 +4413,9 @@ class CameraGalleryCard extends LitElement {
       ? html`
           <div class="objfilters" role="group" aria-label="Object filters">
             ${visibleObjectFilters.map((filterValue) => {
-              const objIcon = this._objectIcon(filterValue);
-              const label = this._filterLabel(filterValue);
-              const objColor = this._objectColor(filterValue);
+              const objIcon = objectIcon(filterValue, this._customIcons, "mdi:magnify");
+              const label = filterLabel(filterValue);
+              const objColor = objectColor(filterValue, this.config?.object_colors ?? {});
               return html`
                 <button
                   class="objbtn icon-only ${this._isObjectFilterActive(filterValue)
@@ -5172,8 +4542,8 @@ class CameraGalleryCard extends LitElement {
                       : "";
 
                     const obj = this._objectForSrc(it.src);
-                    const objIcon = this._objectIcon(obj);
-                    const objColor = this._objectColor(obj);
+                    const objIcon = objectIcon(obj, this._customIcons, "mdi:magnify");
+                    const objColor = objectColor(obj, this.config?.object_colors ?? {});
 
                     const tBarLeft = tTime;
 
@@ -5185,7 +4555,7 @@ class CameraGalleryCard extends LitElement {
 
                     return html`
                       <button
-                        class="tthumb ${isOn ? "on" : ""} ${this._selectMode && isSel ? "sel" : ""}"
+                        class="tthumb ${isOn ? "on" : ""} ${this._selectMode && isSel ? "sel" : ""} bar-${barPos}"
                         data-i="${it.i}"
                         data-lazy-src="${it.src}"
                         style="${thumbStyle}"
@@ -5284,7 +4654,7 @@ class CameraGalleryCard extends LitElement {
                           @click=${(e) => { e.stopPropagation(); this._toggleFavorite(it.src); }}
                           @pointerdown=${(e) => e.stopPropagation()}
                           role="button"
-                          title="Favoriet"
+                          title="Favorite"
                         >
                           <ha-icon icon="${this._favorites.has(it.src) ? 'mdi:star' : 'mdi:star-outline'}"></ha-icon>
                         </div>
@@ -5298,7 +4668,7 @@ class CameraGalleryCard extends LitElement {
                   <div class="thumbs-empty-state">
                     ${this._filterFavorites
                       ? "No favorites for this day."
-                      : `No ${this._filterLabelList(this._objectFilters)} media for this day.`}
+                      : `No ${filterLabelList(this._objectFilters)} media for this day.`}
                   </div>
                 `
               : html``}
@@ -5368,7 +4738,7 @@ class CameraGalleryCard extends LitElement {
               ` : html``}
 
               <div class="seg">
-                <button class="segbtn ${this._filterFavorites ? "on" : ""}" @click=${() => this._toggleFilterFavorites()} title="Favorieten" style="border-radius:10px">
+                <button class="segbtn ${this._filterFavorites ? "on" : ""}" @click=${() => this._toggleFilterFavorites()} title="Favorites" style="border-radius:10px">
                   <ha-icon icon="mdi:star" style="--mdc-icon-size:16px"></ha-icon>
                 </button>
               </div>
@@ -6726,6 +6096,15 @@ class CameraGalleryCard extends LitElement {
         justify-content: center;
         transition: color 0.15s ease;
         filter: drop-shadow(0 1px 2px rgba(0,0,0,0.6));
+        z-index: 3;
+      }
+
+      /* Bar at the bottom would overlay the default bottom-left favorite
+         button (the bar has an opaque blur background). Move the button to
+         the top-left corner in that case so it stays visible. */
+      .tthumb.bar-bottom .fav-btn {
+        top: 4px;
+        bottom: auto;
       }
 
       .fav-btn.on {
@@ -7824,22 +7203,6 @@ class CameraGalleryCardEditor extends HTMLElement {
     const n = Number(v);
     if (!Number.isFinite(n)) return fallback;
     return Math.round(n);
-  }
-
-  _objectIcon(v) {
-    const map = {
-      bicycle: "mdi:bicycle",
-      bird: "mdi:bird",
-      bus: "mdi:bus",
-      car: "mdi:car",
-      cat: "mdi:cat",
-      dog: "mdi:dog",
-      motorcycle: "mdi:motorbike",
-      person: "mdi:account",
-      truck: "mdi:truck",
-      visitor: "mdi:doorbell-video",
-    };
-    return map[v] || "mdi:shape";
   }
 
   _objectLabel(v) {
@@ -9101,7 +8464,7 @@ class CameraGalleryCardEditor extends HTMLElement {
                         title="${this._objectLabel(obj)}"
                       >
                         <span class="objchip-icon" ${currentColor ? `style="color:${currentColor}"` : ""}>
-                          ${svgIcon(this._objectIcon(obj), 18)}
+                          ${svgIcon(objectIcon(obj), 18)}
                         </span>
                         <span class="objchip-color">
                           <input type="color" class="cgc-color" value="${colorVal}" style="${!currentColor ? "opacity:0.35" : ""}" data-filtercolor="${obj}">
@@ -11981,121 +11344,50 @@ if (oldPanel && tmp.firstElementChild) {
   }
 
   setConfig(config) {
-    this._config = this._stripAlwaysTrueKeys({ ...(config || {}) });
+    // Run shared legacy-key migration so the saved YAML uses canonical keys.
+    // The editor preserves the loose `object_filters` shape (string-or-object
+    // entries) so user icon choices survive a YAML save round-trip — full
+    // normalization happens on the card side.
+    const { migrated, hadLegacyKeys } = migrateLegacyKeys(config || {});
 
-    if (typeof this._config.autoplay === "undefined") {
-      this._config.autoplay = DEFAULT_AUTOPLAY;
+    // Defaults the editor reads at render time. These don't propagate back to
+    // YAML on their own — only legacy-key migrations trigger `_fire()`.
+    if (typeof migrated.autoplay === "undefined") {
+      migrated.autoplay = DEFAULT_AUTOPLAY;
+    }
+    if (typeof migrated.auto_muted === "undefined") {
+      migrated.auto_muted = DEFAULT_AUTOMUTED;
+    }
+    if (typeof migrated.live_auto_muted === "undefined") {
+      migrated.live_auto_muted = DEFAULT_LIVE_AUTO_MUTED;
     }
 
-    if (typeof this._config.auto_muted === "undefined") {
-      this._config.auto_muted = DEFAULT_AUTOMUTED;
-    }
-
-    if (typeof this._config.live_auto_muted === "undefined") {
-      this._config.live_auto_muted = DEFAULT_LIVE_AUTO_MUTED;
-    }
-
-    if ("shell_command" in this._config) {
-      const next = { ...this._config };
-      delete next.shell_command;
-      this._config = next;
-    }
-
-    try {
-      const cfg = { ...(config || {}) };
-
-      const normArr = (arr) =>
-        (arr || [])
-          .map(String)
-          .map((s) => s.trim())
-          .filter(Boolean);
-
-      const entArr = Array.isArray(cfg.entities) ? cfg.entities : null;
-      const singleEntity = String(cfg.entity || "").trim();
-
-      const pickedEntities =
-        (entArr && normArr(entArr)) || (singleEntity ? [singleEntity] : []);
-
-      const hasEntities =
-        Array.isArray(this._config.entities) && this._config.entities.length;
-
-      if (
-        !hasEntities &&
-        pickedEntities.length &&
-        ("entity" in cfg || singleEntity)
-      ) {
-        const next = { ...this._config, entities: pickedEntities };
-        delete next.entity;
-        this._config = this._stripAlwaysTrueKeys(next);
-        this._fire();
-      }
-
-      const msArr = Array.isArray(cfg.media_sources) ? cfg.media_sources : null;
-      const favArr = Array.isArray(cfg.media_folders_fav)
-        ? cfg.media_folders_fav
-        : null;
-      const single = String(cfg.media_source || "").trim();
-
-      const pickedMedia =
-        (msArr && normArr(msArr)) ||
-        (favArr && normArr(favArr)) ||
-        (single ? [single] : []);
-
-      const hasMediaSources =
-        Array.isArray(this._config.media_sources) &&
-        this._config.media_sources.length;
-
-      const hasLegacyMedia =
-        "media_folder_favorites" in cfg ||
-        "media_folders_fav" in cfg ||
-        "media_source" in cfg;
-
-      if (
-        !hasMediaSources &&
-        pickedMedia.length &&
-        (hasLegacyMedia || single)
-      ) {
-        const next = { ...this._config, media_sources: pickedMedia };
-        delete next.media_folder_favorites;
-        delete next.media_folders_fav;
-        delete next.media_source;
-        this._config = this._stripAlwaysTrueKeys(next);
-        this._fire();
-      }
-
-      const rawObjectFilters = Array.isArray(cfg.object_filters)
-        ? cfg.object_filters
-        : String(cfg.object_filters || "").trim()
-          ? [cfg.object_filters]
+    // De-dup `object_filters` while preserving the original entry form
+    // (string OR `{name: icon}` object). Editor needs the icon-bearing form
+    // to round-trip user icon choices through YAML.
+    let objectFiltersChanged = false;
+    if ("object_filters" in migrated) {
+      const before = Array.isArray(migrated.object_filters)
+        ? migrated.object_filters
+        : migrated.object_filters
+          ? [migrated.object_filters]
           : [];
-
-      const normObjectFilters = this._normalizeObjectFilters(rawObjectFilters);
-      const currentObjectFilters = Array.isArray(this._config.object_filters)
-        ? this._normalizeObjectFilters(this._config.object_filters)
-        : [];
-
-      if (
-        JSON.stringify(normObjectFilters) !==
-        JSON.stringify(currentObjectFilters)
-      ) {
-        const next = { ...this._config };
-        if (normObjectFilters.length) next.object_filters = normObjectFilters;
-        else delete next.object_filters;
-        this._config = this._stripAlwaysTrueKeys(next);
-        this._fire();
+      const deduped = this._normalizeObjectFilters(before);
+      if (JSON.stringify(deduped) !== JSON.stringify(migrated.object_filters)) {
+        objectFiltersChanged = true;
       }
-
-      const thumbLayout = String(cfg.thumb_layout || "").toLowerCase().trim();
-      if (thumbLayout === "horizontal" || thumbLayout === "vertical") {
-        if (this._config.thumb_layout !== thumbLayout) {
-          this._config = this._stripAlwaysTrueKeys({
-            ...this._config,
-            thumb_layout: thumbLayout,
-          });
-          this._fire();
-        }
+      if (deduped.length) {
+        migrated.object_filters = deduped;
+      } else {
+        delete migrated.object_filters;
       }
-    } catch (_) {}
+    }
+
+    this._config = this._stripAlwaysTrueKeys(migrated);
+
+    if (hadLegacyKeys || objectFiltersChanged) {
+      this._fire();
+    }
 
     this._scheduleRender();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10249,17 +10249,7 @@ if (oldPanel && tmp.firstElementChild) {
 
     this.shadowRoot.querySelectorAll("[data-src]").forEach((btn) => {
       btn.addEventListener("click", () => {
-        const next = btn.dataset.src;
-        if (next === "media") {
-          const cleaned = { ...this._config };
-          delete cleaned.delete_service;
-          delete cleaned.shell_command;
-          delete cleaned.allow_delete;
-          delete cleaned.allow_bulk_delete;
-          delete cleaned.delete_confirm;
-          this._config = this._stripAlwaysTrueKeys(cleaned);
-        }
-        this._set("source_mode", next);
+        this._set("source_mode", btn.dataset.src);
       });
     });
 

--- a/src/util/frigate.spec.ts
+++ b/src/util/frigate.spec.ts
@@ -90,8 +90,8 @@ describe("hasFrigateConfig", () => {
     expect(hasFrigateConfig({ frigate_url: "http://frigate.local:5000" })).toBe(true);
   });
 
-  it("is true when media_source is a Frigate root", () => {
-    expect(hasFrigateConfig({ media_source: FRIGATE_URI_PREFIX })).toBe(true);
+  it("is true when the sole media_sources entry is a Frigate root", () => {
+    expect(hasFrigateConfig({ media_sources: [FRIGATE_URI_PREFIX] })).toBe(true);
   });
 
   it("is true when any media_sources entry is a Frigate root", () => {
@@ -108,7 +108,7 @@ describe("hasFrigateConfig", () => {
   it("is false for non-Frigate media sources only", () => {
     expect(
       hasFrigateConfig({
-        media_source: "media-source://media_source/local/cameras",
+        media_sources: ["media-source://media_source/local/cameras"],
       })
     ).toBe(false);
   });
@@ -124,7 +124,7 @@ describe("hasFrigateConfig", () => {
   it("does NOT match the loose 'frigate' substring elsewhere", () => {
     expect(
       hasFrigateConfig({
-        media_source: "media-source://media_source/local/my-frigate-backup/",
+        media_sources: ["media-source://media_source/local/my-frigate-backup/"],
       })
     ).toBe(false);
   });

--- a/src/util/frigate.ts
+++ b/src/util/frigate.ts
@@ -36,15 +36,11 @@ export function isFrigateRoot(uri: string | null | undefined): boolean {
  * fields are optional in Frigate-only setups.
  */
 export function hasFrigateConfig(config: {
-  frigate_url?: string | null;
-  media_source?: string | null;
-  media_sources?: readonly string[] | null;
+  frigate_url?: string | null | undefined;
+  media_sources?: readonly string[] | null | undefined;
 }): boolean {
-  if (String(config?.frigate_url ?? "").trim()) return true;
-  const roots: string[] = [
-    ...(Array.isArray(config?.media_sources) ? config.media_sources : []),
-    String(config?.media_source ?? ""),
-  ];
+  if ((config.frigate_url ?? "").trim()) return true;
+  const roots = config.media_sources ?? [];
   return roots.some(isFrigateRoot);
 }
 


### PR DESCRIPTION
@TheScubaDiver — heads-up on a sizable PR. The bulk is internal refactoring (no behaviour change), but there are three small bug fixes and two intentional behaviour corrections worth a careful look. **Please verify your own card configurations still load and render correctly** — especially around object filters, the favorite button, and live mode in `media`/`combined` source modes.

## Why this PR

`src/index.js` was a 12k-line monolith with a hand-rolled `setConfig` validator that silently coerced bad input. PR #36 set up the build/CI pipeline; PR #53 added typing baselines and `superstruct`/`custom-card-helpers` deps. This PR is the next major modularization step:

1. **Typed config + superstruct validation** — replaces the bespoke `_norm*` helpers and the legacy-key migration logic in both `setConfig` methods (card + editor) with a single typed pipeline.
2. **Object-filter helpers extracted** — the pure side of the cluster moves to `src/data/object-filters.ts` with typed `Record<ObjectFilter, …>` constants for icons and aliases.
3. **Three bug fixes I found while in this code area** — see below.

`src/index.js` shrinks by **~900 lines** (12,434 → ~11,540). Bundle delta: **+1.9 kB minified** (322,079 → 323,985 bytes), within the ±2 kB target — the new module weight is mostly offset by the deleted `_norm*` methods and a deduplicated icon map between card and editor.

## What changed

### New modules

| File | Purpose |
|------|---------|
| `src/config/structs.ts` | Superstruct validators for the canonical `CameraGalleryCardConfig` shape. Numeric ranges, enums, and nested-object refinements. Top-level uses `type()` (loose) so legacy/unknown keys don't trip validation; nested objects (live_stream_urls, menu_buttons) stay strict so typos are visible. |
| `src/config/normalize.ts` | `normalizeConfig(raw)` (card) + `migrateLegacyKeys(raw)` (shared with editor) + pure helpers. The `InputConfig` interface models the loose YAML shape; `unknown` only appears at the public boundary. |
| `src/config/diff.ts` | `configDiff(prev, next): { changedKeys, isSourceChange, isUiOnly }` replaces the three `_isXChange` methods on the card. |
| `src/data/object-filters.ts` | Pure helpers: `filterLabel`, `filterLabelList`, `getFilterAliases`, `itemFilenameForFilter`, `sensorTextForFilter`, `matchesObjectFilterForFileSensor`, `objectIcon`, `objectColor`. Plus typed `OBJECT_FILTER_ICONS` and `FILTER_ALIASES` constants keyed by `ObjectFilter` so adding a new filter without an icon entry is a TypeScript error. |
| Specs | 4 new spec files, 145 new tests. |

### Card class slimmed

Deleted from `CameraGalleryCard`: `_normMaxMedia`, `_normPrefixHardcoded`, `_normPreviewPosition`, `_normSourceMode`, `_normThumbBarPosition`, `_normThumbLayout`, `_normalizeVisibleObjectFilters`, `_normalizeEntityFilterMap`, `_configChangedKeys`, `_isSourceConfigChange`, `_isUiOnlyConfigChange`, `_sensorNormalizeEntities`, `_msNormalizeRoot`, `_msNormalizeRoots`, `_filterLabel`, `_filterLabelList`, `_getFilterAliases`, `_itemFilenameForFilter`, `_sensorTextForFilter`, `_matchesObjectFilterForFileSensor`, `_objectIcon`, `_objectColor`. Editor lost its duplicate `_objectIcon`.

Card `setConfig` shrunk from ~430 → ~110 lines; editor `setConfig` from ~120 → ~40 lines.

## Bug fixes

### 1. Selected thumbnail invisible while in live mode (`media` / `combined` source)

The selected gallery video's thumbnail was blank while the card showed live preview. As soon as you switched away from live, the thumbnail filled in.

**Root cause:** `_resolveVideoPoster` skips poster capture for `selectedUrl` because the preview's `canplay` handler in `_ensurePreviewVideoHostPlayback` enqueues it instead. But that handler is gated on `!_isLiveActive()` — in live mode the preview shows the live feed, the canplay handler never fires, the poster never enqueues. Fix: only honour the skip when the preview is actually loading the URL (i.e. not in live mode).

### 2. Favorite star button hidden when `thumb_bar_position: bottom`

The `.tbar` (thumbnail label bar) is positioned absolutely at the bottom of each thumb when the user picks `thumb_bar_position: bottom`, with an opaque blur background. It overlays the `.fav-btn` which sits at `bottom: 4px; left: 4px`. Fix: when the bar is at the bottom, the favorite button moves to top-left (`.tthumb.bar-bottom .fav-btn { top: 4px; bottom: auto }`).

### 3. Hardcoded Dutch tooltip strings

`title="Favoriet"` (per-thumb star) and `title="Favorieten"` (filter pill) were in Dutch — the rest of the UI is English. Translated to "Favorite" / "Favorites". A proper i18n pass (with `hass.localize` plumbing) is tracked as PR 15 in `plans/modularization.md`.

## Behaviour changes (not regressions, but worth flagging)

These were latent silent-failure paths that now produce clear errors. Users with malformed YAML will see error messages they didn't see before:

- **Out-of-range numerics now error.** `thumb_size: 30` (below 40) used to be silently clamped; now it throws `invalid config — thumb_size: must be a number between 40 and 220 (got 30)`. Same for `bar_opacity`, `pill_size`, `max_media`, `thumbnail_frame_pct`, plus enum fields (`aspect_ratio`, `controls_mode`, etc.).
- **Malformed `live_stream_urls` / `menu_buttons` entries now error.** Previously, a `live_stream_urls` entry without a `url` was silently dropped; now it throws.
- **`delete_service` invalid format now errors via the struct** (was a separate manual check before — same UX, just consolidated).

The fixes go in the card preview's red error block, not the editor pane (Lovelace's standard place for card config errors).

## How to test

I ran `npm run check` (typecheck + 177 tests + lint + format + build) green. The crucial smoke test is in HA — please walk through this with at least one of your real card configs.

### Tier 1 — must-pass

1. **Open every dashboard with an existing camera-gallery-card.** Card should render identically to before. No console errors, no red error overlay.
2. **Open the visual editor** on each card; cycle every tab (general, sensor/media, live, styling). Make a small change on each, save. Reload, reopen editor — change persisted, card preview re-renders cleanly.
3. **Drop these legacy YAMLs into a card via the Code editor and confirm they auto-migrate:**

```yaml
# Legacy `entity` (singular)
type: custom:camera-gallery-card
entity: sensor.your_filetrack_sensor
folder_datetime_format: '{YYYY}-{MM}-{DD}'
```
After save → reopen Code editor: should auto-rewrite to `entities: [...]`.

```yaml
# Legacy `media_source` (singular) and `media_folders_fav`
type: custom:camera-gallery-card
media_source: media-source://media_source/local/cameras
folder_datetime_format: '{YYYY}-{MM}-{DD}'
```
Auto-rewrites to `media_sources: [...]`.

```yaml
# Legacy `shell_command` and `preview_click_to_open`
type: custom:camera-gallery-card
entities: [sensor.foo]
shell_command: shell.delete_file
preview_click_to_open: true
folder_datetime_format: '{YYYY}-{MM}-{DD}'
```
Rewrites `shell_command` → `delete_service`, `preview_click_to_open` → `clean_mode`.

### Tier 2 — bug fixes

4. **Live-mode thumbnail fix.** Configure a card with `start_mode: live` and `source_mode: media` (or `combined`). The live feed should show in the preview, AND **every thumbnail in the strip should have a poster** — including the currently-selected one. Before this PR, the selected thumb was blank until you clicked away from live.

5. **Favorite button visibility fix.** Configure `thumb_bar_position: bottom`. The favorite-star button should be visible at the **top-left** of each thumb (it was previously hidden behind the bar). With `top` or `hidden`, the star stays at bottom-left as before.

6. **Hardcoded Dutch fix.** Hover the per-thumb favorite button — tooltip is now "Favorite" (was "Favoriet"). Hover the filter pill toolbar's favorites button — tooltip is now "Favorites" (was "Favorieten").

### Tier 3 — behaviour changes (verify intentional)

7. **Out-of-range YAML now errors.** Set `thumb_size: 30` (below the 40 minimum). Card preview shows: `invalid config — thumb_size: must be a number between 40 and 220 (got 30)`. Same for `aspect_ratio: 99:99`, `bar_opacity: 200`, `delete_service: not-a-service`. **Important:** if any of your existing configs had out-of-range values (clamped silently before), they will now show errors. Edit them to valid ranges.

8. **Custom icons round-trip.** Use `object_filters: [{ person: mdi:walk }]`. The pill should show mdi:walk for "person". Open the editor, save without changes, reopen Code editor — the `{ person: mdi:walk }` shape must still be there (icon survives YAML save).

### Tier 4 — feature parity (sanity)

9. All three source modes still work: sensor, media, combined.
10. Live mode: `start_mode: live`, mute, fullscreen, pinch-zoom, aspect-ratio cycle.
11. Favorites (#70) toggle persists across reload.
12. Same-stem pairing (#65/67) still pairs `event.jpg` + `event.mp4` correctly.
13. Frigate integration if you use it: snapshots resolve, REST API path works.

## Out of scope

These are tracked as future PRs in my local `plans/modularization.md`:
- Editor rewrite to `ha-form` schemas (PR 11) — biggest single quality win remaining; touches the ~3,300-line editor render.
- Localization / i18n (PR 15) — the card has zero `hass.localize` plumbing today; ~15-20 hardcoded English strings need to move into a locale file.
- Data-layer extractions: `src/data/{poster-cache, sensor-source, media-walker, pairing, favorites}.ts`.

## Diff summary

- **12 files changed**, +2,184 / -869
- **6 new files** (4 modules + 4 specs in `src/config/` and `src/data/`)
- **177 tests** (was 0 in pre-PR-3 days; was 32 after PR 3 + extras; PR adds 145 covering every audit fix and structural invariant)
- **Bundle:** 322,079 → 323,985 bytes minified (+1.9 kB; within ±2 kB target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)