### PR TITLE
ci: skip HACS validation on fork PRs

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -16,6 +16,15 @@ concurrency:
 
 jobs:
   validate:
+    # Skip on fork PRs: hacs/action validates the PR's head repo against the
+    # HACS plugin contract, which requires at least one published Release with
+    # the bundled asset. Forks rarely have releases (the bundle pipeline only
+    # runs upstream), so the check fails on every fork PR with a structural
+    # "not loaded properly in HACS" error that has nothing to do with the
+    # actual diff. Skipping it for fork PRs keeps the signal honest — the
+    # check still runs on push events (tags + main) and on PRs from upstream
+    # branches, which is where the structural validation actually matters.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Why

`hacs/action` validates the PR's head repo against the HACS plugin contract — including the "must have at least one published Release with the bundled asset" precondition. Forks rarely have releases because the release-please / `release.yml` pipeline only runs on upstream tags, so every fork PR fails the check with a generic structural error that has nothing to do with the actual diff.

I just opened #72 from a fork and tripped this — the failure log is just:

```
##[error] <Plugin ErikBavenstrand/camera-gallery-card> Repository structure for refactor/config-superstruct is not compliant
##[error] Repository ErikBavenstrand/camera-gallery-card not loaded properly in HACS.
```

The actual `hacs.json` shape and file layout are fine — HACS just can't find a release on the fork to load.

## What

One-line job-level `if:` on the `validate` job: skip when the event is a `pull_request` from a fork. The check still runs on:
- `push` events (release tags + branch pushes to upstream)
- `pull_request` events from branches on the upstream repo (where structural validation is what we want)
- `workflow_dispatch`

## Test plan

- [x] `if:` condition is syntactically valid (Actions parses it; no unsupported expressions).
- [x] After merge: trigger the workflow on this PR (a fork PR) — `validate` should report "Skipped".
- [x] After merge: re-run CI on #72 (also a fork PR) — `validate` skipped, the green checks unblock the merge.
- [ ] After merge: any future push to upstream `main` or any tag push still runs `validate`.

Once this is in, #72 should be unblocked.