### PR TITLE
ci: include major bumps in dependabot dev-tooling group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,13 @@ updates:
       prefix: chore
       include: scope
     groups:
-      # Bundle all dev-tooling minor + patch updates into a single weekly PR.
-      # Major bumps fall through to individual PRs so they get a closer look.
+      # Bundle all dev-tooling updates into a single weekly PR.
       # Production deps (lit) are not in this group, so they always get an
       # individual PR for careful review — they affect the shipped bundle.
       dev-tooling:
         dependency-type: development
         update-types:
+          - "major"
           - "minor"
           - "patch"
         patterns:


### PR DESCRIPTION
## Summary

Last Monday's dependabot run produced 4 individual major-bump PRs (`typescript` 5→6, `vitest` 2→4, `@vitest/coverage-v8` 2→4, `globals` 15→17) on top of the grouped minor PR for `eslint`. The `dev-tooling` group was set to `minor` + `patch` only, so majors fell through to individual PRs.

Adding `major` to the group's `update-types` so all dev-tooling updates land in a single weekly PR. Breaking changes still get reviewed — they're just bundled together instead of fragmenting the queue.

Production deps (`lit`) remain outside the group and continue to get individual PRs, since they affect the shipped bundle.

## Test plan

- [x] Merge, then verify next Monday's dependabot run opens a single combined PR
- [x] (Optional) Close the existing #75–#78 after merge so dependabot regroups them on the next cycle