### PR TITLE
fix: refresh media-poll when card becomes visible again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -242,6 +242,14 @@ class CameraGalleryCard extends LitElement {
       this.requestUpdate();
     };
 
+    // iOS WebView freezes JS (including setInterval) when the HA app is
+    // backgrounded. On resume, restart the media-poll so a fresh fetch fires
+    // immediately and the 30s timer is back on schedule.
+    this._onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      this._startMediaPoll();
+    };
+
     this._onZoomTouchStart = (e) => {
       if (!this._isLiveActive() && !this._previewOpen) return;
       if (e.touches.length === 2) {
@@ -377,6 +385,7 @@ class CameraGalleryCard extends LitElement {
     super.connectedCallback();
     document.addEventListener("fullscreenchange", this._onFullscreenChange);
     document.addEventListener("webkitfullscreenchange", this._onFullscreenChange);
+    document.addEventListener("visibilitychange", this._onVisibilityChange);
     this.addEventListener('touchstart', this._onZoomTouchStart, { passive: false });
     this.addEventListener('touchmove', this._onZoomTouchMove, { passive: false });
     this.addEventListener('touchend', this._onZoomTouchEnd);
@@ -394,6 +403,7 @@ class CameraGalleryCard extends LitElement {
 
     document.removeEventListener("fullscreenchange", this._onFullscreenChange);
     document.removeEventListener("webkitfullscreenchange", this._onFullscreenChange);
+    document.removeEventListener("visibilitychange", this._onVisibilityChange);
     this.removeEventListener('touchstart', this._onZoomTouchStart);
     this.removeEventListener('touchmove', this._onZoomTouchMove);
     this.removeEventListener('touchend', this._onZoomTouchEnd);


### PR DESCRIPTION
## Problem

iOS WKWebView freezes JavaScript (including `setInterval`) when the HA
companion app is backgrounded or the iPhone screen is locked. On resume the
polling timer doesn't reliably catch up, so the gallery shows stale clips
until the user taps somewhere to wake the queued events.

## Fix

Add a `visibilitychange` listener: when the document becomes visible again,
restart `_startMediaPoll` so a fresh fetch fires immediately and the 30s
timer is back on schedule.

This covers the realistic flow: open the app → see the latest Frigate clips
within ~1 second, no manual refresh needed.

## Notes on iOS limitations

When the app is in the foreground but the user doesn't interact for a long
time, iOS still throttles JS in the WebView — there's no JS-only fix for
that case. In practice it's a non-issue: opening the app *is* the
interaction, and a tap or scroll wakes any queued polls instantly.

## Changes

- `src/index.js` — `_onVisibilityChange` arrow function in the constructor;
  registered/unregistered in `connectedCallback` / `disconnectedCallback`
  (~10 lines net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)