### PR TITLE
feat: real-time Frigate event updates via Home Assistant WebSocket

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -176,6 +176,9 @@ class CameraGalleryCard extends LitElement {
     this._posterFailed = new Set();
     this._snapshotCache = new Map();
     this._frigateSnapshots = [];
+    // Unsubscribe callback for HA WS Frigate-event-push subscription.
+    // null = not subscribed, function = active subscription.
+    this._frigateEventsUnsub = null;
     this._objectCache = new Map();
     this._previewOpen = false;
     this._selectMode = false;
@@ -387,6 +390,10 @@ class CameraGalleryCard extends LitElement {
     window.addEventListener('mouseup', this._onZoomMouseUp);
     if (navigator.maxTouchPoints > 0) this._showPills(5000);
     this._startMediaPoll();
+    // Idempotent — if hass isn't set yet, returns early; the firstHass branch
+    // in `set hass` then catches it. Covers disconnect→reconnect cycles where
+    // _hass stays set but the previous subscription was torn down.
+    this._subscribeFrigateEvents();
   }
 
   disconnectedCallback() {
@@ -405,6 +412,7 @@ class CameraGalleryCard extends LitElement {
     if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
 
     this._stopMediaPoll();
+    this._unsubscribeFrigateEvents();
     if (this._liveQuickSwitchTimer) clearTimeout(this._liveQuickSwitchTimer);
     if (this._navHideT) clearTimeout(this._navHideT);
     if (this._bulkHintTimer) clearTimeout(this._bulkHintTimer);
@@ -436,6 +444,8 @@ class CameraGalleryCard extends LitElement {
       if (this.config?.start_mode === "live" && this._hasLiveConfig()) {
         this._viewMode = "live";
       }
+      // Fire-and-forget: subscribe to HA's Frigate event push stream.
+      this._subscribeFrigateEvents();
       this.requestUpdate();
       return;
     }
@@ -464,6 +474,82 @@ class CameraGalleryCard extends LitElement {
 
   get hass() {
     return this._hass;
+  }
+
+  // ─── Frigate WS event push ─────────────────────────────────────────
+  //
+  // Subscribe to HA's `frigate/events/subscribe` WS endpoint so new Frigate
+  // events arrive as push messages over the WebSocket connection HA already
+  // keeps alive. On any push we invalidate the freshness gate and trigger a
+  // refresh. Falls back silently when HA's Frigate integration isn't present.
+
+  _frigateInstanceId() {
+    // HA's Frigate integration uses a per-instance client_id. The second
+    // segment of a `media-source://frigate/<client_id>/…` URI is that id.
+    const sources = Array.isArray(this.config?.media_sources)
+      ? this.config.media_sources
+      : [];
+    for (const ms of sources) {
+      const m = String(ms || "").match(/^media-source:\/\/frigate\/([^/]+)/);
+      if (m) return m[1];
+    }
+    return null;
+  }
+
+  async _subscribeFrigateEvents() {
+    if (this._frigateEventsUnsub) return;
+    const conn = this._hass?.connection;
+    if (!conn) return;
+    const sm = this.config?.source_mode;
+    if (sm !== "media" && sm !== "combined") return;
+    const instanceId = this._frigateInstanceId();
+    if (!instanceId) return;
+    try {
+      this._frigateEventsUnsub = await conn.subscribeMessage(
+        (data) => this._onFrigateEventPush(data),
+        { type: "frigate/events/subscribe", instance_id: instanceId }
+      );
+    } catch (_) {
+      // Frigate integration not installed or HA version too old — fall through
+      // to existing polling behavior.
+      this._frigateEventsUnsub = null;
+    }
+  }
+
+  _unsubscribeFrigateEvents() {
+    if (this._frigateEventsUnsub) {
+      try { this._frigateEventsUnsub(); } catch (_) {}
+      this._frigateEventsUnsub = null;
+    }
+  }
+
+  _onFrigateEventPush(data) {
+    // Frigate pushes 'new' / 'update' / 'end' messages per event. Only refresh
+    // on 'end' — the clip is finalized then, and we avoid 3× walks per event.
+    let payload;
+    try {
+      payload = typeof data === "string" ? JSON.parse(data) : data;
+    } catch (_) {
+      return;
+    }
+    if (payload?.type !== "end") return;
+
+    if (this._ms) {
+      // Bypass freshness gate.
+      this._ms.loadedAt = 0;
+      // Bypass the persistent walk cache so we do a real media-source walk
+      // instead of replaying stale localStorage data.
+      try {
+        const roots = Array.isArray(this.config?.media_sources)
+          ? this.config.media_sources
+          : [];
+        if (roots.length) {
+          const cacheKey = this._msWalkCacheKey(this._msKeyFromRoots(roots));
+          localStorage.removeItem(cacheKey);
+        }
+      } catch (_) {}
+    }
+    this._msEnsureLoaded();
   }
 
   // ─── Generic helpers ───────────────────────────────────────────────


### PR DESCRIPTION
## What this changes

New Frigate clips now appear in the gallery automatically, within about a
second of being recorded. The card no longer has to poll for updates.

## Why

The previous approach polled Frigate every 30 seconds. That worked fine in
a desktop browser, but on iOS the Home Assistant app freezes JavaScript
timers when the app is backgrounded or idle, so new clips could be
invisible for minutes — sometimes until you tapped the screen to wake
things up.

This change uses a different mechanism: it asks Home Assistant to push
new Frigate events directly through the existing WebSocket connection.
iOS keeps that WebSocket alive natively, so pushes arrive reliably even
when the rest of the app is dozing.

## Who benefits

Anyone with Home Assistant's Frigate integration installed — that's the
default setup for most Frigate users. The card detects this automatically
from the `media_sources` config.

## Compatibility

Users without the Frigate HA integration are unaffected. The card silently
falls back to the previous polling behavior. No config changes needed.

## Known limits

- Push only fires for the first Frigate instance found in `media_sources`.
  Multi-instance setups still rely on polling for additional instances.
- Updates only fire when an event is fully recorded (the `end` MQTT type),
  so a 10-second clip appears 10 seconds after it starts.