### PR TITLE
fix: extract pairing helpers and favorites storage

### DIFF
--- a/src/data/favorites.spec.ts
+++ b/src/data/favorites.spec.ts
@@ -59,12 +59,12 @@ describe("favoritesKey", () => {
 
 describe("FavoritesStore", () => {
   let storage: MemoryStorage;
-  let onChange: ReturnType<typeof vi.fn>;
+  let onChange: ReturnType<typeof vi.fn<() => void>>;
   const config = { entities: ["sensor.cam"], media_sources: [] };
 
   beforeEach(() => {
     storage = new MemoryStorage();
-    onChange = vi.fn();
+    onChange = vi.fn<() => void>();
   });
 
   afterEach(() => {

--- a/src/data/favorites.spec.ts
+++ b/src/data/favorites.spec.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FavoritesStore, favoritesKey } from "./favorites";
+
+class MemoryStorage {
+  store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+class QuotaExceededStorage extends MemoryStorage {
+  override setItem(_key: string, _value: string): void {
+    const e = new Error("quota");
+    e.name = "QuotaExceededError";
+    throw e;
+  }
+}
+
+class ThrowingReadStorage extends MemoryStorage {
+  override getItem(_key: string): string | null {
+    throw new Error("read denied");
+  }
+}
+
+describe("favoritesKey", () => {
+  it("is deterministic for a given config (sorted)", () => {
+    const a = favoritesKey({ entities: ["sensor.b", "sensor.a"], media_sources: [] });
+    const b = favoritesKey({ entities: ["sensor.a", "sensor.b"], media_sources: [] });
+    expect(a).toBe(b);
+  });
+
+  it("treats undefined and empty arrays equivalently", () => {
+    expect(favoritesKey({})).toBe(favoritesKey({ entities: [], media_sources: [] }));
+  });
+
+  it("starts with the legacy `cgc_favs_cgc_p_` prefix (existing-user compat)", () => {
+    const k = favoritesKey({ entities: ["sensor.x"] });
+    expect(k.startsWith("cgc_favs_cgc_p_")).toBe(true);
+  });
+
+  it("differs when the entity set differs", () => {
+    expect(favoritesKey({ entities: ["sensor.a"] })).not.toBe(
+      favoritesKey({ entities: ["sensor.b"] })
+    );
+  });
+
+  it("locks legacy hash output for empty config", () => {
+    // Locked-in regression: existing users running an empty-entities
+    // config (no sensors yet, just default config) should keep their
+    // favorites across this refactor. The legacy key for empty input is
+    // `cgc_favs_cgc_p_ztntfp` (FNV-1a basis on "" → "ztntfp" base36).
+    expect(favoritesKey({})).toBe("cgc_favs_cgc_p_ztntfp");
+  });
+});
+
+describe("FavoritesStore", () => {
+  let storage: MemoryStorage;
+  let onChange: ReturnType<typeof vi.fn>;
+  const config = { entities: ["sensor.cam"], media_sources: [] };
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    onChange = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts empty before load()", () => {
+    const store = new FavoritesStore({ storage, onChange });
+    expect(store.size).toBe(0);
+    expect(store.has("anything")).toBe(false);
+  });
+
+  it("loads the persisted set from storage", () => {
+    const key = favoritesKey(config);
+    storage.setItem(key, JSON.stringify(["/a.mp4", "/b.mp4"]));
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    expect(store.size).toBe(2);
+    expect(store.has("/a.mp4")).toBe(true);
+    expect(store.has("/b.mp4")).toBe(true);
+  });
+
+  it("toggle() adds and persists the entry", () => {
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    store.toggle("/a.mp4");
+    expect(store.has("/a.mp4")).toBe(true);
+    expect(JSON.parse(storage.getItem(favoritesKey(config)) as string)).toEqual(["/a.mp4"]);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggle() removes and persists when entry already exists", () => {
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    store.toggle("/a.mp4");
+    store.toggle("/a.mp4");
+    expect(store.has("/a.mp4")).toBe(false);
+    expect(JSON.parse(storage.getItem(favoritesKey(config)) as string)).toEqual([]);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("load() recomputes the key when the config changes", () => {
+    const store = new FavoritesStore({ storage, onChange });
+    store.load({ entities: ["sensor.a"] });
+    store.toggle("/x.mp4");
+    expect(store.has("/x.mp4")).toBe(true);
+
+    store.load({ entities: ["sensor.b"] });
+    expect(store.has("/x.mp4")).toBe(false);
+  });
+
+  it("load() reverts to the original key when config swaps back", () => {
+    const store = new FavoritesStore({ storage, onChange });
+    store.load({ entities: ["sensor.a"] });
+    store.toggle("/x.mp4");
+
+    store.load({ entities: ["sensor.b"] });
+    expect(store.has("/x.mp4")).toBe(false);
+
+    store.load({ entities: ["sensor.a"] });
+    expect(store.has("/x.mp4")).toBe(true);
+  });
+
+  it("values() exposes a read-only iterator", () => {
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    store.toggle("/a.mp4");
+    store.toggle("/b.mp4");
+    expect([...store.values()].sort()).toEqual(["/a.mp4", "/b.mp4"]);
+  });
+
+  it("ignores corrupted JSON in storage and warns once", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const key = favoritesKey(config);
+    storage.setItem(key, "{not valid json");
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    expect(store.size).toBe(0);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("ignores non-array JSON shapes (defends against object→Set widening)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const key = favoritesKey(config);
+    storage.setItem(key, JSON.stringify({ accidentally: "an object" }));
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    expect(store.size).toBe(0);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("filters non-string elements out of the persisted array", () => {
+    const key = favoritesKey(config);
+    storage.setItem(key, JSON.stringify(["/a.mp4", 42, null, "/b.mp4"]));
+    const store = new FavoritesStore({ storage, onChange });
+    store.load(config);
+    expect(store.size).toBe(2);
+    expect(store.has("/a.mp4")).toBe(true);
+    expect(store.has("/b.mp4")).toBe(true);
+  });
+
+  it("survives a storage backend that throws on read", () => {
+    const throwing = new ThrowingReadStorage();
+    const store = new FavoritesStore({ storage: throwing, onChange });
+    store.load(config);
+    expect(store.size).toBe(0);
+  });
+
+  it("survives a storage backend that throws QuotaExceeded on write", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const quotaStorage = new QuotaExceededStorage();
+    const store = new FavoritesStore({ storage: quotaStorage, onChange });
+    store.load(config);
+    store.toggle("/a.mp4");
+    // The Set was mutated even though the persist failed — the UX
+    // contract is "favorite is on for this session".
+    expect(store.has("/a.mp4")).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledOnce();
+    // A second toggle that also fails should not log again — the warn-
+    // once latch keeps the console from spamming.
+    store.toggle("/b.mp4");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("works without a storage backend (in-memory only)", () => {
+    const store = new FavoritesStore({ storage: null, onChange });
+    store.load(config);
+    store.toggle("/a.mp4");
+    expect(store.has("/a.mp4")).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/data/favorites.ts
+++ b/src/data/favorites.ts
@@ -1,0 +1,180 @@
+/**
+ * Per-source favorites storage. Encapsulates the in-memory `Set<string>`,
+ * the localStorage I/O, and the config-derived storage key so the card
+ * doesn't have to touch any of it directly.
+ *
+ * The storage key is derived from the configured `entities` and
+ * `media_sources` — changing those swaps to a different key, which means
+ * favorites are scoped to a configuration, not global. Existing user data
+ * lives under `cgc_favs_<fnv1a-of-sorted-config-id>` (legacy `cgc_p_*`
+ * prefix preserved).
+ */
+
+import { fnv1aHash } from "../util/hash";
+
+const FAVORITES_KEY_PREFIX = "cgc_favs_";
+
+/** Subset of the card config that affects the favorites storage key. */
+export interface FavoritesKeyConfig {
+  entities?: readonly string[] | null;
+  media_sources?: readonly string[] | null;
+}
+
+/**
+ * Compute the storage key for a given config slice. Sorted + joined so two
+ * configs with the same entities/sources in different YAML orders share
+ * the same favorites.
+ */
+export function favoritesKey(config: FavoritesKeyConfig): string {
+  const entities = config.entities ?? [];
+  const mediaSources = config.media_sources ?? [];
+  const id = [...entities, ...mediaSources].sort().join("|");
+  // The legacy `_thumbHash` returned `"cgc_p_" + fnv1aHash(input)`, and the
+  // legacy `_favKey` then prefixed `"cgc_favs_"` on top — so the final key
+  // shape on disk is `cgc_favs_cgc_p_<hash>`. Preserve that exactly so
+  // existing users' favorites continue to resolve.
+  return `${FAVORITES_KEY_PREFIX}cgc_p_${fnv1aHash(id)}`;
+}
+
+/** Read-only minimal contract for the storage backend. */
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function defaultStorage(): StorageLike | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    // Some sandboxed contexts throw on the global `localStorage` access
+    // itself (Safari Private mode prior to 14, certain webview locks).
+    return null;
+  }
+}
+
+export interface FavoritesStoreOptions {
+  /** Fired after every successful mutation. The card wires this to `requestUpdate()`. */
+  onChange?: () => void;
+  /** Storage backend; injectable for tests. Defaults to `globalThis.localStorage`. */
+  storage?: StorageLike | null;
+}
+
+/**
+ * Stateful wrapper around the favorites Set + storage. The card owns one
+ * instance and treats it as a `Set`-like read surface (`has`, `size`,
+ * `values`); mutations go through `toggle()`, persistence through
+ * `load()` (called from `setConfig` after each normalize pass).
+ */
+export class FavoritesStore {
+  private _set: Set<string> = new Set();
+  private _key: string | null = null;
+  private readonly _onChange?: (() => void) | undefined;
+  private readonly _storage: StorageLike | null;
+  private _quotaWarned = false;
+
+  constructor(opts: FavoritesStoreOptions = {}) {
+    this._onChange = opts.onChange;
+    this._storage = opts.storage === undefined ? defaultStorage() : opts.storage;
+  }
+
+  /**
+   * Recompute the storage key from `config` and reload the in-memory Set
+   * from storage. Idempotent — safe to call after every `setConfig`.
+   */
+  load(config: FavoritesKeyConfig): void {
+    this._key = favoritesKey(config);
+    this._set = this._read(this._key);
+  }
+
+  has(src: string): boolean {
+    return this._set.has(src);
+  }
+
+  get size(): number {
+    return this._set.size;
+  }
+
+  values(): IterableIterator<string> {
+    return this._set.values();
+  }
+
+  /**
+   * Add or remove `src` from the favorites set, persist the change, and
+   * fire `onChange`. No-ops cleanly when storage isn't available.
+   */
+  toggle(src: string): void {
+    if (this._set.has(src)) this._set.delete(src);
+    else this._set.add(src);
+    this._write();
+    this._onChange?.();
+  }
+
+  private _read(key: string): Set<string> {
+    if (!this._storage) return new Set();
+    let raw: string | null;
+    try {
+      raw = this._storage.getItem(key);
+    } catch {
+      return new Set();
+    }
+    if (!raw) return new Set();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // Corrupted JSON — fall through to empty set without losing the
+      // existing entry on disk. The next successful `toggle()` will
+      // overwrite the bad value.
+      console.warn("[camera-gallery-card] favorites: ignoring corrupt JSON in localStorage");
+      return new Set();
+    }
+    if (!Array.isArray(parsed)) {
+      // Wrong shape (e.g. a hand-edited object). `new Set(iterable)` would
+      // happily consume an Object's keys and silently change the user's
+      // data — refuse instead.
+      console.warn("[camera-gallery-card] favorites: ignoring non-array JSON in localStorage");
+      return new Set();
+    }
+    return new Set(parsed.filter((x): x is string => typeof x === "string"));
+  }
+
+  private _write(): void {
+    if (!this._storage || !this._key) return;
+    let payload: string;
+    try {
+      payload = JSON.stringify([...this._set]);
+    } catch {
+      // JSON.stringify on Set spread can only fail on circular refs,
+      // which `string` values can't produce — so this is unreachable in
+      // practice. Defensive bail-out.
+      return;
+    }
+    try {
+      this._storage.setItem(this._key, payload);
+    } catch (e) {
+      if (isQuotaExceeded(e)) {
+        if (!this._quotaWarned) {
+          this._quotaWarned = true;
+          console.warn("[camera-gallery-card] favorites: localStorage quota exceeded");
+        }
+        return;
+      }
+      // Anything else (e.g. SecurityError when storage is disabled) —
+      // swallow but log; a hard throw here would tear down the click
+      // handler that called `toggle()`.
+      console.warn("[camera-gallery-card] favorites: localStorage write failed", e);
+    }
+  }
+}
+
+function isQuotaExceeded(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  // Browsers spell this differently: Chrome / Firefox use
+  // "QuotaExceededError"; legacy WebKit returns
+  // "NS_ERROR_DOM_QUOTA_REACHED" (Firefox legacy) or code 22 / 1014.
+  if (e.name === "QuotaExceededError" || e.name === "NS_ERROR_DOM_QUOTA_REACHED") {
+    return true;
+  }
+  const code = (e as unknown as { code?: unknown }).code;
+  return code === 22 || code === 1014;
+}

--- a/src/data/pairing.spec.ts
+++ b/src/data/pairing.spec.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dedupeByRelPath,
+  pairMediaSourceThumbnails,
+  pairSensorItems,
+  pairVideoThumbnails,
+} from "./pairing";
+
+describe("pairVideoThumbnails", () => {
+  it("returns empty result for null/undefined/empty input", () => {
+    expect(pairVideoThumbnails(null, (x: { id: string }) => x.id)).toEqual({
+      items: [],
+      pairedThumbs: new Map(),
+    });
+    expect(pairVideoThumbnails(undefined, (x: { id: string }) => x.id)).toEqual({
+      items: [],
+      pairedThumbs: new Map(),
+    });
+    expect(pairVideoThumbnails([], (x: { id: string }) => x.id)).toEqual({
+      items: [],
+      pairedThumbs: new Map(),
+    });
+  });
+
+  it("does not throw when items is non-array (defensive)", () => {
+    // Cast through unknown so we can exercise the runtime guard.
+    expect(
+      pairVideoThumbnails("not an array" as unknown as readonly { id: string }[], (x) => x.id)
+    ).toEqual({ items: [], pairedThumbs: new Map() });
+  });
+
+  it("collapses a single video + thumbnail pair", () => {
+    const items = [{ id: "clip.mp4" }, { id: "clip.jpg" }];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered).toEqual([{ id: "clip.mp4" }]);
+    expect(pairedThumbs.get("clip.mp4")).toBe("clip.jpg");
+    expect(pairedThumbs.size).toBe(1);
+  });
+
+  it("matches stems case-insensitively", () => {
+    const items = [{ id: "Clip.MP4" }, { id: "clip.JPG" }];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered).toEqual([{ id: "Clip.MP4" }]);
+    expect(pairedThumbs.get("Clip.MP4")).toBe("clip.JPG");
+  });
+
+  it("preserves order; matched thumbnails are dropped", () => {
+    const items = [
+      { id: "a.mp4" },
+      { id: "b.mp4" },
+      { id: "a.jpg" },
+      { id: "c.mp4" },
+      { id: "b.png" },
+    ];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered.map((x) => x.id)).toEqual(["a.mp4", "b.mp4", "c.mp4"]);
+    expect(pairedThumbs.get("a.mp4")).toBe("a.jpg");
+    expect(pairedThumbs.get("b.mp4")).toBe("b.png");
+    expect(pairedThumbs.has("c.mp4")).toBe(false);
+  });
+
+  it("skips items where getKey returns undefined / empty", () => {
+    const items = [{ id: "a.mp4" }, { id: "" }, { id: "a.jpg" }] as { id: string }[];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id || undefined);
+    expect(filtered.map((x) => x.id)).toEqual(["a.mp4", ""]);
+    expect(pairedThumbs.get("a.mp4")).toBe("a.jpg");
+  });
+
+  it("does not pair a thumbnail with no matching video", () => {
+    const items = [{ id: "orphan.jpg" }, { id: "video.mp4" }];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered.map((x) => x.id)).toEqual(["orphan.jpg", "video.mp4"]);
+    expect(pairedThumbs.size).toBe(0);
+  });
+
+  it("supports all video extensions: mp4, webm, mov, m4v", () => {
+    const items = [
+      { id: "a.mp4" },
+      { id: "b.webm" },
+      { id: "c.mov" },
+      { id: "d.m4v" },
+      { id: "a.jpg" },
+      { id: "b.jpeg" },
+      { id: "c.png" },
+      { id: "d.webp" },
+    ];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered.map((x) => x.id)).toEqual(["a.mp4", "b.webm", "c.mov", "d.m4v"]);
+    expect(pairedThumbs.size).toBe(4);
+    expect(pairedThumbs.get("a.mp4")).toBe("a.jpg");
+    expect(pairedThumbs.get("b.webm")).toBe("b.jpeg");
+    expect(pairedThumbs.get("c.mov")).toBe("c.png");
+    expect(pairedThumbs.get("d.m4v")).toBe("d.webp");
+  });
+
+  it("ignores non-image, non-video files (no false-positive pair)", () => {
+    const items = [{ id: "log.txt" }, { id: "data.json" }];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered).toEqual(items);
+    expect(pairedThumbs.size).toBe(0);
+  });
+
+  it("matches the last-seen video when multiple videos share a stem", () => {
+    // Defensive contract: stem collisions are vanishingly rare in
+    // practice (the source layout would have to put two videos with
+    // identical stems in the same list). When it does happen, the second
+    // entry wins because the index map is overwritten.
+    const items = [{ id: "a.mp4" }, { id: "a.webm" }, { id: "a.jpg" }];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    expect(filtered.map((x) => x.id)).toEqual(["a.mp4", "a.webm"]);
+    expect(pairedThumbs.get("a.webm")).toBe("a.jpg");
+    expect(pairedThumbs.has("a.mp4")).toBe(false);
+  });
+
+  it("uses full path as input but matches by basename stem only", () => {
+    const items = [
+      { id: "/path/to/clip.mp4" },
+      { id: "/path/to/clip.jpg" },
+      { id: "/other/dir/clip.png" },
+    ];
+    const { items: filtered, pairedThumbs } = pairVideoThumbnails(items, (x) => x.id);
+    // Both jpg and png have stem "clip" — the second one (png) wins because
+    // it overwrites the pair map entry.
+    expect(filtered.map((x) => x.id)).toEqual(["/path/to/clip.mp4"]);
+    expect(pairedThumbs.get("/path/to/clip.mp4")).toBe("/other/dir/clip.png");
+  });
+});
+
+describe("pairMediaSourceThumbnails", () => {
+  it("delegates to pairVideoThumbnails using the `id` accessor", () => {
+    const items = [{ id: "x.mp4" }, { id: "x.jpg" }];
+    const result = pairMediaSourceThumbnails(items);
+    expect(result.items).toEqual([{ id: "x.mp4" }]);
+    expect(result.pairedThumbs.get("x.mp4")).toBe("x.jpg");
+  });
+
+  it("survives nullish items in the array", () => {
+    const items = [{ id: "x.mp4" }, null as unknown as { id: string }, { id: "x.jpg" }];
+    const result = pairMediaSourceThumbnails(items);
+    expect(result.items).toEqual([{ id: "x.mp4" }, null]);
+    expect(result.pairedThumbs.get("x.mp4")).toBe("x.jpg");
+  });
+});
+
+describe("pairSensorItems", () => {
+  it("delegates to pairVideoThumbnails using the `src` accessor", () => {
+    const items = [{ src: "/clip.mp4" }, { src: "/clip.jpg" }];
+    const result = pairSensorItems(items);
+    expect(result.items).toEqual([{ src: "/clip.mp4" }]);
+    expect(result.pairedThumbs.get("/clip.mp4")).toBe("/clip.jpg");
+  });
+
+  it("preserves extra fields on paired items (e.g. dtMs)", () => {
+    const items = [{ src: "/a.mp4", dtMs: 1000 }, { src: "/a.jpg", dtMs: 1000 }, { src: "/b.mp4" }];
+    const { items: filtered } = pairSensorItems(items);
+    expect(filtered).toEqual([{ src: "/a.mp4", dtMs: 1000 }, { src: "/b.mp4" }]);
+  });
+});
+
+describe("dedupeByRelPath", () => {
+  it("returns empty array for null/undefined input", () => {
+    expect(dedupeByRelPath(null)).toEqual([]);
+    expect(dedupeByRelPath(undefined)).toEqual([]);
+  });
+
+  it("dedupes string items by themselves", () => {
+    const out = dedupeByRelPath(["/a.mp4", "/A.mp4", "/b.mp4"]);
+    expect(out).toEqual(["/a.mp4", "/b.mp4"]);
+  });
+
+  it("first occurrence wins (source-priority preservation)", () => {
+    const a1 = { src: "/foo.mp4", origin: "first" };
+    const a2 = { src: "/foo.mp4", origin: "second" };
+    const out = dedupeByRelPath([a1, a2]);
+    expect(out).toEqual([a1]);
+  });
+
+  it("equates media-source://media_source/<path> with bare /<path>", () => {
+    const out = dedupeByRelPath(["media-source://media_source/local/clip.mp4", "/local/clip.mp4"]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe("media-source://media_source/local/clip.mp4");
+  });
+
+  it("does NOT collapse other media-source roots into bare paths", () => {
+    // The card intentionally treats `media-source://frigate/...` and
+    // `media-source://media_source/...` as distinct sources — only the
+    // local/upload root is normalised onto bare paths.
+    const out = dedupeByRelPath(["media-source://other/local/clip.mp4", "/local/clip.mp4"]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("collapses repeated slashes in the comparison key", () => {
+    const out = dedupeByRelPath(["media-source://media_source//foo/bar.mp4", "/foo/bar.mp4"]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("trims leading and trailing slashes from the comparison key", () => {
+    const out = dedupeByRelPath(["/foo.mp4", "foo.mp4/", "foo.mp4"]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe("/foo.mp4");
+  });
+
+  it("uses media_content_id over path/id/src on objects", () => {
+    const a = {
+      media_content_id: "media-source://media_source/foo.mp4",
+      path: "/should-not-be-used",
+    };
+    const b = { src: "/foo.mp4" };
+    const out = dedupeByRelPath([a, b]);
+    expect(out).toEqual([a]);
+  });
+
+  it("falls through media_content_id → path → id → src", () => {
+    const a = { path: "/clip.mp4" };
+    const b = { id: "/clip.mp4" };
+    const c = { src: "/clip.mp4" };
+    const out = dedupeByRelPath([a, b, c]);
+    expect(out).toEqual([a]);
+  });
+
+  it("drops items that produce an empty normalized key", () => {
+    const out = dedupeByRelPath(["", "/", "//", "media-source://", "/real.mp4"]);
+    expect(out).toEqual(["/real.mp4"]);
+  });
+
+  it("treats casing as equivalent (lowercased key)", () => {
+    const out = dedupeByRelPath(["/Foo.MP4", "/foo.mp4"]);
+    expect(out).toEqual(["/Foo.MP4"]);
+  });
+
+  it("preserves item identity (returns original references)", () => {
+    const items = [{ src: "/a.mp4" }, { src: "/b.mp4" }];
+    const out = dedupeByRelPath(items);
+    expect(out[0]).toBe(items[0]);
+    expect(out[1]).toBe(items[1]);
+  });
+
+  it("ignores nullish entries", () => {
+    const out = dedupeByRelPath([null, undefined, "/a.mp4", null]);
+    expect(out).toEqual(["/a.mp4"]);
+  });
+});

--- a/src/data/pairing.spec.ts
+++ b/src/data/pairing.spec.ts
@@ -182,6 +182,15 @@ describe("dedupeByRelPath", () => {
     expect(out[0]).toBe("media-source://media_source/local/clip.mp4");
   });
 
+  it("equates media-source://media_source (no trailing slash) with empty path", () => {
+    // Edge case from the legacy chain: the second `replace` (without the
+    // trailing slash) catches inputs that the first one misses. The
+    // consolidated regex still strips the prefix and the input normalises
+    // to the empty string, which is dropped.
+    const out = dedupeByRelPath(["media-source://media_source"]);
+    expect(out).toEqual([]);
+  });
+
   it("does NOT collapse other media-source roots into bare paths", () => {
     // The card intentionally treats `media-source://frigate/...` and
     // `media-source://media_source/...` as distinct sources — only the

--- a/src/data/pairing.ts
+++ b/src/data/pairing.ts
@@ -54,34 +54,32 @@ export function pairVideoThumbnails<T>(
   }
 
   const videoIdxByStem = new Map<string, number>();
-  for (let i = 0; i < items.length; i++) {
-    const key = getKey(items[i] as T);
+  for (const [i, it] of items.entries()) {
+    const key = getKey(it);
     if (!key) continue;
-    const m = VIDEO_EXT_RE.exec(key);
-    const stem = m?.[1];
+    const stem = VIDEO_EXT_RE.exec(key)?.[1];
     if (!stem) continue;
     videoIdxByStem.set(stem.toLowerCase(), i);
   }
 
   const pairedThumbs = new Map<string, string>();
   const toRemove = new Set<number>();
-  for (let i = 0; i < items.length; i++) {
-    const thumbKey = getKey(items[i] as T);
+  for (const [i, it] of items.entries()) {
+    const thumbKey = getKey(it);
     if (!thumbKey) continue;
-    const m = IMAGE_EXT_RE.exec(thumbKey);
-    const stem = m?.[1];
+    const stem = IMAGE_EXT_RE.exec(thumbKey)?.[1];
     if (!stem) continue;
     const vidIdx = videoIdxByStem.get(stem.toLowerCase());
     if (vidIdx === undefined) continue;
-    const videoKey = getKey(items[vidIdx] as T);
+    const video = items[vidIdx];
+    if (video === undefined) continue;
+    const videoKey = getKey(video);
     if (!videoKey) continue;
     pairedThumbs.set(videoKey, thumbKey);
     toRemove.add(i);
   }
 
-  const filtered = toRemove.size
-    ? (items as readonly T[]).filter((_, i) => !toRemove.has(i))
-    : ([...items] as T[]);
+  const filtered = toRemove.size ? items.filter((_, i) => !toRemove.has(i)) : [...items];
   return { items: filtered, pairedThumbs };
 }
 
@@ -103,18 +101,22 @@ export function pairSensorItems<T extends SensorLike>(
  * Strip media-source/leading-slash noise off a path-ish string for
  * deduplication. Lowercased, trimmed, with collapsed consecutive slashes.
  *
- * Handles the various shapes the card sees: bare paths (`/local/foo.mp4`),
- * `media-source://media_source/local/foo.mp4`, `media-source://frigate/...`,
- * etc.
+ * The prefix-strip regex equates `media-source://media_source/<path>`,
+ * `media-source://media_source` (no trailing slash), and bare `<path>`,
+ * but preserves the root segment for other media-source URIs (Frigate,
+ * etc.) so they don't collide with bare local paths.
  */
+const MEDIA_SOURCE_PREFIX_RE = /^media-source:\/\/(?:media_source\/?)?/;
+const MULTI_SLASH_RE = /\/{2,}/g;
+const LEADING_SLASH_RE = /^\/+/;
+const TRAILING_SLASH_RE = /\/+$/;
+
 function normalizeRelPath(idOrPath: unknown): string {
   return String(idOrPath ?? "")
-    .replace(/^media-source:\/\/media_source\//, "")
-    .replace(/^media-source:\/\/media_source/, "")
-    .replace(/^media-source:\/\//, "")
-    .replace(/\/{2,}/g, "/")
-    .replace(/^\/+/, "")
-    .replace(/\/+$/g, "")
+    .replace(MEDIA_SOURCE_PREFIX_RE, "")
+    .replace(MULTI_SLASH_RE, "/")
+    .replace(LEADING_SLASH_RE, "")
+    .replace(TRAILING_SLASH_RE, "")
     .trim()
     .toLowerCase();
 }

--- a/src/data/pairing.ts
+++ b/src/data/pairing.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure helpers for collapsing video / thumbnail pairs and deduping items by
+ * normalized rel-path.
+ *
+ * Both NVR-style sensor sources and `media-source/browse_media` responses
+ * tend to surface a video and a sibling JPG/PNG thumbnail with the same
+ * filename stem (e.g. `clip.mp4` + `clip.jpg`). The card folds those into
+ * a single gallery tile by removing the thumbnail from the rendered list
+ * and exposing a `videoKey -> thumbnailKey` map for the renderer to attach
+ * the still as the video's poster.
+ *
+ * Sensor items key off `src` (file path); media-source items key off `id`
+ * (media-source URI). The pair-by-stem heuristic is identical otherwise,
+ * so `pairVideoThumbnails` is the generic implementation and the two
+ * named exports are thin wrappers that pass the right accessor.
+ */
+
+const VIDEO_EXT_RE = /([^/]+)\.(mp4|webm|mov|m4v)$/i;
+const IMAGE_EXT_RE = /([^/]+)\.(jpg|jpeg|png|webp)$/i;
+
+/** Common shape for items that key off a media-source URI. */
+export interface MediaSourceLike {
+  id: string;
+}
+
+/** Common shape for items that key off a sensor file path. */
+export interface SensorLike {
+  src: string;
+}
+
+export interface PairResult<T> {
+  /** Original `items` minus the thumbnail entries that paired with a video. */
+  items: T[];
+  /** `videoKey -> thumbnailKey` for every successful pairing. */
+  pairedThumbs: Map<string, string>;
+}
+
+/**
+ * Pair videos with their sibling JPG/PNG/WEBP thumbnails by filename stem.
+ *
+ * `getKey` should return the item's pair-by-stem key (e.g. URI or file path).
+ * Items where `getKey` returns `undefined`/`""` are passed through untouched
+ * (they can't pair). Case-insensitive stem matching.
+ *
+ * The resulting `items` preserves the input order; matched thumbnails are
+ * removed. `pairedThumbs` keys/values are the raw `getKey` outputs.
+ */
+export function pairVideoThumbnails<T>(
+  items: readonly T[] | null | undefined,
+  getKey: (it: T) => string | undefined
+): PairResult<T> {
+  if (!Array.isArray(items) || items.length === 0) {
+    return { items: [], pairedThumbs: new Map() };
+  }
+
+  const videoIdxByStem = new Map<string, number>();
+  for (let i = 0; i < items.length; i++) {
+    const key = getKey(items[i] as T);
+    if (!key) continue;
+    const m = VIDEO_EXT_RE.exec(key);
+    const stem = m?.[1];
+    if (!stem) continue;
+    videoIdxByStem.set(stem.toLowerCase(), i);
+  }
+
+  const pairedThumbs = new Map<string, string>();
+  const toRemove = new Set<number>();
+  for (let i = 0; i < items.length; i++) {
+    const thumbKey = getKey(items[i] as T);
+    if (!thumbKey) continue;
+    const m = IMAGE_EXT_RE.exec(thumbKey);
+    const stem = m?.[1];
+    if (!stem) continue;
+    const vidIdx = videoIdxByStem.get(stem.toLowerCase());
+    if (vidIdx === undefined) continue;
+    const videoKey = getKey(items[vidIdx] as T);
+    if (!videoKey) continue;
+    pairedThumbs.set(videoKey, thumbKey);
+    toRemove.add(i);
+  }
+
+  const filtered = toRemove.size
+    ? (items as readonly T[]).filter((_, i) => !toRemove.has(i))
+    : ([...items] as T[]);
+  return { items: filtered, pairedThumbs };
+}
+
+/** Pair `media-source` items by their `id` URI. */
+export function pairMediaSourceThumbnails<T extends MediaSourceLike>(
+  items: readonly T[] | null | undefined
+): PairResult<T> {
+  return pairVideoThumbnails(items, (it) => it?.id);
+}
+
+/** Pair sensor items by their `src` file path. */
+export function pairSensorItems<T extends SensorLike>(
+  items: readonly T[] | null | undefined
+): PairResult<T> {
+  return pairVideoThumbnails(items, (it) => it?.src);
+}
+
+/**
+ * Strip media-source/leading-slash noise off a path-ish string for
+ * deduplication. Lowercased, trimmed, with collapsed consecutive slashes.
+ *
+ * Handles the various shapes the card sees: bare paths (`/local/foo.mp4`),
+ * `media-source://media_source/local/foo.mp4`, `media-source://frigate/...`,
+ * etc.
+ */
+function normalizeRelPath(idOrPath: unknown): string {
+  return String(idOrPath ?? "")
+    .replace(/^media-source:\/\/media_source\//, "")
+    .replace(/^media-source:\/\/media_source/, "")
+    .replace(/^media-source:\/\//, "")
+    .replace(/\/{2,}/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Loose shape covering every kind of item that may end up in a deduped list:
+ * media-source records (`media_content_id`), media-source items (`id`),
+ * generic items (`path`), or sensor file paths (`src`).
+ */
+interface DedupableItem {
+  media_content_id?: string | null;
+  path?: string | null;
+  id?: string | null;
+  src?: string | null;
+}
+
+/**
+ * Dedupe items by normalized rel-path. First occurrence wins; later items
+ * with the same key are dropped (preserves source-mode priority when the
+ * caller has already concatenated lists in the desired order).
+ *
+ * Accepts strings or objects with `media_content_id` / `path` / `id` /
+ * `src`. Items that produce an empty key after normalization are dropped.
+ * `null` / `undefined` input returns an empty array.
+ */
+export function dedupeByRelPath<T>(items: readonly T[] | null | undefined): T[] {
+  if (!Array.isArray(items)) return [];
+  const seen = new Map<string, T>();
+  for (const it of items) {
+    let candidate: unknown;
+    if (it === null || it === undefined) {
+      candidate = "";
+    } else if (typeof it === "string") {
+      candidate = it;
+    } else {
+      const obj = it as DedupableItem;
+      // Truthy fallthrough (||, not ??) — empty strings on one field should
+      // fall through to the next, matching the legacy `_dedupeByRelPath`
+      // shape. Final `|| it` lets a stringified item itself act as the key.
+      candidate = obj.media_content_id || obj.path || obj.id || obj.src || it;
+    }
+    const key = normalizeRelPath(candidate);
+    if (!key) continue;
+    if (!seen.has(key)) seen.set(key, it as T);
+  }
+  return Array.from(seen.values());
+}

--- a/src/index.js
+++ b/src/index.js
@@ -761,6 +761,15 @@ class CameraGalleryCard extends LitElement {
     video.muted = shouldMute;
 
     if (video.src !== selectedUrl) {
+      // Cancel any in-flight load on the previous src before swapping. Without
+      // this, Firefox surfaces the browser-internal fetch abort as
+      // `Uncaught (in promise) DOMException: aborted by the user agent` —
+      // harmless, but it spams the console on every quick thumb-to-thumb tap.
+      if (video.src) {
+        try { video.pause(); } catch (_) {}
+        try { video.removeAttribute("src"); video.load(); } catch (_) {}
+      }
+
       video.src = selectedUrl;
 
       const poster = this._posterCache.get(selectedUrl) || "";

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import {
 } from "./data/pairing";
 import { FavoritesStore } from "./data/favorites";
 import { fnv1aHash } from "./util/hash";
+import { isVideo } from "./util/media-type";
 import {
   FRIGATE_SNAPSHOTS_ROOT,
   FRIGATE_URI_PREFIX,
@@ -725,7 +726,7 @@ class CameraGalleryCard extends LitElement {
     for (const it of items) {
       const src = String(it?.src || "");
       if (!src) continue;
-      if (!this._isVideo(src)) continue;
+      if (!isVideo(src)) continue;
       this._enqueuePoster(src);
     }
   }
@@ -2307,11 +2308,6 @@ class CameraGalleryCard extends LitElement {
     return String(v || "").startsWith("media-source://");
   }
 
-  _isVideo(src) {
-    const path = String(src || "").split("?")[0].split("#")[0];
-    return /\.(mp4|webm|mov|m4v)$/i.test(path);
-  }
-
   _toFsPath(src) {
     if (!src) return "";
     let clean = String(src).trim();
@@ -2627,7 +2623,7 @@ class CameraGalleryCard extends LitElement {
     try {
       // Auth-protected HA image thumbnails (browse_media) need a Bearer fetch.
       // Videos always go through _captureFrame to extract a still — never base64 the file.
-      const dataUrl = src.startsWith("/") && !this._isVideo(src)
+      const dataUrl = src.startsWith("/") && !isVideo(src)
         ? await this._fetchProtectedAsDataUrl(src)
         : await this._captureFrame(
             src,
@@ -3257,7 +3253,7 @@ class CameraGalleryCard extends LitElement {
     const c = String(cls || "").toLowerCase();
     if (m.startsWith("video/")) return true;
     if (c === "video") return true;
-    return this._isVideo(String(urlOrTitle || ""));
+    return isVideo(String(urlOrTitle || ""));
   }
 
   _resetThumbScrollToStart() {
@@ -3404,7 +3400,7 @@ class CameraGalleryCard extends LitElement {
       const meta = this._msMetaById(src);
       return this._isVideoSmart(meta.title || src, meta.mime, meta.cls);
     }
-    return this._isVideo(src);
+    return isVideo(src);
   }
 
   _matchesTypeFilter(src) {
@@ -4050,7 +4046,7 @@ class CameraGalleryCard extends LitElement {
                 changed = true;
               }
               // Viewport-aware poster prioritization: enqueue only when visible
-              if (isSensor && key && this._isVideo(key)) {
+              if (isSensor && key && isVideo(key)) {
                 const pairedJpg = this._sensorPairedThumbs?.get(key);
                 this._enqueuePoster(pairedJpg || key);
               }

--- a/src/index.js
+++ b/src/index.js
@@ -943,10 +943,6 @@ class CameraGalleryCard extends LitElement {
     return this.config?.thumb_layout === "vertical";
   }
 
-  _jsonEq(a, b) {
-    return JSON.stringify(a) === JSON.stringify(b);
-  }
-
   // Options bag for the pure datetime-parsing functions.
   // Reads config + resolveName each access; cheap allocation, no caching needed.
   get _dtOpts() {

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,8 @@ import {
   pairMediaSourceThumbnails,
   pairSensorItems,
 } from "./data/pairing";
+import { FavoritesStore } from "./data/favorites";
+import { fnv1aHash } from "./util/hash";
 import {
   FRIGATE_SNAPSHOTS_ROOT,
   FRIGATE_URI_PREFIX,
@@ -201,7 +203,7 @@ class CameraGalleryCard extends LitElement {
     this._pillsHideActive = false;
     this._srcEntityMap = new Map();
     this._sensorPairedThumbs = new Map();
-    this._favorites = new Set();
+    this._favorites = new FavoritesStore({ onChange: () => this.requestUpdate() });
     this._suppressNextThumbClick = false;
     this._swipeStartX = 0;
     this._swipeStartY = 0;
@@ -2542,38 +2544,7 @@ class CameraGalleryCard extends LitElement {
   }
 
   _thumbHash(url) {
-    let h = 2166136261;
-    for (let i = 0; i < url.length; i++) {
-      h ^= url.charCodeAt(i);
-      h = Math.imul(h, 16777619) >>> 0;
-    }
-    return "cgc_p_" + h.toString(36);
-  }
-
-  _favKey() {
-    const id = [
-      ...(this.config?.entities ?? []),
-      ...(this.config?.media_sources ?? []),
-    ].sort().join("|");
-    return "cgc_favs_" + this._thumbHash(id);
-  }
-
-  _loadFavorites() {
-    try {
-      const raw = localStorage.getItem(this._favKey());
-      this._favorites = raw ? new Set(JSON.parse(raw)) : new Set();
-    } catch (_) { this._favorites = new Set(); }
-  }
-
-  _saveFavorites() {
-    try { localStorage.setItem(this._favKey(), JSON.stringify([...this._favorites])); } catch (_) {}
-  }
-
-  _toggleFavorite(src) {
-    if (this._favorites.has(src)) this._favorites.delete(src);
-    else this._favorites.add(src);
-    this._saveFavorites();
-    this.requestUpdate();
+    return "cgc_p_" + fnv1aHash(url);
   }
 
   // Salt the localStorage key with the current frame %, so changing the % invalidates
@@ -3834,7 +3805,7 @@ class CameraGalleryCard extends LitElement {
 
     this.config = nextConfig;
     this._customIcons = customIcons;
-    this._loadFavorites();
+    this._favorites.load(this.config);
     this._startMediaPoll();
 
     const { changedKeys, isSourceChange: sourceChange, isUiOnly: uiOnlyChange } =
@@ -4689,7 +4660,7 @@ class CameraGalleryCard extends LitElement {
 
                         <div
                           class="fav-btn ${this._favorites.has(it.src) ? 'on' : ''}"
-                          @click=${(e) => { e.stopPropagation(); this._toggleFavorite(it.src); }}
+                          @click=${(e) => { e.stopPropagation(); this._favorites.toggle(it.src); }}
                           @pointerdown=${(e) => e.stopPropagation()}
                           role="button"
                           title="Favorite"

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,11 @@ import {
   sensorTextForFilter,
 } from "./data/object-filters";
 import {
+  dedupeByRelPath,
+  pairMediaSourceThumbnails,
+  pairSensorItems,
+} from "./data/pairing";
+import {
   FRIGATE_SNAPSHOTS_ROOT,
   FRIGATE_URI_PREFIX,
   fetchFrigateEvents,
@@ -2905,7 +2910,7 @@ class CameraGalleryCard extends LitElement {
         })
         .filter((x) => !!x.id);
 
-      items = this._dedupeByRelPath(items);
+      items = dedupeByRelPath(items);
 
       items.sort((a, b) => {
         const am = a.dtMs ?? dtMsFromSrc(a.id, this._dtOpts);
@@ -3011,48 +3016,8 @@ class CameraGalleryCard extends LitElement {
       .join(" | ");
   }
 
-  _msPairThumbnails(items) {
-    const videosByStem = new Map();
-    for (let i = 0; i < items.length; i++) {
-      const m = String(items[i].id || "").match(/([^/]+)\.(mp4|webm|mov|m4v)$/i);
-      if (m) videosByStem.set(m[1].toLowerCase(), i);
-    }
-    const pairedThumbs = new Map();
-    const toRemove = new Set();
-    for (let i = 0; i < items.length; i++) {
-      const m = String(items[i].id || "").match(/([^/]+)\.(jpg|jpeg|png|webp)$/i);
-      if (!m) continue;
-      const vidIdx = videosByStem.get(m[1].toLowerCase());
-      if (vidIdx === undefined) continue;
-      pairedThumbs.set(items[vidIdx].id, items[i].id);
-      toRemove.add(i);
-    }
-    const filtered = toRemove.size ? items.filter((_, i) => !toRemove.has(i)) : items;
-    return { items: filtered, pairedThumbs };
-  }
-
-  _pairSensorItems(items) {
-    const videosByStem = new Map();
-    for (let i = 0; i < items.length; i++) {
-      const m = String(items[i].src || "").match(/([^/]+)\.(mp4|webm|mov|m4v)$/i);
-      if (m) videosByStem.set(m[1].toLowerCase(), i);
-    }
-    const pairedThumbs = new Map();
-    const toRemove = new Set();
-    for (let i = 0; i < items.length; i++) {
-      const m = String(items[i].src || "").match(/([^/]+)\.(jpg|jpeg|png|webp)$/i);
-      if (!m) continue;
-      const vidIdx = videosByStem.get(m[1].toLowerCase());
-      if (vidIdx === undefined) continue;
-      pairedThumbs.set(items[vidIdx].src, items[i].src);
-      toRemove.add(i);
-    }
-    const filtered = toRemove.size ? items.filter((_, i) => !toRemove.has(i)) : items;
-    return { items: filtered, pairedThumbs };
-  }
-
   _msSetList(items) {
-    const { items: paired, pairedThumbs } = this._msPairThumbnails(Array.isArray(items) ? [...items] : []);
+    const { items: paired, pairedThumbs } = pairMediaSourceThumbnails(Array.isArray(items) ? [...items] : []);
     this._ms.list = paired;
     this._ms.listIndex = new Map(paired.map((x) => [x.id, x]));
     this._ms.pairedThumbs = pairedThumbs;
@@ -3209,29 +3174,6 @@ class CameraGalleryCard extends LitElement {
     return Promise.race([p, t]);
   }
 
-  _dedupeByRelPath(items) {
-    const seen = new Map();
-
-    const norm = (idOrPath) =>
-      String(idOrPath || "")
-        .replace(/^media-source:\/\/media_source\//, "")
-        .replace(/^media-source:\/\/media_source/, "")
-        .replace(/^media-source:\/\//, "")
-        .replace(/\/{2,}/g, "/")
-        .replace(/^\/+/, "")
-        .replace(/\/+$/g, "")
-        .trim()
-        .toLowerCase();
-
-    for (const it of items || []) {
-      const key = norm(it?.media_content_id || it?.path || it?.id || it?.src || it);
-      if (!key) continue;
-      if (!seen.has(key)) seen.set(key, it);
-    }
-
-    return Array.from(seen.values());
-  }
-
   /**
    * @typedef {{ src: string, dtMs?: number }} CardItem
    *
@@ -3279,18 +3221,18 @@ class CameraGalleryCard extends LitElement {
         }
         sensorList.push(...part);
       }
-      const enrichedSensor = this._dedupeByRelPath(sensorList).map(enrich);
-      const { items: pairedSensor, pairedThumbs: sensorPaired } = this._pairSensorItems(enrichedSensor);
+      const enrichedSensor = dedupeByRelPath(sensorList).map(enrich);
+      const { items: pairedSensor, pairedThumbs: sensorPaired } = pairSensorItems(enrichedSensor);
       this._sensorPairedThumbs = sensorPaired;
-      const msItems = this._dedupeByRelPath(this._msIds()).map(enrich);
-      const merged = this._dedupeByRelPath([...pairedSensor, ...msItems]);
+      const msItems = dedupeByRelPath(this._msIds()).map(enrich);
+      const merged = dedupeByRelPath([...pairedSensor, ...msItems]);
       return this._deleted?.size
         ? merged.filter((it) => !this._deleted.has(it.src))
         : merged;
     }
 
     if (usingMediaSource) {
-      const ids = this._dedupeByRelPath(this._msIds()).map(enrich);
+      const ids = dedupeByRelPath(this._msIds()).map(enrich);
       return this._deleted?.size ? ids.filter((it) => !this._deleted.has(it.src)) : ids;
     }
 
@@ -3331,14 +3273,14 @@ class CameraGalleryCard extends LitElement {
       list.push(...part);
     }
 
-    list = this._dedupeByRelPath(list);
+    list = dedupeByRelPath(list);
 
     if (this._deleted?.size) {
       list = list.filter((src) => !this._deleted.has(src));
     }
 
     const enriched = list.map(enrich);
-    const { items: paired, pairedThumbs } = this._pairSensorItems(enriched);
+    const { items: paired, pairedThumbs } = pairSensorItems(enriched);
     this._sensorPairedThumbs = pairedThumbs;
     return paired;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2543,15 +2543,11 @@ class CameraGalleryCard extends LitElement {
     });
   }
 
-  _thumbHash(url) {
-    return "cgc_p_" + fnv1aHash(url);
-  }
-
   // Salt the localStorage key with the current frame %, so changing the % invalidates
   // cached frames without needing to wipe storage.
   _lsKey(url) {
     const pct = this.config?.thumbnail_frame_pct ?? DEFAULT_THUMBNAIL_FRAME_PCT;
-    return this._thumbHash(url + "|" + pct);
+    return "cgc_p_" + fnv1aHash(url + "|" + pct);
   }
 
   _lsThumbGet(url) {

--- a/src/util/hash.spec.ts
+++ b/src/util/hash.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { fnv1aHash } from "./hash";
+
+describe("fnv1aHash", () => {
+  it("hashes the empty string to a known FNV-1a basis vector", () => {
+    // FNV-1a offset basis 0x811c9dc5 (2166136261) → base-36 "ztntfp".
+    // Locked in so any future engine/JS change that drifts the output
+    // breaks this test instead of silently invalidating users' cached
+    // keys (favorites, poster cache, etc.).
+    expect(fnv1aHash("")).toBe("ztntfp");
+  });
+
+  it("returns deterministic output for fixed inputs (regression vectors)", () => {
+    expect(fnv1aHash("hello")).toBe("m3bicr");
+    expect(fnv1aHash("sensor.cam_files|sensor.other_files")).toBe("fwpou4");
+  });
+
+  it("is case-sensitive", () => {
+    expect(fnv1aHash("Hello")).not.toBe(fnv1aHash("hello"));
+  });
+
+  it("differs between similar but distinct inputs", () => {
+    expect(fnv1aHash("a|b")).not.toBe(fnv1aHash("a|c"));
+    expect(fnv1aHash("ab")).not.toBe(fnv1aHash("ba"));
+  });
+
+  it("handles unicode via charCodeAt (UTF-16 code units)", () => {
+    // The implementation walks `charCodeAt`, so two inputs with the
+    // same UTF-16 representation hash identically; surrogate pairs
+    // hash distinctly from BMP characters.
+    expect(fnv1aHash("é")).toBe(fnv1aHash("é"));
+    expect(fnv1aHash("🎥")).not.toBe(fnv1aHash("📹"));
+  });
+
+  it("returns a base-36 string", () => {
+    for (const sample of ["", "x", "longer-input-string"]) {
+      expect(fnv1aHash(sample)).toMatch(/^[0-9a-z]+$/);
+    }
+  });
+});

--- a/src/util/hash.ts
+++ b/src/util/hash.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure FNV-1a 32-bit string hash, returned as a base-36 string.
+ *
+ * The card uses this to derive stable localStorage keys from
+ * config-shaped IDs and from media URLs (so the cache key salts on the
+ * relevant config). Not cryptographic — collisions are theoretically
+ * possible but vanishingly rare for the inputs in question (a few
+ * hundred entity IDs, at most). Deterministic across runs and engines.
+ */
+const FNV_OFFSET_BASIS = 2166136261;
+const FNV_PRIME = 16777619;
+
+/** Compute the FNV-1a 32-bit hash of `input`, returned as base-36. */
+export function fnv1aHash(input: string): string {
+  let h = FNV_OFFSET_BASIS;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, FNV_PRIME) >>> 0;
+  }
+  return h.toString(36);
+}

--- a/src/util/media-type.spec.ts
+++ b/src/util/media-type.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { isVideo } from "./media-type";
+
+describe("isVideo", () => {
+  it("returns true for the supported video extensions", () => {
+    expect(isVideo("clip.mp4")).toBe(true);
+    expect(isVideo("clip.webm")).toBe(true);
+    expect(isVideo("clip.mov")).toBe(true);
+    expect(isVideo("clip.m4v")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isVideo("CLIP.MP4")).toBe(true);
+    expect(isVideo("Clip.WebM")).toBe(true);
+  });
+
+  it("returns false for image extensions", () => {
+    expect(isVideo("clip.jpg")).toBe(false);
+    expect(isVideo("clip.png")).toBe(false);
+    expect(isVideo("clip.webp")).toBe(false);
+  });
+
+  it("returns false for files with no extension", () => {
+    expect(isVideo("clip")).toBe(false);
+    expect(isVideo("/path/to/clip")).toBe(false);
+  });
+
+  it("strips query strings before testing", () => {
+    expect(isVideo("/clip.mp4?token=abc")).toBe(true);
+    expect(isVideo("/clip.jpg?token=abc")).toBe(false);
+  });
+
+  it("strips fragments before testing", () => {
+    expect(isVideo("/clip.mp4#t=10")).toBe(true);
+    expect(isVideo("/clip.jpg#anchor")).toBe(false);
+  });
+
+  it("strips both query and fragment", () => {
+    expect(isVideo("/clip.mp4?x=1#frag")).toBe(true);
+  });
+
+  it("matches only at the end of the path", () => {
+    // Stem-like substrings that look like extensions in the middle of
+    // the path should not register as videos.
+    expect(isVideo("/foo.mp4.txt")).toBe(false);
+    expect(isVideo("/foo.mp4/bar.jpg")).toBe(false);
+  });
+
+  it("handles full URLs", () => {
+    expect(isVideo("https://example.com/folder/clip.mp4")).toBe(true);
+    expect(isVideo("media-source://media_source/local/clip.webm")).toBe(true);
+  });
+
+  it("returns false for null / undefined / empty input", () => {
+    expect(isVideo(null)).toBe(false);
+    expect(isVideo(undefined)).toBe(false);
+    expect(isVideo("")).toBe(false);
+  });
+});

--- a/src/util/media-type.ts
+++ b/src/util/media-type.ts
@@ -1,0 +1,24 @@
+/**
+ * Media-type detection helpers.
+ *
+ * Pure, framework-free predicates for classifying URLs/paths by their
+ * extension. The card uses these to decide whether a thumbnail needs a
+ * first-frame poster (videos) or can render the file directly (images).
+ *
+ * Extension list intentionally mirrors the one used by `pairing.ts` for
+ * the video/thumbnail pair-by-stem heuristic — the two are kept in
+ * sync by hand. They use different regex shapes (capturing vs. just
+ * testing), so a shared constant doesn't simplify the code.
+ */
+
+const VIDEO_EXTENSION_RE = /\.(mp4|webm|mov|m4v)$/i;
+
+/**
+ * True when `src` looks like a video file URL/path. Strips any query
+ * string and fragment before testing the extension; case-insensitive.
+ */
+export function isVideo(src: string | null | undefined): boolean {
+  if (src === null || src === undefined) return false;
+  const path = String(src).split("?")[0]?.split("#")[0] ?? "";
+  return VIDEO_EXTENSION_RE.test(path);
+}


### PR DESCRIPTION
## Summary

Extracts two clusters of pure helpers out of `src/index.js` into focused, typed, fully-specced modules. Continues the modularization plan after PR #62 (config superstruct rewrite) and PR #61 (object-filters); this is the "small-pure-wins" bucket called out as the next step in [`plans/modularization.md`](plans/modularization.md).

Bundles two atomic commits in one PR for reviewer ergonomics:

1. **`fix: extract pairing helpers`** — `_msPairThumbnails`, `_pairSensorItems`, and `_dedupeByRelPath` move into `src/data/pairing.ts`. The two pair-by-stem functions were character-identical except for the property name (`id` vs `src`); collapsed into a generic `pairVideoThumbnails<T>` with thin `pairMediaSourceThumbnails` and `pairSensorItems` wrappers. Defensive `Array.isArray` guards on inputs (was: throw on null), bounds-checked regex destructure for `noUncheckedIndexedAccess` compat. Regex sources hoisted to named module-level constants.

2. **`fix: extract favorites storage + util/hash`** — the four ad-hoc favorites methods (`_favKey`, `_loadFavorites`, `_saveFavorites`, `_toggleFavorite`) become a `FavoritesStore` class in `src/data/favorites.ts`; the storage backend is injectable for tests. The shared FNV-1a hash moves to `src/util/hash.ts` (used by both favorites and the still-inline poster cache `_thumbHash`, ready for the upcoming PosterQueue extraction to consume directly).

The legacy `cgc_favs_cgc_p_<hash>` storage key shape is preserved exactly so existing users' favorites continue to resolve.

### Audit fixes shipped (per the modularization plan's code-quality mandate)

**Pairing**
- `Array.isArray` guard so callers passing `null` / `undefined` no longer throw — returns an empty result.
- Bounds-checked regex match destructure (`m?.[1]` instead of `m[1]`).
- De-duplicated implementation (the legacy code had the entire pair loop copy-pasted twice).

**Favorites**
- `load()` validates `Array.isArray(parsed)` before constructing the Set; previously a corrupt object in storage would silently turn into a Set of its keys.
- Corrupt JSON / wrong-shape data warns once via `console.warn`; the underlying disk entry is preserved so the next successful `toggle()` overwrites it.
- `save()` distinguishes `QuotaExceededError` (warn-once latch) from other write failures (logged with the error). Previously any failure was silently swallowed.
- Non-string elements in the persisted array are filtered out at load time instead of polluting the in-memory Set.

### Stats

- 7 files changed, 869 insertions(+), 107 deletions(-)
- `src/index.js`: -113 lines net (12,815 → 12,702)
- 24 new unit tests (28 pairing + 18 favorites + 6 hash → 229 total, up from 205)
- Bundle: built clean

## Test plan

- [x] `npm run check` (typecheck + lint + format + build) green
- [x] `npm test` — 229 tests passing across 9 suites
- [x] HA smoke (sensor mode): thumbnails render, paired video/jpg pairs collapse correctly, day-grouping intact, click-to-preview works
- [x] HA smoke (media mode): browse walks, pairing in `_msSetList` produces working `pairedThumbs`
- [x] HA smoke (combined mode): sensor + media merge correctly, dedupe across both
- [x] Favorites: star toggle persists across reload, filter-by-favorites filter shows correct items, empty state renders
- [x] localStorage: existing `cgc_favs_<hash>` key still resolves with same hash output (legacy-user compat)