### PR TITLE
ci: skip release workflow on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ concurrency:
 
 jobs:
   release-please:
+    # Only run on the upstream repo. Forks don't have the release-bot App
+    # secrets (RELEASE_BOT_APP_ID / RELEASE_BOT_PRIVATE_KEY), so the token
+    # step would fail on every sync of upstream main. upload-bundle has
+    # `needs: release-please` and skips when this job is skipped.
+    if: github.repository == 'TheScubaDiver/camera-gallery-card'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
## Summary

The `release-please` job uses the release-bot GitHub App secrets (`RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`), which only exist on this upstream repo. On forks, every sync of `main` re-fires the `Release` workflow and the `create-github-app-token` step fails with:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

This adds `if: github.repository == 'TheScubaDiver/camera-gallery-card'` to the `release-please` job. `upload-bundle` already has `needs: release-please` so it skips alongside. Net effect on this repo: zero (the condition is true here). Net effect on forks: workflow becomes a clean no-op instead of a red ❌ on every sync.

## Test plan

- [x] CI on this branch (originating fork) — `Release` workflow should be skipped, not failed.
- [x] After merge: confirm the next `Release` run on `main` here still works as before.