### PR TITLE
fix: use CSS fallback for fullscreen in HA Android Companion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1634,10 +1634,24 @@ class CameraGalleryCard extends LitElement {
 
   _toggleLiveFullscreen() {
     const video = this._findLiveVideo();
+    const ua = navigator.userAgent || "";
+    // HA Companion's Android WebView mishandles requestFullscreen on a
+    // custom element (system bar hides but the element doesn't fill the
+    // viewport). The CSS fallback works correctly there. iOS Companion is
+    // unaffected because the video.webkitEnterFullscreen path runs first.
+    const isAndroidWebView = /Android/.test(ua) && (/Home Assistant\//.test(ua) || /; wv\)/.test(ua));
 
     // Uitgang fullscreen
-    if (document.fullscreenElement || document.webkitFullscreenElement) {
-      (document.exitFullscreen || document.webkitExitFullscreen).call(document).catch(() => {});
+    if (document.fullscreenElement || document.webkitFullscreenElement || this._liveFullscreen) {
+      if (document.fullscreenElement || document.webkitFullscreenElement) {
+        (document.exitFullscreen || document.webkitExitFullscreen).call(document).catch(() => {});
+        return;
+      }
+      // CSS-fallback exit
+      this._liveFullscreen = false;
+      this._resetZoom();
+      this.removeAttribute("data-live-fs");
+      this.requestUpdate();
       return;
     }
 
@@ -1647,16 +1661,15 @@ class CameraGalleryCard extends LitElement {
       return;
     }
 
-    // Standard fullscreen API — altijd op 'this' zodat pinch-zoom werkt
-    if (document.fullscreenEnabled) {
+    // Android WebView: skip native API, go to CSS fallback (zie boven)
+    if (!isAndroidWebView && document.fullscreenEnabled) {
       this.requestFullscreen().catch(() => {});
       return;
     }
 
-    // CSS fallback
-    this._liveFullscreen = !this._liveFullscreen;
-    if (!this._liveFullscreen) this._resetZoom();
-    this.toggleAttribute("data-live-fs", this._liveFullscreen);
+    // CSS fallback (Android WebView, of geen native fullscreen support)
+    this._liveFullscreen = true;
+    this.setAttribute("data-live-fs", "");
     this.requestUpdate();
   }
 


### PR DESCRIPTION
## Summary
The HA Companion app's Android WebView mishandles `requestFullscreen()` on a custom element: the system bar hides (immersive mode kicks in) but the requested element doesn't size to the viewport, so the card stays at its original layout dimensions and visually appears to *shrink* rather than go fullscreen.

This change detects HA Companion (UA contains `Home Assistant/`) or any generic Android WebView (`; wv)` in UA) and routes those clients to the existing CSS-fallback path (`position: fixed; inset: 0; width: 100vw; height: 100vh`) which is already used as a fallback for browsers without native fullscreen support. The CSS fallback fills the viewport correctly under WebView's immersive mode.

iOS Companion is unaffected — its `video.webkitEnterFullscreen()` path runs before the new branch, and that path works correctly on iOS.

## Test plan
- [x] Reproduced original bug in Android emulator (system bar hides, card doesn't fill screen)
- [x] After fix in emulator: tap fullscreen pill → card fills the entire viewport edge-to-edge
- [x] Tap fullscreen pill again → exits cleanly, returns to normal layout
- [ ] Verify on a real Android device with HA Companion (Erik — if you have an Android device, could you verify this? It worked for me via the emulator, but real-device behaviour is sometimes slightly different)
- [x] iOS Companion unchanged — native video fullscreen still works
- [x] Desktop browsers unchanged — native `requestFullscreen` still used