### PR TITLE
fix: empty thumbnail tiles when the gallery has many videos

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -70,7 +70,7 @@ export const BAR_OPACITY_MIN = 0;
 export const BAR_OPACITY_MAX = 100;
 
 // -------- Sensor poster generation --------
-export const SENSOR_POSTER_CONCURRENCY = 16;
+export const SENSOR_POSTER_CONCURRENCY = 8;
 export const SENSOR_POSTER_QUEUE_LIMIT = 500;
 
 // -------- Long-press gestures --------

--- a/src/const.ts
+++ b/src/const.ts
@@ -70,8 +70,8 @@ export const BAR_OPACITY_MIN = 0;
 export const BAR_OPACITY_MAX = 100;
 
 // -------- Sensor poster generation --------
-export const SENSOR_POSTER_CONCURRENCY = 8;
-export const SENSOR_POSTER_QUEUE_LIMIT = 100;
+export const SENSOR_POSTER_CONCURRENCY = 16;
+export const SENSOR_POSTER_QUEUE_LIMIT = 500;
 
 // -------- Long-press gestures --------
 export const THUMB_LONG_PRESS_MOVE_PX = 12;

--- a/src/index.js
+++ b/src/index.js
@@ -692,8 +692,14 @@ class CameraGalleryCard extends LitElement {
     this._posterQueued.add(key);
     this._posterQueue.push(key);
 
+    // Cap by dropping the OLDEST entries (front of array). The naïve
+    // `length = …` truncate dropped from the END — i.e. the just-pushed
+    // item — and leaked `_posterQueued` state, so subsequent calls
+    // early-returned and the thumb was never generated.
     if (this._posterQueue.length > SENSOR_POSTER_QUEUE_LIMIT) {
-      this._posterQueue.length = SENSOR_POSTER_QUEUE_LIMIT;
+      const overflow = this._posterQueue.length - SENSOR_POSTER_QUEUE_LIMIT;
+      const dropped = this._posterQueue.splice(0, overflow);
+      for (const k of dropped) this._posterQueued.delete(k);
     }
 
     this._drainPosterQueue();
@@ -2855,7 +2861,10 @@ class CameraGalleryCard extends LitElement {
         }
       };
 
-      timeout = setTimeout(() => fail(new Error("poster timeout")), 3000);
+      // 10s — large MP4s with the moov atom at the end (common for hardware
+      // encoders) need extra time to expose metadata, even with
+      // `preload=metadata`. 3s was too tight on slow-disk HA hosts.
+      timeout = setTimeout(() => fail(new Error("poster timeout")), 10000);
       v.addEventListener(
         "error",
         () => {
@@ -2956,6 +2965,15 @@ class CameraGalleryCard extends LitElement {
   async _ensurePoster(src) {
     if (!src || this._posterCache.has(src) || this._posterPending.has(src)) return;
     if (this._posterFailed.has(src)) return;
+
+    // Fast-path for Frigate-served thumbnail URLs: HA's frontend cookie auth
+    // already covers `/api/frigate/...`, so an <img src> element can fetch it
+    // straight without the Bearer-fetch + base64 dance below.
+    if (/^\/api\/frigate\//.test(src)) {
+      this._posterCache.set(src, src);
+      this.requestUpdate();
+      return;
+    }
 
     const cached = this._lsThumbGet(src);
     if (cached) {


### PR DESCRIPTION
When a card has many videos in the gallery, some thumbnails never appear — they stay as a blank black tile with just the play icon. Two reasons:

**The thumbnail queue dropped the wrong end.** Thumbnails go through a queue capped at 100 items. When it filled up, the code threw away the *newest* item — the one just added — instead of the oldest. It also left a stale flag behind that prevented re-queueing. So the thumbnail you just opened was the first to get dropped.

**The timeout was too short.** Each video has 3 seconds to expose its first frame so the card can capture a thumbnail. For larger MP4s (30 MB+, common with doorbell cameras), the browser has to read further into the file to find the metadata. 3s isn't always enough → time-out → permanent black tile for that video within the session.

## What this changes

- Drop the *oldest* queued item when the queue fills up (and clear the stale flag so it can be re-tried).
- Bump timeout from 3s → 10s.
- Skip the heavy fetch-and-base64 dance for Frigate-served thumbnail URLs — cookie auth is enough for an `<img>` tag.
- Bump queue size 100 → 500 and concurrency 8 → 16 so big galleries don't hit the limit as easily.

## What you'll notice

- Thumbnails appear for all videos, not just the first batch.
- Bigger MP4s actually show their thumbnail instead of staying black.