### PR TITLE
feat: faster Frigate loading via direct WebSocket call

### DIFF
--- a/src/data/media-walker.ts
+++ b/src/data/media-walker.ts
@@ -40,8 +40,12 @@ import type { MediaSourceItem } from "../types/media-source";
 import { fnv1aHash } from "../util/hash";
 import {
   FRIGATE_SNAPSHOTS_ROOT,
+  FRIGATE_URI_PREFIX,
+  type FrigateEvent,
   fetchFrigateEvents,
+  fetchFrigateEventsViaWs,
   frigateEventIdMs,
+  frigateInstanceIdFromRoot,
   isFrigateRoot,
   mapFrigateEventToItem,
 } from "../util/frigate";
@@ -490,7 +494,118 @@ export class MediaSourceClient {
       return;
     }
 
+    // No `frigate_url` but Frigate event roots present → try the WS path
+    // through the Frigate-HA integration. One WS roundtrip returns all
+    // events with timestamps, no CORS, no per-folder browse storms. Falls
+    // through to the walker on failure.
+    const frigateRoots = roots.filter(isFrigateRoot);
+    if (frigateRoots.length > 0 && !failedRecently) {
+      const wsHandled = await this._loadFrigateWsPath(frigateRoots, config);
+      if (wsHandled) return;
+    }
+
     await this._loadWalkPath(roots, config);
+  }
+
+  /**
+   * Try the Frigate WS events path. Returns `true` when items were loaded
+   * (state was updated), `false` when nothing was returned and the caller
+   * should fall back to the walker. Aggregates events across all configured
+   * Frigate instances (one WS call per instance).
+   */
+  private async _loadFrigateWsPath(
+    frigateRoots: readonly string[],
+    config: CameraGalleryCardConfig
+  ): Promise<boolean> {
+    const hass = this._hass;
+    if (!hass) return false;
+    const cap = config.max_media ?? DEFAULT_MAX_MEDIA;
+    const key = `frigate_ws:${frigateRoots.slice().sort().join("|")}:${cap}`;
+    const sameKey = this.state.key === key;
+    const fresh = sameKey && Date.now() - (this.state.loadedAt ?? 0) < ENSURE_LOADED_FRESHNESS_MS;
+    if (this.state.loading || fresh) return true;
+
+    if (!sameKey) {
+      this.state.key = key;
+      this.setList([]);
+      this.state.urlCache = new Map();
+      this.resolveFailed = new Map();
+      this.state.frigateApiFailed = false;
+      this.state.frigateApiFailedAt = 0;
+    }
+
+    this.state.loading = true;
+    const gen = this._loadGeneration;
+    try {
+      const all: MsItem[] = [];
+      const seenIds = new Set<string>();
+      let anyResult = false;
+      // Match Frigate's own `.all` shortcut — high enough to span years of
+      // events. Frigate's default limit is 100 (too low).
+      const FRIGATE_WS_LIMIT = 10000;
+      for (const root of frigateRoots) {
+        if (this._isStale(gen)) return false;
+        const inst = frigateInstanceIdFromRoot(root);
+        if (!inst) continue;
+        const events: FrigateEvent[] | null = await fetchFrigateEventsViaWs(
+          hass,
+          inst,
+          FRIGATE_WS_LIMIT
+        );
+        if (!events) continue;
+        anyResult = true;
+        for (const ev of events) {
+          const eventId = String(ev?.id ?? "");
+          if (!eventId) continue;
+          const camera = String(ev?.camera ?? "");
+          if (!camera) continue;
+          const id = `${FRIGATE_URI_PREFIX}/${inst}/event/clips/${camera}/${eventId}`;
+          if (seenIds.has(id)) continue;
+          seenIds.add(id);
+          const startSec = Number(ev?.start_time ?? 0);
+          const dtMs =
+            Number.isFinite(startSec) && startSec > 0
+              ? Math.round(startSec * 1000)
+              : (frigateEventIdMs(id) ?? 0);
+          if (!dtMs) continue;
+          const label = String(ev?.label ?? "");
+          const title = [new Date(dtMs).toLocaleString(), camera, label]
+            .filter(Boolean)
+            .join(" — ");
+          all.push({
+            id,
+            title,
+            cls: "video",
+            mime: "video/mp4",
+            // Notifications proxy is permissive (cookie auth via <img src>) —
+            // the strict /thumbnail/<id> route requires a Bearer header that
+            // an <img> can't send.
+            thumb: `/api/frigate/${inst}/notifications/${eventId}/thumbnail.jpg`,
+            dtMs,
+          });
+        }
+      }
+      if (this._isStale(gen)) return false;
+      if (!anyResult) {
+        // No instance returned anything — let the walker try.
+        this.state.loading = false;
+        return false;
+      }
+      all.sort((a, b) => (b.dtMs ?? 0) - (a.dtMs ?? 0));
+      this.setList(all.slice(0, cap));
+      this.state.loadedAt = Date.now();
+      return true;
+    } catch (e) {
+      if (this._isStale(gen)) return false;
+      console.warn("CGC Frigate WS load failed:", e);
+      this.setList([]);
+      return false;
+    } finally {
+      if (!this._isStale(gen)) {
+        this.state.loading = false;
+        this._fireChange();
+      }
+    }
   }
 
   private async _loadFrigateApiPath(

--- a/src/util/frigate.ts
+++ b/src/util/frigate.ts
@@ -155,3 +155,59 @@ export function mapFrigateEventToItem(ev: FrigateEvent, base: string): MappedFri
   };
   return { item, clipUrl };
 }
+
+// ---------- WebSocket via Frigate-HA integration ----------
+
+/**
+ * Fetch Frigate events via the Frigate-hass-integration's
+ * `frigate/events/get` WebSocket command. Same payload shape as the REST
+ * endpoint, but routed through HA — so it works regardless of CORS and
+ * without needing a `frigate_url` in the card config.
+ *
+ * Returns null on any failure (no instance id, integration missing, transport
+ * error). Caller treats null as "no events" and falls back to the REST/walk path.
+ */
+interface HassLike {
+  callWS<T>(msg: Record<string, unknown>): Promise<T>;
+}
+export async function fetchFrigateEventsViaWs(
+  hass: HassLike | null | undefined,
+  instanceId: string | null | undefined,
+  limit?: number
+): Promise<FrigateEvent[] | null> {
+  if (!hass || !instanceId) return null;
+  try {
+    const msg: Record<string, unknown> = {
+      type: "frigate/events/get",
+      instance_id: instanceId,
+      has_clip: true,
+    };
+    if (typeof limit === "number" && limit > 0) msg["limit"] = limit;
+    const result = await hass.callWS<unknown>(msg);
+    // Frigate-hass-integration's WS handler ships the response with
+    // `decode_json=False`, so we get the raw JSON string here. Parse it.
+    let parsed: unknown = result;
+    if (typeof parsed === "string") {
+      try {
+        parsed = JSON.parse(parsed);
+      } catch {
+        return null;
+      }
+    }
+    if (Array.isArray(parsed)) return parsed as FrigateEvent[];
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the Frigate instance id from a media-source URI like
+ * `media-source://frigate/<inst>/event-search/clips`. Returns null when the
+ * URI isn't a Frigate root.
+ */
+export function frigateInstanceIdFromRoot(uri: string | null | undefined): string | null {
+  const s = String(uri ?? "");
+  const m = s.match(/^media-source:\/\/frigate\/([^/]+)/);
+  return m?.[1] ?? null;
+}


### PR DESCRIPTION
The card currently loads Frigate events by browsing media-source folders one by one. For a setup with thousands of events, that can take several seconds and triggers many WebSocket calls.

The Frigate-HA integration already exposes a `frigate/events/get` WebSocket command that returns all events in a single call. This PR uses that path before falling back to the slower folder walk.

## What this changes

- New `_loadFrigateWsPath` method on `MediaSourceClient` that calls `frigate/events/get`.
- Tried after the REST path (when `frigate_url` is set) and before the recursive walker.
- One roundtrip per Frigate instance returns all events (with timestamps, camera, label).
- Falls back to the walker if the integration isn't installed or returns nothing.

## What you'll notice

- Frigate clips appear (almost) instantly when opening the card.
- No need to set `frigate_url` to get fast loading.
- Works regardless of CORS — the WS goes through HA, not directly to Frigate.