### PR TITLE
perf: lazy-load thumbnails + pause polling on hidden tabs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -260,11 +260,19 @@ class CameraGalleryCard extends LitElement {
     this._onVisibilityChange = () => {
       if (document.hidden) {
         this._stopMediaPoll();
+        this._perfCounters.visibilityHidden++;
+        if (this.config?.debug_enabled === true) {
+          console.info("[cgc] visibility: hidden, poll paused");
+        }
       } else {
         // Force-fresh on return from hidden — the cached state could be
         // ENSURE_LOADED_FRESHNESS_MS (30s) stale or worse.
         this._mediaClient?.invalidate?.();
         this._startMediaPoll();
+        this._perfCounters.visibilityVisible++;
+        if (this.config?.debug_enabled === true) {
+          console.info("[cgc] visibility: visible, poll resumed");
+        }
       }
     };
 
@@ -379,6 +387,21 @@ class CameraGalleryCard extends LitElement {
     this._thumbObserver = null;
     this._thumbObserverRoot = null;
     this._observedThumbs = new WeakSet();
+
+    // Perf counters surfaced in the Diagnostics modal when debug_enabled.
+    // Lets users (and reviewers) verify the lazy-load + visibility pause
+    // are doing what they should: high observer share = lazy is working;
+    // visibility hidden/visible bumps = poll-pause is firing.
+    this._perfCounters = {
+      thumbsRevealed: 0,
+      postersEnqueued: 0,
+      postersEnqueuedFromObserver: 0,
+      pollsStarted: 0,
+      pollsStopped: 0,
+      visibilityHidden: 0,
+      visibilityVisible: 0,
+      sessionStartedAt: Date.now(),
+    };
   }
 
   _startMediaPoll() {
@@ -389,12 +412,14 @@ class CameraGalleryCard extends LitElement {
       this._mediaClient.invalidate();
       this._mediaClient.ensureLoaded();
     }, 30_000);
+    if (this._perfCounters) this._perfCounters.pollsStarted++;
   }
 
   _stopMediaPoll() {
     if (this._mediaPollInterval) {
       clearInterval(this._mediaPollInterval);
       this._mediaPollInterval = null;
+      if (this._perfCounters) this._perfCounters.pollsStopped++;
     }
   }
 
@@ -696,7 +721,7 @@ class CameraGalleryCard extends LitElement {
     this._ensurePreviewVideoHostPlayback(selectedUrl);
   }
 
-  _enqueuePoster(src) {
+  _enqueuePoster(src, source = "?") {
     const key = String(src || "").trim();
     if (!key) return;
     if (this._posterCache.has(key)) return;
@@ -707,6 +732,11 @@ class CameraGalleryCard extends LitElement {
 
     this._posterQueued.add(key);
     this._posterQueue.push(key);
+    this._perfCounters.postersEnqueued++;
+    if (source === "observer") this._perfCounters.postersEnqueuedFromObserver++;
+    if (this.config?.debug_enabled === true) {
+      console.info(`[cgc] poster enqueue (${source}):`, key.length > 80 ? key.slice(0, 77) + "…" : key);
+    }
 
     if (this._posterQueue.length > SENSOR_POSTER_QUEUE_LIMIT) {
       this._posterQueue.length = SENSOR_POSTER_QUEUE_LIMIT;
@@ -756,7 +786,7 @@ class CameraGalleryCard extends LitElement {
       const src = String(it?.src || "");
       if (!src) continue;
       if (!isVideo(src)) continue;
-      this._enqueuePoster(src);
+      this._enqueuePoster(src, "queue-sensor-work");
     }
   }
 
@@ -814,7 +844,7 @@ class CameraGalleryCard extends LitElement {
         // Enqueue poster pas na laden: voorkomt dat de capture de preview-verbinding blokkeert
         const urlForPoster = selectedUrl;
         video.addEventListener("canplay", () => {
-          if (!this._posterCache.has(urlForPoster)) this._enqueuePoster(urlForPoster);
+          if (!this._posterCache.has(urlForPoster)) this._enqueuePoster(urlForPoster, "preview-canplay");
         }, { once: true });
       }
 
@@ -1255,6 +1285,24 @@ class CameraGalleryCard extends LitElement {
         ["Live card mounted", this._liveCard ? "yes" : "no", this._liveCard ? "ok" : (cfg.live_enabled ? "warn" : null)],
         ["Live layout override", this._liveLayoutOverride || "—"],
       ]],
+      ["Perf counters (this session)", "mdi:gauge", (() => {
+        const pc = this._perfCounters || {};
+        const sessionMs = Date.now() - (pc.sessionStartedAt || Date.now());
+        const sessionMin = Math.max(1, Math.round(sessionMs / 60000));
+        const observerShare =
+          pc.postersEnqueued > 0
+            ? `${Math.round((pc.postersEnqueuedFromObserver / pc.postersEnqueued) * 100)}%`
+            : "—";
+        return [
+          ["Session length", `${sessionMin} min`],
+          ["Tiles revealed (visible)", String(pc.thumbsRevealed || 0)],
+          ["Posters enqueued (total)", String(pc.postersEnqueued || 0)],
+          ["Posters enqueued from observer", `${pc.postersEnqueuedFromObserver || 0} (${observerShare})`],
+          ["Polls started / stopped", `${pc.pollsStarted || 0} / ${pc.pollsStopped || 0}`],
+          ["Visibility hidden / visible", `${pc.visibilityHidden || 0} / ${pc.visibilityVisible || 0}`],
+          ["Poll currently active", this._mediaPollInterval ? "yes" : "no", this._mediaPollInterval ? "ok" : null],
+        ];
+      })()],
       ["Live cameras", "mdi:cctv", (() => {
         const cams = Array.isArray(cfg.live_camera_entities) ? cfg.live_camera_entities : [];
         if (!cams.length) return [["(no cameras configured)", "—"]];
@@ -2812,7 +2860,7 @@ class CameraGalleryCard extends LitElement {
       if (jpgUrl) {
         const cached = this._posterCache.get(jpgUrl);
         if (cached) return cached;
-        this._enqueuePoster(jpgUrl);
+        this._enqueuePoster(jpgUrl, "resolve-paired-jpg");
         return "";
       }
       this._mediaClient.queueResolve([pairedJpgId]);
@@ -2834,7 +2882,7 @@ class CameraGalleryCard extends LitElement {
       const cached = this._posterCache.get(url);
       if (cached) return cached;
       const skipForPreview = previewOwnsSelectedPoster && url === selectedUrl;
-      if (!skipForPreview) this._enqueuePoster(url);
+      if (!skipForPreview) this._enqueuePoster(url, "resolve-video-poster");
       return "";
     }
     return "";
@@ -3848,12 +3896,16 @@ class CameraGalleryCard extends LitElement {
               const key = entry.target.dataset.lazySrc;
               if (key && !this._revealedThumbs.has(key)) {
                 this._revealedThumbs.add(key);
+                this._perfCounters.thumbsRevealed++;
+                if (this.config?.debug_enabled === true) {
+                  console.info("[cgc] tile reveal:", key.length > 80 ? key.slice(0, 77) + "…" : key);
+                }
                 changed = true;
               }
               // Viewport-aware poster prioritization: enqueue only when visible
               if (usingSensor && key && isVideo(key)) {
                 const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(key);
-                this._enqueuePoster(pairedJpg || key);
+                this._enqueuePoster(pairedJpg || key, "observer");
               }
               // Media-source items: also lazy. Use the meta thumb URL when
               // the resolved URL hasn't arrived yet — observer fires once
@@ -3862,7 +3914,7 @@ class CameraGalleryCard extends LitElement {
                 const meta = this._mediaClient.getMetaById(key);
                 const fallback = meta?.thumb || "";
                 if (fallback && !this._posterCache.has(fallback)) {
-                  this._enqueuePoster(fallback);
+                  this._enqueuePoster(fallback, "observer");
                 }
               }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -254,6 +254,20 @@ class CameraGalleryCard extends LitElement {
       this.requestUpdate();
     };
 
+    // Pause the 30s media poll when the tab is hidden (background browser tab,
+    // phone screen off, etc.) — saves both bandwidth and battery. On return
+    // we force one immediate refresh so the gallery is current.
+    this._onVisibilityChange = () => {
+      if (document.hidden) {
+        this._stopMediaPoll();
+      } else {
+        // Force-fresh on return from hidden — the cached state could be
+        // ENSURE_LOADED_FRESHNESS_MS (30s) stale or worse.
+        this._mediaClient?.invalidate?.();
+        this._startMediaPoll();
+      }
+    };
+
     this._onZoomTouchStart = (e) => {
       if (!this._isLiveActive() && !this._previewOpen) return;
       if (this._isGridLayout()) return;
@@ -388,6 +402,7 @@ class CameraGalleryCard extends LitElement {
     super.connectedCallback();
     document.addEventListener("fullscreenchange", this._onFullscreenChange);
     document.addEventListener("webkitfullscreenchange", this._onFullscreenChange);
+    document.addEventListener("visibilitychange", this._onVisibilityChange);
     this.addEventListener('touchstart', this._onZoomTouchStart, { passive: false });
     this.addEventListener('touchmove', this._onZoomTouchMove, { passive: false });
     this.addEventListener('touchend', this._onZoomTouchEnd);
@@ -409,6 +424,7 @@ class CameraGalleryCard extends LitElement {
 
     document.removeEventListener("fullscreenchange", this._onFullscreenChange);
     document.removeEventListener("webkitfullscreenchange", this._onFullscreenChange);
+    document.removeEventListener("visibilitychange", this._onVisibilityChange);
     this.removeEventListener('touchstart', this._onZoomTouchStart);
     this.removeEventListener('touchmove', this._onZoomTouchMove);
     this.removeEventListener('touchend', this._onZoomTouchEnd);
@@ -3825,7 +3841,8 @@ class CameraGalleryCard extends LitElement {
       this._thumbObserver = new IntersectionObserver(
         (entries) => {
           let changed = false;
-          const isSensor = this.config?.source_mode === "sensor" || this.config?.source_mode === "combined";
+          const usingSensor = this.config?.source_mode === "sensor" || this.config?.source_mode === "combined";
+          const usingMedia = this.config?.source_mode === "media" || this.config?.source_mode === "combined";
           for (const entry of entries) {
             if (entry.isIntersecting) {
               const key = entry.target.dataset.lazySrc;
@@ -3834,9 +3851,19 @@ class CameraGalleryCard extends LitElement {
                 changed = true;
               }
               // Viewport-aware poster prioritization: enqueue only when visible
-              if (isSensor && key && isVideo(key)) {
+              if (usingSensor && key && isVideo(key)) {
                 const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(key);
                 this._enqueuePoster(pairedJpg || key);
+              }
+              // Media-source items: also lazy. Use the meta thumb URL when
+              // the resolved URL hasn't arrived yet — observer fires once
+              // per tile, so no risk of double-enqueue.
+              if (usingMedia && key && isMediaSourceId(key)) {
+                const meta = this._mediaClient.getMetaById(key);
+                const fallback = meta?.thumb || "";
+                if (fallback && !this._posterCache.has(fallback)) {
+                  this._enqueuePoster(fallback);
+                }
               }
             }
           }
@@ -4321,20 +4348,19 @@ class CameraGalleryCard extends LitElement {
                       ? this._resolveVideoPoster(it, isMs, thumbUrl, tThumb, selectedUrl)
                       : thumbUrl;
                     // For unresolved MS images, use the browse_media thumbnail as fallback
-                    // so the thumbnail appears immediately while the full URL is still resolving
+                    // so the thumbnail appears once the IntersectionObserver fires for it.
+                    // The observer drives the actual enqueue — render no longer kicks it.
                     if (!isVid && !poster && isMs && tThumb) {
                       poster = this._posterCache.get(tThumb) || "";
-                      if (!poster) this._enqueuePoster(tThumb);
                     }
 
                     const needsResolve = isMs;
                     const hasUrl = !needsResolve || !!thumbUrl || !!tThumb || !!poster;
-                    // For media source: show as soon as poster is ready — no observer gate needed
-                    // because we eagerly resolve all visible items. For sensor mode: keep lazy
-                    // reveal via IntersectionObserver to avoid loading off-screen video frames.
-                    const showImg = isMs
-                      ? (hasUrl && !!poster)
-                      : (this._revealedThumbs.has(it.src) && hasUrl && !!poster);
+                    // Lazy reveal for both modes — IntersectionObserver gates poster
+                    // generation to only the visible (or about-to-be-visible) tiles.
+                    // Without this, a 50-item gallery loads 50 video metadata blocks
+                    // up front even though the user only sees ~10.
+                    const showImg = this._revealedThumbs.has(it.src) && hasUrl && !!poster;
 
                     const tTime = Number.isFinite(it.dtMs)
                       ? formatTimeFromMs(it.dtMs, this._hass?.locale)

--- a/src/index.js
+++ b/src/index.js
@@ -4111,6 +4111,11 @@ class CameraGalleryCard extends LitElement {
     `;
     const galleryPillsRight = html`
       <div class="gallery-pills-right">
+        ${this.config?.debug_enabled ? html`
+          <button class="gallery-pill live-pill-btn" title="Diagnostics" @pointerdown=${(e) => e.stopPropagation()} @click=${(e) => { e.stopPropagation(); this._openDebug(); }}>
+            <ha-icon icon="mdi:bug-outline"></ha-icon>
+          </button>
+        ` : html``}
         ${!selectedIsVideo && selectedHasUrl && !noResultsForFilter ? html`
           <button class="gallery-pill live-pill-btn" @pointerdown=${(e) => e.stopPropagation()} @click=${(e) => { e.stopPropagation(); this._openImageFullscreen(); }}>
             <ha-icon icon="mdi:fullscreen"></ha-icon>


### PR DESCRIPTION
Two complementary network-I/O reductions, both small and orthogonal.

## What was happening

Two cases where the card was doing more work than the user could see:

**1. Media-mode thumbnails were eagerly loaded.** The card already had an IntersectionObserver-driven lazy reveal for sensor-mode tiles, but media-source items skipped that path entirely — every visible-window item enqueued its poster on every render, regardless of whether it was actually on screen. A 50-item gallery would load 50 video metadata blocks even if the user only saw 10.

**2. The 30s media poll kept running on hidden tabs.** A dashboard left open on a phone in your pocket, or a background browser tab, kept polling `media_source/browse_media` every 30 seconds. Wasted bandwidth and battery.

## What this changes

- **Extend the existing lazy-reveal observer** to media-mode items too. Both modes now wait for a tile to enter (or come within 200px of) the viewport before kicking off poster work.
- **Pause the media poll while the tab is hidden** via the Page Visibility API. On return, force one immediate refresh so the gallery is current.

## What you'll notice

- Faster first paint on busy galleries — the card stops trying to generate posters for items the user can't see.
- Galleries left open on phones / background tabs no longer drain battery polling for updates.

## What stays the same

- Behaviour of the live view, day-picker, filters, delete, etc. is unchanged.
- The lazy logic only gates *poster fetching*. Tile chrome (date / time / play icon) renders for every item as before.