### PR TITLE
feat: optional Frigate clip delete via rest_command service

### DIFF
--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -176,6 +176,7 @@ export const cameraGalleryCardConfigStruct = type({
   allow_bulk_delete: defaulted(boolean(), DEFAULT_ALLOW_BULK_DELETE),
   delete_confirm: defaulted(boolean(), DEFAULT_DELETE_CONFIRM),
   delete_service: defaulted(serviceId, DEFAULT_DELETE_SERVICE),
+  frigate_delete_service: defaulted(serviceId, ""),
 
   // ─── Object filters ────────────────────────────────────────
   // The loose `string | { name: icon }` input shape is unwrapped in

--- a/src/data/delete-service.spec.ts
+++ b/src/data/delete-service.spec.ts
@@ -6,7 +6,7 @@ import { canDeleteItem, deleteItem } from "./delete-service";
 
 type Config = Pick<
   CameraGalleryCardConfig,
-  "source_mode" | "allow_delete" | "delete_service" | "delete_confirm"
+  "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service" | "delete_confirm"
 >;
 
 const cfg = (overrides: Partial<Config> = {}): Config =>
@@ -14,9 +14,12 @@ const cfg = (overrides: Partial<Config> = {}): Config =>
     source_mode: "sensor",
     allow_delete: true,
     delete_service: "shell_command.delete_clip",
+    frigate_delete_service: "",
     delete_confirm: false,
     ...overrides,
   }) as Config;
+
+const FRIGATE_SRC = "media-source://frigate/frigate/event/clips/achtertuin/1778250346.47892-y8byzk";
 
 describe("canDeleteItem — matrix gate", () => {
   it("returns false when src is missing", () => {
@@ -166,5 +169,137 @@ describe("deleteItem", () => {
       srcEntityMap: new Map(),
     });
     expect(ok).toBe(false);
+  });
+});
+
+describe("Frigate delete path", () => {
+  describe("canDeleteItem", () => {
+    it("enables delete on a Frigate event when frigate_delete_service is set", () => {
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({
+            source_mode: "media",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(true);
+    });
+
+    it("disables delete on a Frigate event when frigate_delete_service is empty", () => {
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({ source_mode: "media", frigate_delete_service: "" }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(false);
+    });
+
+    it("works for Frigate items even in combined mode without sensor backing", () => {
+      // The Frigate path is independent of the sensor-backed gate.
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({
+            source_mode: "combined",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(true);
+    });
+
+    it("respects allow_delete=false even when frigate_delete_service is set", () => {
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({
+            allow_delete: false,
+            source_mode: "media",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(false);
+    });
+
+    it("rejects Frigate URIs with no parseable event id", () => {
+      // Recordings root has no event id in the URI.
+      expect(
+        canDeleteItem({
+          src: "media-source://frigate/frigate/recordings/2026-05-10/12",
+          config: cfg({
+            source_mode: "media",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("deleteItem", () => {
+    it("calls the configured rest_command with event_id and camera", async () => {
+      const hass = makeFakeHass();
+      const ok = await deleteItem({
+        hass,
+        src: FRIGATE_SRC,
+        config: cfg({
+          source_mode: "media",
+          frigate_delete_service: "rest_command.delete_frigate",
+          delete_confirm: false,
+        }),
+        srcEntityMap: new Map(),
+      });
+      expect(ok).toBe(true);
+      expect(hass.serviceCalls).toHaveLength(1);
+      const call = hass.serviceCalls[0]!;
+      expect(call.domain).toBe("rest_command");
+      expect(call.service).toBe("delete_frigate");
+      expect(call.data).toEqual({
+        event_id: "1778250346.47892-y8byzk",
+        camera: "achtertuin",
+      });
+    });
+
+    it("returns false when user cancels the confirm prompt", async () => {
+      const hass = makeFakeHass();
+      const confirm = vi.fn(() => false);
+      const ok = await deleteItem({
+        hass,
+        src: FRIGATE_SRC,
+        config: cfg({
+          source_mode: "media",
+          frigate_delete_service: "rest_command.delete_frigate",
+          delete_confirm: true,
+        }),
+        srcEntityMap: new Map(),
+        confirm,
+      });
+      expect(ok).toBe(false);
+      expect(confirm).toHaveBeenCalled();
+      expect(hass.serviceCalls).toHaveLength(0);
+    });
+
+    it("falls through to sensor path when src isn't a Frigate event", async () => {
+      const hass = makeFakeHass();
+      const ok = await deleteItem({
+        hass,
+        src: "/config/www/foo.mp4",
+        config: cfg({
+          source_mode: "sensor",
+          delete_service: "shell_command.delete_clip",
+          frigate_delete_service: "rest_command.delete_frigate",
+        }),
+        srcEntityMap: new Map(),
+      });
+      expect(ok).toBe(true);
+      const call = hass.serviceCalls[0]!;
+      expect(call.domain).toBe("shell_command");
+      expect(call.service).toBe("delete_clip");
+      expect(call.data).toHaveProperty("path");
+    });
   });
 });

--- a/src/data/delete-service.ts
+++ b/src/data/delete-service.ts
@@ -21,31 +21,55 @@
 import { DELETE_PREFIX_NORMALIZED } from "../const";
 import type { CameraGalleryCardConfig } from "../config/normalize";
 import type { HomeAssistant } from "../types/hass";
+import { frigateEventIdFromSrc, isFrigateRoot } from "../util/frigate";
 import { parseServiceParts, toFsPath } from "./sensor-source";
 
 export interface CanDeleteArgs {
   /** The src field from a CardItem. */
   src: string | undefined;
   /** Normalized config — only the fields below are read. */
-  config: Pick<CameraGalleryCardConfig, "source_mode" | "allow_delete" | "delete_service"> | null;
+  config: Pick<
+    CameraGalleryCardConfig,
+    "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service"
+  > | null;
   /** From `SensorSourceClient.getSrcEntityMap()`. Required for combined-mode gate. */
   srcEntityMap: ReadonlyMap<string, string>;
 }
 
 /**
+ * `true` when `src` is a Frigate event item AND a `frigate_delete_service`
+ * is configured. Used both as a delete-eligibility check and as the
+ * dispatch switch in `deleteItem`. Requires the URI to carry a parseable
+ * Frigate event id (snapshots and clip events qualify; recordings don't).
+ */
+function isFrigateDeleteEligible(
+  src: string | undefined,
+  config: Pick<CameraGalleryCardConfig, "frigate_delete_service"> | null
+): boolean {
+  if (!src) return false;
+  if (!isFrigateRoot(src)) return false;
+  if (frigateEventIdFromSrc(src) === null) return false;
+  return parseServiceParts(config?.frigate_delete_service) !== null;
+}
+
+/**
  * Return `true` iff the thumb's trash icon should appear:
- *   - mode is `sensor` or `combined`
- *   - in combined mode, the item is sensor-backed (entry in the map)
- *   - `allow_delete` is on
- *   - `delete_service` parses as `domain.service`
+ *   - sensor item: mode is `sensor` or `combined` (with sensor-backed src),
+ *     `allow_delete` is on, and `delete_service` parses.
+ *   - Frigate event item (any mode): `frigate_delete_service` is configured
+ *     and `allow_delete` is on. The two paths are independent — a setup
+ *     can have only-sensor-delete, only-Frigate-delete, or both.
  */
 export function canDeleteItem(args: CanDeleteArgs): boolean {
   const { src, config, srcEntityMap } = args;
   if (!src) return false;
+  if (!config?.allow_delete) return false;
+  // Frigate path — works in any mode where the item is a Frigate event.
+  if (isFrigateDeleteEligible(src, config)) return true;
+  // Sensor / combined-sensor-backed path.
   const mode = config?.source_mode;
   if (mode !== "sensor" && mode !== "combined") return false;
   if (mode === "combined" && !srcEntityMap.has(src)) return false;
-  if (!config?.allow_delete) return false;
   return parseServiceParts(config?.delete_service) !== null;
 }
 
@@ -54,7 +78,7 @@ export interface DeleteItemArgs {
   src: string;
   config: Pick<
     CameraGalleryCardConfig,
-    "source_mode" | "allow_delete" | "delete_service" | "delete_confirm"
+    "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service" | "delete_confirm"
   > | null;
   srcEntityMap: ReadonlyMap<string, string>;
   /** Confirm prompt; defaults to `window.confirm`. Inject for tests. */
@@ -62,19 +86,51 @@ export interface DeleteItemArgs {
 }
 
 /**
- * Invoke the configured `delete_service` for `src`. Returns `true` on
- * success, `false` on every gate failure (mode wrong, prefix mismatch,
- * user cancelled the confirm, callService threw).
+ * Invoke the appropriate delete service for `src`. Two dispatch paths:
  *
- * The path-prefix gate (`fsPath.startsWith(DELETE_PREFIX_NORMALIZED)`)
- * is the safety net that prevents a malformed `src` from passing an
- * arbitrary filesystem path to the user's shell command.
+ *   1. **Frigate event item** — calls `frigate_delete_service` with
+ *      `{ event_id, camera }` so the configured `rest_command` can hit
+ *      Frigate's `DELETE /api/events/<id>` endpoint via HA (no CORS,
+ *      no `frigate_url` required).
+ *
+ *   2. **Sensor / combined-sensor item** — calls `delete_service` with
+ *      `{ path }` (the legacy shell-command flow). The path-prefix gate
+ *      (`fsPath.startsWith(DELETE_PREFIX_NORMALIZED)`) prevents a
+ *      malformed `src` from passing an arbitrary filesystem path to
+ *      the user's shell command.
+ *
+ * Returns `true` on success, `false` on any gate failure (mode wrong,
+ * prefix mismatch, user cancelled, callService threw).
  */
 export async function deleteItem(args: DeleteItemArgs): Promise<boolean> {
   const { hass, src, config, srcEntityMap, confirm = defaultConfirm } = args;
   if (!hass) return false;
   if (!canDeleteItem({ src, config, srcEntityMap })) return false;
 
+  // Frigate dispatch wins when the URI is a Frigate event AND the
+  // service is configured — leaves the sensor path alone in combined
+  // setups for non-Frigate items.
+  if (isFrigateDeleteEligible(src, config)) {
+    const sp = parseServiceParts(config?.frigate_delete_service);
+    if (!sp) return false;
+    const eventId = frigateEventIdFromSrc(src);
+    if (!eventId) return false;
+    if (config?.delete_confirm) {
+      if (!confirm("Delete this Frigate event?")) return false;
+    }
+    // Camera segment: `media-source://frigate/<inst>/event/clips/<camera>/<id>`.
+    // Some users template `{{ camera }}` into their rest_command for path
+    // interpolation; pass it through alongside `event_id`.
+    const camera = extractFrigateCameraFromSrc(src);
+    try {
+      await hass.callService(sp.domain, sp.service, { event_id: eventId, camera });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Sensor / combined-sensor path.
   const sp = parseServiceParts(config?.delete_service);
   if (!sp) return false;
 
@@ -91,6 +147,13 @@ export async function deleteItem(args: DeleteItemArgs): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/** Extract the camera segment from a Frigate event URI. Returns "" when not parseable. */
+function extractFrigateCameraFromSrc(src: string): string {
+  // Shape: `media-source://frigate/<inst>/event/<media_type>/<camera>/<event_id>`
+  const m = String(src ?? "").match(/^media-source:\/\/frigate\/[^/]+\/event\/[^/]+\/([^/]+)\//);
+  return m?.[1] ?? "";
 }
 
 function defaultConfirm(message: string): boolean {

--- a/src/util/frigate.ts
+++ b/src/util/frigate.ts
@@ -66,6 +66,18 @@ export function frigateEventIdMs(src: string): number | null {
   return sec * 1000;
 }
 
+/**
+ * Extract the raw event id (`<unix_epoch>.<micros>-<random>`) from a Frigate
+ * media-source URI or REST URL. This is the form Frigate's
+ * `DELETE /api/events/<id>` endpoint expects.
+ */
+export function frigateEventIdFromSrc(src: string | null | undefined): string | null {
+  const m = String(src ?? "").match(
+    /(?:^|[/_.-])(\d{9,11}(?:\.\d+)?-[a-z0-9]+)(?:\.[a-z0-9]+)?(?:[/?#]|$)/i
+  );
+  return m?.[1] ?? null;
+}
+
 // ---------- REST API ----------
 
 /** Subset of fields the card consumes from a Frigate API event. */


### PR DESCRIPTION
The card has always had a delete button, but only for sensor-mode items (where the path can be passed to a shell_command). Frigate clips were stuck — you had to switch to Frigate's web UI to wipe one.

This PR adds an optional second delete path that sends the event id to a rest_command (or any HA service) the user has wired up. The trash icon now appears on Frigate clips too, when configured.

## How a user enables it

One-time, in `configuration.yaml`:

```yaml
rest_command:
  delete_frigate:
    url: http://frigate:5000/api/events/{{ event_id }}
    method: DELETE
```

Then on the card:

```yaml
frigate_delete_service: rest_command.delete_frigate
```

That's it. Trash icon now works on Frigate event tiles.

## How it works

- `canDeleteItem` has a Frigate-eligibility branch independent of the sensor gate. A setup can have sensor-only delete, Frigate-only delete, or both — they're orthogonal.
- `deleteItem` detects Frigate event URIs (parseable event id, root under `media-source://frigate/`) and dispatches to the configured service with `{ event_id, camera }` instead of the sensor path's `{ path }`.
- The two service-call shapes don't collide: sensor uses `path`, Frigate uses `event_id`/`camera`. Users can hook either into a `rest_command` or `shell_command` template however they like.

## What it doesn't do

- **Bulk-delete stays sensor-only.** Frigate retention prunes automatically and the manual cleanup case is rare; can revisit if there's demand.
- No editor UI yet — YAML only. Editor toggle is a follow-up if the feature lands well.
- Recordings roots (no event id in URI) aren't eligible — only event clips and snapshots.

## Tests

8 new specs in `delete-service.spec.ts` cover: gate eligibility, allow_delete respected, recordings rejected, service call shape, confirm flow, fall-through to sensor path for non-Frigate items.