### PR TITLE
fix: keep WebSocket fallback alive when Direct API fails

### DIFF
--- a/src/data/media-walker.ts
+++ b/src/data/media-walker.ts
@@ -670,8 +670,12 @@ export class MediaSourceClient {
     const frigateRoots = roots.filter(isFrigateRoot);
     const otherRoots = roots.filter((r) => !isFrigateRoot(r));
 
+    // WS path is independent of `frigate_url` — don't gate it on the REST
+    // API's recent-failure flag. Otherwise a transient REST failure (wrong
+    // URL, network blip, CORS) takes the WS fallback offline too, leaving
+    // the gallery empty for FRIGATE_API_RETRY_AFTER_MS.
     let frigateItems: MsItem[] = [];
-    if (frigateRoots.length > 0 && !failedRecently) {
+    if (frigateRoots.length > 0) {
       frigateItems = await this._fetchFrigateWsItems(frigateRoots, config);
     }
 


### PR DESCRIPTION
## What I ran into

`frigate_url` failed (network blip, mixed-content, typo) and the
gallery stayed empty for 5 minutes. Diagnostics:

- Direct API: failed
- WS subscribe: active
- Items in gallery: **0**

WS was active but not being used.

## Cause

When REST fails, the card sets a 5-min "recently failed" flag to
stop hammering the dead endpoint — but the same flag also gated the
WS fallback. So one REST blip = 5 min downtime.

## Fix

WS doesn't depend on `frigate_url` and shouldn't share the REST flag:

```diff
- if (frigateRoots.length > 0 && !failedRecently) {
+ if (frigateRoots.length > 0) {
```

## Test plan

- [x] Set bad `frigate_url`, reload → items still load via WS
- [x] Remove `frigate_url` → default path still works