### PR TITLE
feat: delete frigate clips from the gallery

### DIFF
--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -178,6 +178,7 @@ export const cameraGalleryCardConfigStruct = type({
   allow_bulk_delete: defaulted(boolean(), DEFAULT_ALLOW_BULK_DELETE),
   delete_confirm: defaulted(boolean(), DEFAULT_DELETE_CONFIRM),
   delete_service: defaulted(serviceId, DEFAULT_DELETE_SERVICE),
+  frigate_delete_service: defaulted(serviceId, ""),
 
   // ─── Object filters ────────────────────────────────────────
   // The loose `string | { name: icon }` input shape is unwrapped in

--- a/src/data/delete-service.spec.ts
+++ b/src/data/delete-service.spec.ts
@@ -6,7 +6,7 @@ import { canDeleteItem, deleteItem } from "./delete-service";
 
 type Config = Pick<
   CameraGalleryCardConfig,
-  "source_mode" | "allow_delete" | "delete_service" | "delete_confirm"
+  "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service" | "delete_confirm"
 >;
 
 const cfg = (overrides: Partial<Config> = {}): Config =>
@@ -14,9 +14,12 @@ const cfg = (overrides: Partial<Config> = {}): Config =>
     source_mode: "sensor",
     allow_delete: true,
     delete_service: "shell_command.delete_clip",
+    frigate_delete_service: "",
     delete_confirm: false,
     ...overrides,
   }) as Config;
+
+const FRIGATE_SRC = "media-source://frigate/frigate/event/clips/achtertuin/1778250346.47892-y8byzk";
 
 describe("canDeleteItem — matrix gate", () => {
   it("returns false when src is missing", () => {
@@ -166,5 +169,137 @@ describe("deleteItem", () => {
       srcEntityMap: new Map(),
     });
     expect(ok).toBe(false);
+  });
+});
+
+describe("Frigate delete path", () => {
+  describe("canDeleteItem", () => {
+    it("enables delete on a Frigate event when frigate_delete_service is set", () => {
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({
+            source_mode: "media",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(true);
+    });
+
+    it("disables delete on a Frigate event when frigate_delete_service is empty", () => {
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({ source_mode: "media", frigate_delete_service: "" }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(false);
+    });
+
+    it("works for Frigate items even in combined mode without sensor backing", () => {
+      // The Frigate path is independent of the sensor-backed gate.
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({
+            source_mode: "combined",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(true);
+    });
+
+    it("respects allow_delete=false even when frigate_delete_service is set", () => {
+      expect(
+        canDeleteItem({
+          src: FRIGATE_SRC,
+          config: cfg({
+            allow_delete: false,
+            source_mode: "media",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(false);
+    });
+
+    it("rejects Frigate URIs with no parseable event id", () => {
+      // Recordings root has no event id in the URI.
+      expect(
+        canDeleteItem({
+          src: "media-source://frigate/frigate/recordings/2026-05-10/12",
+          config: cfg({
+            source_mode: "media",
+            frigate_delete_service: "rest_command.delete_frigate",
+          }),
+          srcEntityMap: new Map(),
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("deleteItem", () => {
+    it("calls the configured rest_command with event_id and camera", async () => {
+      const hass = makeFakeHass();
+      const ok = await deleteItem({
+        hass,
+        src: FRIGATE_SRC,
+        config: cfg({
+          source_mode: "media",
+          frigate_delete_service: "rest_command.delete_frigate",
+          delete_confirm: false,
+        }),
+        srcEntityMap: new Map(),
+      });
+      expect(ok).toBe(true);
+      expect(hass.serviceCalls).toHaveLength(1);
+      const call = hass.serviceCalls[0]!;
+      expect(call.domain).toBe("rest_command");
+      expect(call.service).toBe("delete_frigate");
+      expect(call.data).toEqual({
+        event_id: "1778250346.47892-y8byzk",
+        camera: "achtertuin",
+      });
+    });
+
+    it("returns false when user cancels the confirm prompt", async () => {
+      const hass = makeFakeHass();
+      const confirm = vi.fn(() => false);
+      const ok = await deleteItem({
+        hass,
+        src: FRIGATE_SRC,
+        config: cfg({
+          source_mode: "media",
+          frigate_delete_service: "rest_command.delete_frigate",
+          delete_confirm: true,
+        }),
+        srcEntityMap: new Map(),
+        confirm,
+      });
+      expect(ok).toBe(false);
+      expect(confirm).toHaveBeenCalled();
+      expect(hass.serviceCalls).toHaveLength(0);
+    });
+
+    it("falls through to sensor path when src isn't a Frigate event", async () => {
+      const hass = makeFakeHass();
+      const ok = await deleteItem({
+        hass,
+        src: "/config/www/foo.mp4",
+        config: cfg({
+          source_mode: "sensor",
+          delete_service: "shell_command.delete_clip",
+          frigate_delete_service: "rest_command.delete_frigate",
+        }),
+        srcEntityMap: new Map(),
+      });
+      expect(ok).toBe(true);
+      const call = hass.serviceCalls[0]!;
+      expect(call.domain).toBe("shell_command");
+      expect(call.service).toBe("delete_clip");
+      expect(call.data).toHaveProperty("path");
+    });
   });
 });

--- a/src/data/delete-service.ts
+++ b/src/data/delete-service.ts
@@ -21,31 +21,55 @@
 import { DELETE_PREFIX_NORMALIZED } from "../const";
 import type { CameraGalleryCardConfig } from "../config/normalize";
 import type { HomeAssistant } from "../types/hass";
+import { frigateEventIdFromSrc, isFrigateRoot } from "../util/frigate";
 import { parseServiceParts, toFsPath } from "./sensor-source";
 
 export interface CanDeleteArgs {
   /** The src field from a CardItem. */
   src: string | undefined;
   /** Normalized config — only the fields below are read. */
-  config: Pick<CameraGalleryCardConfig, "source_mode" | "allow_delete" | "delete_service"> | null;
+  config: Pick<
+    CameraGalleryCardConfig,
+    "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service"
+  > | null;
   /** From `SensorSourceClient.getSrcEntityMap()`. Required for combined-mode gate. */
   srcEntityMap: ReadonlyMap<string, string>;
 }
 
 /**
+ * `true` when `src` is a Frigate event item AND a `frigate_delete_service`
+ * is configured. Used both as a delete-eligibility check and as the
+ * dispatch switch in `deleteItem`. Requires the URI to carry a parseable
+ * Frigate event id (snapshots and clip events qualify; recordings don't).
+ */
+function isFrigateDeleteEligible(
+  src: string | undefined,
+  config: Pick<CameraGalleryCardConfig, "frigate_delete_service"> | null
+): boolean {
+  if (!src) return false;
+  if (!isFrigateRoot(src)) return false;
+  if (frigateEventIdFromSrc(src) === null) return false;
+  return parseServiceParts(config?.frigate_delete_service) !== null;
+}
+
+/**
  * Return `true` iff the thumb's trash icon should appear:
- *   - mode is `sensor` or `combined`
- *   - in combined mode, the item is sensor-backed (entry in the map)
- *   - `allow_delete` is on
- *   - `delete_service` parses as `domain.service`
+ *   - sensor item: mode is `sensor` or `combined` (with sensor-backed src),
+ *     `allow_delete` is on, and `delete_service` parses.
+ *   - Frigate event item (any mode): `frigate_delete_service` is configured
+ *     and `allow_delete` is on. The two paths are independent — a setup
+ *     can have only-sensor-delete, only-Frigate-delete, or both.
  */
 export function canDeleteItem(args: CanDeleteArgs): boolean {
   const { src, config, srcEntityMap } = args;
   if (!src) return false;
+  if (!config?.allow_delete) return false;
+  // Frigate path — works in any mode where the item is a Frigate event.
+  if (isFrigateDeleteEligible(src, config)) return true;
+  // Sensor / combined-sensor-backed path.
   const mode = config?.source_mode;
   if (mode !== "sensor" && mode !== "combined") return false;
   if (mode === "combined" && !srcEntityMap.has(src)) return false;
-  if (!config?.allow_delete) return false;
   return parseServiceParts(config?.delete_service) !== null;
 }
 
@@ -54,7 +78,7 @@ export interface DeleteItemArgs {
   src: string;
   config: Pick<
     CameraGalleryCardConfig,
-    "source_mode" | "allow_delete" | "delete_service" | "delete_confirm"
+    "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service" | "delete_confirm"
   > | null;
   srcEntityMap: ReadonlyMap<string, string>;
   /** Confirm prompt; defaults to `window.confirm`. Inject for tests. */
@@ -62,19 +86,51 @@ export interface DeleteItemArgs {
 }
 
 /**
- * Invoke the configured `delete_service` for `src`. Returns `true` on
- * success, `false` on every gate failure (mode wrong, prefix mismatch,
- * user cancelled the confirm, callService threw).
+ * Invoke the appropriate delete service for `src`. Two dispatch paths:
  *
- * The path-prefix gate (`fsPath.startsWith(DELETE_PREFIX_NORMALIZED)`)
- * is the safety net that prevents a malformed `src` from passing an
- * arbitrary filesystem path to the user's shell command.
+ *   1. **Frigate event item** — calls `frigate_delete_service` with
+ *      `{ event_id, camera }` so the configured `rest_command` can hit
+ *      Frigate's `DELETE /api/events/<id>` endpoint via HA (no CORS,
+ *      no `frigate_url` required).
+ *
+ *   2. **Sensor / combined-sensor item** — calls `delete_service` with
+ *      `{ path }` (the legacy shell-command flow). The path-prefix gate
+ *      (`fsPath.startsWith(DELETE_PREFIX_NORMALIZED)`) prevents a
+ *      malformed `src` from passing an arbitrary filesystem path to
+ *      the user's shell command.
+ *
+ * Returns `true` on success, `false` on any gate failure (mode wrong,
+ * prefix mismatch, user cancelled, callService threw).
  */
 export async function deleteItem(args: DeleteItemArgs): Promise<boolean> {
   const { hass, src, config, srcEntityMap, confirm = defaultConfirm } = args;
   if (!hass) return false;
   if (!canDeleteItem({ src, config, srcEntityMap })) return false;
 
+  // Frigate dispatch wins when the URI is a Frigate event AND the
+  // service is configured — leaves the sensor path alone in combined
+  // setups for non-Frigate items.
+  if (isFrigateDeleteEligible(src, config)) {
+    const sp = parseServiceParts(config?.frigate_delete_service);
+    if (!sp) return false;
+    const eventId = frigateEventIdFromSrc(src);
+    if (!eventId) return false;
+    if (config?.delete_confirm) {
+      if (!confirm("Delete this Frigate event?")) return false;
+    }
+    // Camera segment: `media-source://frigate/<inst>/event/clips/<camera>/<id>`.
+    // Some users template `{{ camera }}` into their rest_command for path
+    // interpolation; pass it through alongside `event_id`.
+    const camera = extractFrigateCameraFromSrc(src);
+    try {
+      await hass.callService(sp.domain, sp.service, { event_id: eventId, camera });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Sensor / combined-sensor path.
   const sp = parseServiceParts(config?.delete_service);
   if (!sp) return false;
 
@@ -91,6 +147,13 @@ export async function deleteItem(args: DeleteItemArgs): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/** Extract the camera segment from a Frigate event URI. Returns "" when not parseable. */
+function extractFrigateCameraFromSrc(src: string): string {
+  // Shape: `media-source://frigate/<inst>/event/<media_type>/<camera>/<event_id>`
+  const m = String(src ?? "").match(/^media-source:\/\/frigate\/[^/]+\/event\/[^/]+\/([^/]+)\//);
+  return m?.[1] ?? "";
 }
 
 function defaultConfirm(message: string): boolean {

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ import { isVideo } from "./util/media-type";
 import { posterStore } from "./util/poster-store";
 import {
   FRIGATE_URI_PREFIX,
+  frigateEventIdFromSrc,
   frigateEventIdMs,
   hasFrigateConfig,
   isFrigateRecordingsRoot,
@@ -111,6 +112,7 @@ class CameraGalleryCard extends LitElement {
       _selectedSet: { type: Object },
       _selectMode: { type: Boolean },
       _showBulkHint: { type: Boolean },
+      _errorToast: { type: Object },
       _showDatePicker: { type: Boolean },
       _showLivePicker: { type: Boolean },
       _showLiveQuickSwitch: { type: Boolean },
@@ -164,6 +166,7 @@ class CameraGalleryCard extends LitElement {
     this._prefetchKey = "";
     this._selectedPreviewSrc = "";
     this._deleted = new Set();
+    this._deletedFrigateEventIds = new Set();
     this._forceThumbReset = false;
     this._liveCard = null;
     this._liveCardConfigKey = "";
@@ -221,6 +224,8 @@ class CameraGalleryCard extends LitElement {
     this._selectedSet = new Set();
     this._showBulkHint = false;
     this._bulkHintTimer = null;
+    this._errorToast = null;
+    this._errorToastTimer = null;
     this._showDatePicker = false;
     this._datePickerDays = null;
     this._showLivePicker = false;
@@ -1285,6 +1290,29 @@ class CameraGalleryCard extends LitElement {
       this._bulkHintTimer = null;
       this.requestUpdate();
     }, 5000);
+  }
+
+  _showErrorToast(title, message) {
+    if (this._errorToastTimer) {
+      clearTimeout(this._errorToastTimer);
+      this._errorToastTimer = null;
+    }
+    this._errorToast = { title, message };
+    this.requestUpdate();
+    this._errorToastTimer = setTimeout(() => {
+      this._errorToast = null;
+      this._errorToastTimer = null;
+      this.requestUpdate();
+    }, 8000);
+  }
+
+  _dismissErrorToast() {
+    if (this._errorToastTimer) {
+      clearTimeout(this._errorToastTimer);
+      this._errorToastTimer = null;
+    }
+    this._errorToast = null;
+    this.requestUpdate();
   }
 
   // ─── Normalizers / config helpers ─────────────────────────────────
@@ -2729,7 +2757,6 @@ class CameraGalleryCard extends LitElement {
 
   _onThumbContextMenu(e, item) {
     if (this._selectMode) return;
-    if (this._isFrigateMediaItem(item?.src)) return;
 
     e.preventDefault();
     e.stopPropagation();
@@ -2746,7 +2773,6 @@ class CameraGalleryCard extends LitElement {
     if (this._selectMode) return;
     if (!item?.src) return;
     if (e?.button != null && e.button !== 0) return;
-    if (this._isFrigateMediaItem(item.src)) return;
 
     this._thumbLongPressStartX = e.clientX ?? 0;
     this._thumbLongPressStartY = e.clientY ?? 0;
@@ -2929,11 +2955,47 @@ class CameraGalleryCard extends LitElement {
       config: this.config,
       srcEntityMap: this._sensorClient.getSrcEntityMap(),
     });
-    if (!ok) return;
+    if (!ok) {
+      // Surface the failure via an in-card toast instead of swallowing it
+      // silently — otherwise the user taps Delete, nothing happens, and they
+      // have no idea why.
+      const eventId = frigateEventIdFromSrc(src);
+      const isFrigate = eventId !== null && isFrigateRoot(src);
+      this._showErrorToast(
+        "Delete failed",
+        isFrigate
+          ? `Frigate event could not be deleted. Check that the rest_command service is configured correctly and can reach Frigate.`
+          : `File could not be deleted. Check the delete_service config and that the file still exists.`
+      );
+      return;
+    }
 
     this._deleted.add(src);
     this._selectedSet?.delete?.(src);
     this._invalidateItems();
+
+    // Frigate's DELETE /api/events/<id> wipes clip + paired snapshot in
+    // one call, so any item whose URI carries the same event id should
+    // be hidden together. Event-id-keyed filter survives URI shape and
+    // re-fetches better than exact-URI-only matching.
+    const eventId = frigateEventIdFromSrc(src);
+    let alsoHidden = [];
+    if (eventId) {
+      this._deletedFrigateEventIds.add(eventId);
+      alsoHidden = (this._mediaClient?.state?.list || [])
+        .map((it) => it?.id)
+        .filter((id) => id && id !== src && id.includes(eventId));
+    }
+
+    // Diagnostic log so testing can verify both the clip and the paired
+    // snapshot get hidden after one delete.
+    console.info(
+      "[cgc delete]",
+      eventId
+        ? `Frigate event_id=${eventId} — deleted src=${src} — also hiding ${alsoHidden.length} matching item(s):`
+        : `non-Frigate src=${src}`,
+      alsoHidden
+    );
 
     const rawItems = this._items();
     if (!rawItems.length) {
@@ -3680,26 +3742,30 @@ class CameraGalleryCard extends LitElement {
       return dtMs !== null ? { src, dtMs } : { src };
     };
 
+    const isItemDeleted = (it) => {
+      if (this._deleted?.has(it.src)) return true;
+      if (this._deletedFrigateEventIds?.size) {
+        const eid = frigateEventIdFromSrc(it.src);
+        if (eid && this._deletedFrigateEventIds.has(eid)) return true;
+      }
+      return false;
+    };
+    const filterDeleted = (arr) =>
+      this._deleted?.size || this._deletedFrigateEventIds?.size
+        ? arr.filter((it) => !isItemDeleted(it))
+        : arr;
+
     let result;
     if (mode === "combined") {
-      const merged = this._combinedClient.getItems(enrich);
-      result = this._deleted?.size
-        ? merged.filter((it) => !this._deleted.has(it.src))
-        : merged;
+      result = filterDeleted(this._combinedClient.getItems(enrich));
     } else if (usingMediaSource) {
-      const ids = dedupeByRelPath(this._mediaClient.getIds()).map(enrich);
-      result = this._deleted?.size
-        ? ids.filter((it) => !this._deleted.has(it.src))
-        : ids;
+      result = filterDeleted(dedupeByRelPath(this._mediaClient.getIds()).map(enrich));
     } else {
       // Sensor (and the implicit fall-through default) — delegate.
       // Render-side reads of srcEntityMap / sensorPairedThumbs route through
       // `this._sensorClient.getSrcEntityMap()` and `getSensorPairedThumbs()`
       // directly; no mirror-back needed.
-      const items = this._sensorClient.getItems(enrich);
-      result = this._deleted?.size
-        ? items.filter((it) => !this._deleted.has(it.src))
-        : items;
+      result = filterDeleted(this._sensorClient.getItems(enrich));
     }
 
     this._cachedItems = result;
@@ -5342,6 +5408,22 @@ class CameraGalleryCard extends LitElement {
           ? html`
               <div class="bulk-floating-hint">
                 Select thumbnails to delete
+              </div>
+            `
+          : html``}
+
+        ${this._errorToast
+          ? html`
+              <div
+                class="cgc-error-toast"
+                @click=${() => this._dismissErrorToast()}
+                role="alert"
+              >
+                <ha-icon icon="mdi:alert-circle-outline"></ha-icon>
+                <div class="cgc-error-toast-text">
+                  <div class="cgc-error-toast-title">${this._errorToast.title}</div>
+                  <div class="cgc-error-toast-msg">${this._errorToast.message}</div>
+                </div>
               </div>
             `
           : html``}
@@ -7159,6 +7241,59 @@ class CameraGalleryCard extends LitElement {
         }
       }
 
+      .cgc-error-toast {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        max-width: min(420px, 92%);
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(180, 35, 35, 0.95);
+        color: #fff;
+        font-size: 13px;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.32);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        z-index: 60;
+        cursor: pointer;
+        animation: cgcErrorToastIn 0.22s ease-out;
+      }
+      .cgc-error-toast ha-icon {
+        flex: 0 0 auto;
+        --mdc-icon-size: 22px;
+        color: #fff;
+        margin-top: 1px;
+      }
+      .cgc-error-toast-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .cgc-error-toast-title {
+        font-weight: 700;
+        font-size: 13px;
+      }
+      .cgc-error-toast-msg {
+        font-weight: 400;
+        font-size: 12px;
+        opacity: 0.92;
+        line-height: 1.35;
+      }
+      @keyframes cgcErrorToastIn {
+        from {
+          opacity: 0;
+          transform: translate(-50%, calc(-50% + 8px));
+        }
+        to {
+          opacity: 1;
+          transform: translate(-50%, -50%);
+        }
+      }
+
       .empty {
         padding: 12px;
         border-radius: 14px;
@@ -8685,6 +8820,9 @@ class CameraGalleryCardEditor extends HTMLElement {
     const shellCmds = Object.keys(allServices.shell_command || {})
       .map((svc) => `shell_command.${svc}`)
       .sort((a, b) => a.localeCompare(b));
+    const restCmds = Object.keys(allServices.rest_command || {})
+      .map((svc) => `rest_command.${svc}`)
+      .sort((a, b) => a.localeCompare(b));
 
     const deleteService = String(
       c.delete_service || c.shell_command || ""
@@ -8695,6 +8833,16 @@ class CameraGalleryCardEditor extends HTMLElement {
     const deleteChoices = (() => {
       const set = new Set(shellCmds);
       if (deleteService) set.add(deleteService);
+      return Array.from(set).sort((a, b) => a.localeCompare(b));
+    })();
+
+    const frigateDeleteService = String(c.frigate_delete_service || "").trim();
+    const frigateDeleteOk =
+      !frigateDeleteService ||
+      /^[a-z0-9_]+\.[a-z0-9_]+$/i.test(frigateDeleteService);
+    const frigateDeleteChoices = (() => {
+      const set = new Set(restCmds);
+      if (frigateDeleteService) set.add(frigateDeleteService);
       return Array.from(set).sort((a, b) => a.localeCompare(b));
     })();
 
@@ -9143,41 +9291,53 @@ class CameraGalleryCardEditor extends HTMLElement {
                 </div>
               </div>
 
-              <div class="row ${mediaModeOn ? "row-disabled" : ""}">
-                <div class="lbl">Delete service</div>
-                <div class="hint">
-                  ${mediaModeOn ? `
-                    ${svgIcon('mdi:information-outline', 14)}
-                    <span>Delete is not available in <strong>Media folders</strong> mode. Media-source items don't map to filesystem paths the shell command can delete — switch the source above to enable.</span>
-                  ` : `
-                    ${svgIcon('mdi:help-circle-outline', 14)}
-                    <a
-                      href="https://github.com/TheScubadiver/camera-gallery-card?tab=readme-ov-file#delete-setup"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      How to configure the shell command
-                    </a>
-                  `}
-                </div>
-
-                <div class="selectwrap">
-                  <select class="select ${deleteOk ? "" : "invalid"}" id="delservice" ${mediaModeOn ? "disabled" : ""}>
-                    ${
-                      deleteChoices.length
-                        ? `<option value=""></option>` +
-                          deleteChoices
-                            .map(
-                              (id) =>
-                                `<option value="${id}" ${
-                                  id === deleteService ? "selected" : ""
-                                }>${id}</option>`
-                            )
-                            .join("")
-                        : `<option value="" selected>(no shell_command services found)</option>`
-                    }
-                  </select>
-                  <span class="selarrow"></span>
+              <div class="row">
+                <div class="lbl">Delete services</div>
+                <div style="padding-top:8px;display:flex;flex-direction:column;gap:14px;">
+                  <div class="${mediaModeOn ? "row-disabled" : ""}">
+                    <div class="lbl">Sensor</div>
+                    <div class="selectwrap" style="margin-top:4px;">
+                      <select class="select ${deleteOk ? "" : "invalid"}" id="delservice" ${mediaModeOn ? "disabled" : ""}>
+                        ${
+                          deleteChoices.length
+                            ? `<option value=""></option>` +
+                              deleteChoices
+                                .map(
+                                  (id) =>
+                                    `<option value="${id}" ${
+                                      id === deleteService ? "selected" : ""
+                                    }>${id}</option>`
+                                )
+                                .join("")
+                            : `<option value="" selected>(no shell_command services found)</option>`
+                        }
+                      </select>
+                      <span class="selarrow"></span>
+                    </div>
+                  </div>
+                  ${hasFrigateConfig(c) ? `
+                  <div>
+                    <div class="lbl">Frigate</div>
+                    <div class="selectwrap" style="margin-top:4px;">
+                      <select class="select ${frigateDeleteOk ? "" : "invalid"}" id="frigate-delservice">
+                        ${
+                          frigateDeleteChoices.length
+                            ? `<option value="">(none — Frigate delete disabled)</option>` +
+                              frigateDeleteChoices
+                                .map(
+                                  (id) =>
+                                    `<option value="${id}" ${
+                                      id === frigateDeleteService ? "selected" : ""
+                                    }>${id}</option>`
+                                )
+                                .join("")
+                            : `<option value="" selected>(no rest_command services found — add one to configuration.yaml)</option>`
+                        }
+                      </select>
+                      <span class="selarrow"></span>
+                    </div>
+                  </div>
+                  ` : ``}
                 </div>
               </div>
 
@@ -11613,6 +11773,22 @@ if (oldPanel && tmp.firstElementChild) {
 
     delserviceEl?.addEventListener("change", commitDeleteService, _sig);
 
+    const frigateDelserviceEl = $("frigate-delservice");
+    const commitFrigateDeleteService = () => {
+      const v = String(frigateDelserviceEl?.value || "").trim();
+      if (!v) {
+        const next = { ...this._config };
+        delete next.frigate_delete_service;
+        this._config = this._stripAlwaysTrueKeys(next);
+        this._fire();
+        this._scheduleRender();
+        return;
+      }
+      this._set("frigate_delete_service", v);
+    };
+    frigateDelserviceEl?.addEventListener("change", commitFrigateDeleteService, _sig);
+
+
     const commitNumberField = (key, el, fallback, commit = false) => {
       const raw = String(el?.value ?? "").trim();
 
@@ -12617,7 +12793,7 @@ if (oldPanel && tmp.firstElementChild) {
     }
 
     this._fire();
-    const RENDERS_REQUIRED = new Set(["source_mode", "live_enabled", "live_camera_entities", "object_filters", "delete_service", "live_camera_entity", "menu_buttons", "frigate_url", "live_layout"]);
+    const RENDERS_REQUIRED = new Set(["source_mode", "live_enabled", "live_camera_entities", "object_filters", "delete_service", "frigate_delete_service", "live_camera_entity", "menu_buttons", "frigate_url", "live_layout"]);
     if (RENDERS_REQUIRED.has(key)) this._scheduleRender();
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ import { FavoritesStore } from "./data/favorites";
 import {
   parseServiceParts,
   SensorSourceClient,
-  toFsPath,
   toWebPath,
 } from "./data/sensor-source";
 import {
@@ -1137,10 +1136,10 @@ class CameraGalleryCard extends LitElement {
   }
 
   _thumbCanMultipleDelete() {
-    const mode = this.config?.source_mode;
-    if (mode !== "sensor" && mode !== "combined") return false;
     if (!this.config?.allow_delete || !this.config?.allow_bulk_delete) return false;
-    return !!parseServiceParts(this.config?.delete_service);
+    const hasSensorService = !!parseServiceParts(this.config?.delete_service);
+    const hasFrigateService = !!parseServiceParts(this.config?.frigate_delete_service);
+    return hasSensorService || hasFrigateService;
   }
 
   _friendlyCameraName(entityId) {
@@ -4194,32 +4193,42 @@ class CameraGalleryCard extends LitElement {
   // ─── Selection / bulk delete ──────────────────────────────────────
 
   async _bulkDelete(selectedSrcList) {
-    const mode = this.config?.source_mode;
-    if (mode !== "sensor" && mode !== "combined") return;
     if (!this.config?.allow_delete || !this.config?.allow_bulk_delete) return;
 
-    const sp = parseServiceParts(this.config?.delete_service);
-    if (!sp) return;
-
-    const prefix = DELETE_PREFIX_NORMALIZED;
     const srcs = Array.from(selectedSrcList || []);
     if (!srcs.length) return;
 
     if (this.config?.delete_confirm) {
       const ok = window.confirm(
-        `Are you sure you want to delete ${srcs.length} file(s)?`
+        `Are you sure you want to delete ${srcs.length} item(s)?`
       );
       if (!ok) return;
     }
 
-    for (const src of srcs) {
-      const fsPath = toFsPath(src);
-      if (!fsPath || !fsPath.startsWith(prefix)) continue;
+    // Route every item through the same deleteItem() helper as single
+    // delete — picks sensor or Frigate dispatch per item, validates path
+    // prefixes, surfaces errors. `confirm: () => true` suppresses the
+    // per-item dialog since we already confirmed the batch above.
+    const srcEntityMap = this._sensorClient.getSrcEntityMap();
+    let okCount = 0;
+    const failed = [];
 
-      try {
-        await this._hass.callService(sp.domain, sp.service, { path: fsPath });
+    for (const src of srcs) {
+      const ok = await deleteItem({
+        hass: this._hass,
+        src,
+        config: this.config,
+        srcEntityMap,
+        confirm: () => true,
+      });
+      if (ok) {
+        okCount++;
         this._deleted.add(src);
-      } catch (_) {}
+        const eventId = frigateEventIdFromSrc(src);
+        if (eventId) this._deletedFrigateEventIds.add(eventId);
+      } else {
+        failed.push(src);
+      }
     }
 
     this._invalidateItems();
@@ -4227,6 +4236,15 @@ class CameraGalleryCard extends LitElement {
     this._selectMode = false;
     this._hideBulkDeleteHint();
     this.requestUpdate();
+
+    if (failed.length > 0) {
+      this._showErrorToast(
+        "Some deletes failed",
+        okCount > 0
+          ? `Deleted ${okCount} of ${srcs.length}. ${failed.length} failed — check delete_service / frigate_delete_service config.`
+          : `Could not delete ${failed.length} item(s). Check delete_service / frigate_delete_service config.`
+      );
+    }
   }
 
   _exitSelectMode() {
@@ -4789,15 +4807,14 @@ class CameraGalleryCard extends LitElement {
     const isToday = currentForNav === newestDay;
 
     const sp = parseServiceParts(this.config?.delete_service);
+    const fsp = parseServiceParts(this.config?.frigate_delete_service);
 
     const canDelete =
-      (this.config?.source_mode === "sensor" || this.config?.source_mode === "combined") &&
       !!this.config?.allow_delete &&
-      !!sp;
+      (!!sp || !!fsp);
     const canBulkDelete =
-      (this.config?.source_mode === "sensor" || this.config?.source_mode === "combined") &&
       !!this.config?.allow_bulk_delete &&
-      !!sp;
+      (!!sp || !!fsp);
 
     const tsPosClass = this.config.bar_position === "bottom"
       ? "bottom"

--- a/src/util/frigate.ts
+++ b/src/util/frigate.ts
@@ -79,6 +79,18 @@ export function frigateEventIdMs(src: string): number | null {
   return sec * 1000;
 }
 
+/**
+ * Extract the raw event id (`<unix_epoch>.<micros>-<random>`) from a Frigate
+ * media-source URI or REST URL. This is the form Frigate's
+ * `DELETE /api/events/<id>` endpoint expects.
+ */
+export function frigateEventIdFromSrc(src: string | null | undefined): string | null {
+  const m = String(src ?? "").match(
+    /(?:^|[/_.-])(\d{9,11}(?:\.\d+)?-[a-z0-9]+)(?:\.[a-z0-9]+)?(?:[/?#]|$)/i
+  );
+  return m?.[1] ?? null;
+}
+
 // ---------- REST API ----------
 
 /** Subset of fields the card consumes from a Frigate API event. */


### PR DESCRIPTION
## Summary

New feature, picking up #106. Adds support for deleting Frigate
clips directly from the card via Frigate's delete API, called
through a user-configured `rest_command` in HA.

- New `frigate_delete_service` config option (a rest_command that
  hits `DELETE /api/events/<id>`)
- Delete shows an in-card error toast when the service call fails
- A clip and its paired snapshot disappear together in one action
- Bulk delete now handles sensor + Frigate items in one batch

## Test plan
- [x] Sensor single delete still works
- [x] Frigate single delete removes clip + paired snapshot
- [x] Mixed sensor + Frigate bulk delete
- [x] Bad rest_command shows error toast
- [x] `delete_confirm: true` still prompts
- [x] `allow_bulk_delete: false` hides bulk-select UI