### PR TITLE
feat: red selection style and matching delete button

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7160,8 +7160,9 @@ class CameraGalleryCard extends LitElement {
       }
 
       .bulkdelete {
-        background: color-mix(in srgb, var(--error-color, #c62828) 18%, transparent);
-        border: 1px solid color-mix(in srgb, var(--error-color, #c62828) 35%, transparent);
+        background: var(--cgc-delete-bg, var(--cgc-live-active-bg, var(--error-color, #c62828)));
+        color: var(--text-primary-color, #fff);
+        border: 1px solid var(--cgc-delete-bg, var(--cgc-live-active-bg, var(--error-color, #c62828)));
       }
 
       @media (max-width: 700px) {
@@ -7658,6 +7659,7 @@ const STYLE_SECTIONS = [
       { type: "color",  hostId: "ctrl-txt-host",     variable: "--cgc-ctrl-txt",       label: "Text color" },
       { type: "color",  hostId: "ctrl-chevron-host", variable: "--cgc-ctrl-chevron",   label: "Chevron color" },
       { type: "color",  hostId: "live-active-host",  variable: "--cgc-live-active-bg", label: "Live active color" },
+      { type: "color",  hostId: "delete-bg-host",    variable: "--cgc-delete-bg",      label: "Delete button color" },
       { type: "radius", variable: "--cgc-ctrl-radius", label: "Border radius", min: 0, max: 16, default: 10 },
     ],
   },

--- a/src/index.js
+++ b/src/index.js
@@ -5286,11 +5286,7 @@ class CameraGalleryCard extends LitElement {
                           : html``}
 
                         ${this._selectMode
-                          ? html`
-                              <div class="selOverlay ${isSel ? "on" : ""}">
-                                <ha-icon icon="mdi:check"></ha-icon>
-                              </div>
-                            `
+                          ? html`<div class="selOverlay ${isSel ? "on" : ""}"></div>`
                           : html``}
 
                         <div
@@ -6838,10 +6834,6 @@ class CameraGalleryCard extends LitElement {
         box-sizing: border-box;
       }
 
-      .tthumb.sel::after {
-        border: 2px solid var(--primary-color, #2196f3);
-      }
-
       .timg {
         width: 100%;
         height: 100%;
@@ -7089,15 +7081,7 @@ class CameraGalleryCard extends LitElement {
 
       .selOverlay.on {
         opacity: 1;
-        background: var(--cgc-sel-ov-b);
-      }
-
-      .selOverlay ha-icon {
-        color: var(--cgc-txt);
-        --mdc-icon-size: 22px;
-        --ha-icon-size: 22px;
-        width: 22px;
-        height: 22px;
+        background: rgba(244, 67, 54, 0.4);
       }
 
       .bulkbar {


### PR DESCRIPTION
## Summary

- Selected thumbs get a translucent red tint (no more orange border
  or check icon)
- Bulk-delete button is now solid red, matching the Live button
- New `--cgc-delete-bg` theme variable + editor picker for an
  independent delete color