### PR TITLE
refactor: drop redundant allow_delete config flag

### DIFF
--- a/src/config/diff.spec.ts
+++ b/src/config/diff.spec.ts
@@ -16,7 +16,6 @@ const baseConfig = (overrides: Partial<CameraGalleryCardConfig> = {}): CameraGal
     live_camera_entity: "",
     live_camera_entities: [],
     start_mode: "gallery",
-    allow_delete: true,
     allow_bulk_delete: true,
     delete_confirm: true,
     delete_service: "",

--- a/src/config/diff.ts
+++ b/src/config/diff.ts
@@ -17,7 +17,6 @@ type ConfigKey = keyof CameraGalleryCardConfig;
  */
 const SOURCE_KEYS = new Set<ConfigKey>([
   "allow_bulk_delete",
-  "allow_delete",
   "delete_confirm",
   "delete_service",
   "entities",

--- a/src/config/normalize.spec.ts
+++ b/src/config/normalize.spec.ts
@@ -290,36 +290,22 @@ describe("Cross-field rules", () => {
 });
 
 describe("Delete gating", () => {
-  it("media mode forces delete OFF and clears delete_service", () => {
+  it("media mode clears delete_service and forces bulk OFF", () => {
     const { config } = normalizeConfig({
       source_mode: "media",
       media_sources: ["frigate/x"],
       path_datetime_format: "YYYY-MM-DD",
-      allow_delete: true,
       delete_service: "shell.delete_file",
     });
-    expect(config.allow_delete).toBe(false);
     expect(config.allow_bulk_delete).toBe(false);
     expect(config.delete_service).toBe("");
   });
 
-  it("sensor mode without delete_service forces delete OFF", () => {
+  it("sensor mode keeps a valid delete_service intact", () => {
     const { config } = normalizeConfig({
       ...minimalSensor,
-      allow_delete: true,
-      delete_service: "",
-    });
-    expect(config.allow_delete).toBe(false);
-    expect(config.allow_bulk_delete).toBe(false);
-  });
-
-  it("sensor mode with valid delete_service keeps allow_delete true", () => {
-    const { config } = normalizeConfig({
-      ...minimalSensor,
-      allow_delete: true,
       delete_service: "shell.delete_file",
     });
-    expect(config.allow_delete).toBe(true);
     expect(config.delete_service).toBe("shell.delete_file");
   });
 
@@ -457,7 +443,6 @@ describe("Defaults are applied", () => {
     expect(config.autoplay).toBe(false);
     expect(config.auto_muted).toBe(true);
     expect(config.live_auto_muted).toBe(true);
-    expect(config.allow_delete).toBe(false); // gated off — no delete_service in minimal
   });
 
   it("fills missing numeric fields with their DEFAULT_*", () => {

--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -115,7 +115,6 @@ export interface InputConfig {
   start_mode?: string;
 
   // ─── Delete ────────────────────────────────────────────────
-  allow_delete?: boolean;
   allow_bulk_delete?: boolean;
   delete_confirm?: boolean;
   delete_service?: string;
@@ -544,22 +543,18 @@ function applyPreviewCloseOnTapDefault(
 }
 
 /**
- * Apply mode-aware delete gating:
- *   - Pure `media` mode can't delete (URIs aren't filesystem paths).
- *   - Sensor/combined modes need a `delete_service` for delete to work; if
- *     missing, both `allow_delete` and `allow_bulk_delete` are forced off.
+ * Apply mode-aware delete gating: pure `media` mode can't delete (URIs
+ * aren't filesystem paths), so the delete_service is cleared and the
+ * bulk-select UI is suppressed. Other modes rely on `delete_service`
+ * being empty to disable delete — no separate flag needed.
  */
 function applyDeleteGating(config: CameraGalleryCardConfig): CameraGalleryCardConfig {
   if (config.source_mode === "media") {
     return {
       ...config,
-      allow_delete: false,
       allow_bulk_delete: false,
       delete_service: "",
     };
-  }
-  if (config.allow_delete && !config.delete_service) {
-    return { ...config, allow_delete: false, allow_bulk_delete: false };
   }
   return config;
 }

--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -35,7 +35,6 @@ import {
   BAR_POSITIONS,
   CONTROLS_MODES,
   DEFAULT_ALLOW_BULK_DELETE,
-  DEFAULT_ALLOW_DELETE,
   DEFAULT_ASPECT_RATIO,
   DEFAULT_AUTOMUTED,
   DEFAULT_AUTOPLAY,
@@ -174,7 +173,6 @@ export const cameraGalleryCardConfigStruct = type({
   start_mode: defaulted(enums(START_MODES), "gallery"),
 
   // ─── Delete ────────────────────────────────────────────────
-  allow_delete: defaulted(boolean(), DEFAULT_ALLOW_DELETE),
   allow_bulk_delete: defaulted(boolean(), DEFAULT_ALLOW_BULK_DELETE),
   delete_confirm: defaulted(boolean(), DEFAULT_DELETE_CONFIRM),
   delete_service: defaulted(serviceId, DEFAULT_DELETE_SERVICE),

--- a/src/const.ts
+++ b/src/const.ts
@@ -136,7 +136,6 @@ export type ObjectFilter = (typeof AVAILABLE_OBJECT_FILTERS)[number];
 
 // -------- Config defaults (DEFAULT_*) --------
 export const DEFAULT_ALLOW_BULK_DELETE = true;
-export const DEFAULT_ALLOW_DELETE = true;
 export const DEFAULT_AUTOMUTED = true;
 export const DEFAULT_AUTOPLAY = false;
 export const DEFAULT_ASPECT_RATIO = "16:9" satisfies AspectRatio;

--- a/src/data/delete-service.spec.ts
+++ b/src/data/delete-service.spec.ts
@@ -6,13 +6,12 @@ import { canDeleteItem, deleteItem } from "./delete-service";
 
 type Config = Pick<
   CameraGalleryCardConfig,
-  "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service" | "delete_confirm"
+  "source_mode" | "delete_service" | "frigate_delete_service" | "delete_confirm"
 >;
 
 const cfg = (overrides: Partial<Config> = {}): Config =>
   ({
     source_mode: "sensor",
-    allow_delete: true,
     delete_service: "shell_command.delete_clip",
     frigate_delete_service: "",
     delete_confirm: false,
@@ -62,11 +61,11 @@ describe("canDeleteItem — matrix gate", () => {
     ).toBe(true);
   });
 
-  it("returns false when allow_delete is false", () => {
+  it("returns false when delete_service is empty", () => {
     expect(
       canDeleteItem({
         src: "/local/a.mp4",
-        config: cfg({ allow_delete: false }),
+        config: cfg({ delete_service: "" }),
         srcEntityMap: new Map(),
       })
     ).toBe(false);
@@ -209,20 +208,6 @@ describe("Frigate delete path", () => {
           srcEntityMap: new Map(),
         })
       ).toBe(true);
-    });
-
-    it("respects allow_delete=false even when frigate_delete_service is set", () => {
-      expect(
-        canDeleteItem({
-          src: FRIGATE_SRC,
-          config: cfg({
-            allow_delete: false,
-            source_mode: "media",
-            frigate_delete_service: "rest_command.delete_frigate",
-          }),
-          srcEntityMap: new Map(),
-        })
-      ).toBe(false);
     });
 
     it("rejects Frigate URIs with no parseable event id", () => {

--- a/src/data/delete-service.ts
+++ b/src/data/delete-service.ts
@@ -30,7 +30,7 @@ export interface CanDeleteArgs {
   /** Normalized config — only the fields below are read. */
   config: Pick<
     CameraGalleryCardConfig,
-    "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service"
+    "source_mode" | "delete_service" | "frigate_delete_service"
   > | null;
   /** From `SensorSourceClient.getSrcEntityMap()`. Required for combined-mode gate. */
   srcEntityMap: ReadonlyMap<string, string>;
@@ -54,16 +54,15 @@ function isFrigateDeleteEligible(
 
 /**
  * Return `true` iff the thumb's trash icon should appear:
- *   - sensor item: mode is `sensor` or `combined` (with sensor-backed src),
- *     `allow_delete` is on, and `delete_service` parses.
- *   - Frigate event item (any mode): `frigate_delete_service` is configured
- *     and `allow_delete` is on. The two paths are independent — a setup
- *     can have only-sensor-delete, only-Frigate-delete, or both.
+ *   - sensor item: mode is `sensor` or `combined` (with sensor-backed src)
+ *     and `delete_service` parses.
+ *   - Frigate event item (any mode): `frigate_delete_service` is configured.
+ *     The two paths are independent — a setup can have only-sensor-delete,
+ *     only-Frigate-delete, or both.
  */
 export function canDeleteItem(args: CanDeleteArgs): boolean {
   const { src, config, srcEntityMap } = args;
   if (!src) return false;
-  if (!config?.allow_delete) return false;
   // Frigate path — works in any mode where the item is a Frigate event.
   if (isFrigateDeleteEligible(src, config)) return true;
   // Sensor / combined-sensor-backed path.
@@ -78,7 +77,7 @@ export interface DeleteItemArgs {
   src: string;
   config: Pick<
     CameraGalleryCardConfig,
-    "source_mode" | "allow_delete" | "delete_service" | "frigate_delete_service" | "delete_confirm"
+    "source_mode" | "delete_service" | "frigate_delete_service" | "delete_confirm"
   > | null;
   srcEntityMap: ReadonlyMap<string, string>;
   /** Confirm prompt; defaults to `window.confirm`. Inject for tests. */

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,6 @@ import {
 import {
   AVAILABLE_OBJECT_FILTERS,
   DEFAULT_ALLOW_BULK_DELETE,
-  DEFAULT_ALLOW_DELETE,
   DEFAULT_AUTOMUTED,
   DEFAULT_AUTOPLAY,
   DEFAULT_BAR_OPACITY,
@@ -1136,7 +1135,7 @@ class CameraGalleryCard extends LitElement {
   }
 
   _thumbCanMultipleDelete() {
-    if (!this.config?.allow_delete || !this.config?.allow_bulk_delete) return false;
+    if (!this.config?.allow_bulk_delete) return false;
     const hasSensorService = !!parseServiceParts(this.config?.delete_service);
     const hasFrigateService = !!parseServiceParts(this.config?.frigate_delete_service);
     return hasSensorService || hasFrigateService;
@@ -4193,7 +4192,7 @@ class CameraGalleryCard extends LitElement {
   // ─── Selection / bulk delete ──────────────────────────────────────
 
   async _bulkDelete(selectedSrcList) {
-    if (!this.config?.allow_delete || !this.config?.allow_bulk_delete) return;
+    if (!this.config?.allow_bulk_delete) return;
 
     const srcs = Array.from(selectedSrcList || []);
     if (!srcs.length) return;
@@ -4809,9 +4808,7 @@ class CameraGalleryCard extends LitElement {
     const sp = parseServiceParts(this.config?.delete_service);
     const fsp = parseServiceParts(this.config?.frigate_delete_service);
 
-    const canDelete =
-      !!this.config?.allow_delete &&
-      (!!sp || !!fsp);
+    const canDelete = !!sp || !!fsp;
     const canBulkDelete =
       !!this.config?.allow_bulk_delete &&
       (!!sp || !!fsp);


### PR DESCRIPTION
## Summary

Removes the `allow_delete` config flag. Same effect is achieved by
leaving `delete_service` empty — the `canDeleteItem` gate already
enforces that. One fewer knob to misconfigure.

`allow_bulk_delete` and `delete_confirm` stay; each expresses a
distinct intent.

**Breaking change for users who set `allow_delete: false` in YAML**:
delete becomes available again if `delete_service` is configured. To
disable delete, clear `delete_service`.