### PR TITLE
feat: sort order toggle for thumbnails

### DIFF
--- a/src/config/diff.spec.ts
+++ b/src/config/diff.spec.ts
@@ -27,6 +27,7 @@ const baseConfig = (overrides: Partial<CameraGalleryCardConfig> = {}): CameraGal
     thumb_size: 86,
     thumb_bar_position: "bottom",
     thumb_layout: "horizontal",
+    thumb_sort_order: "newest",
     thumbnail_frame_pct: 0,
     pill_size: 14,
     aspect_ratio: "16:9",

--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -130,6 +130,7 @@ export interface InputConfig {
   thumb_size?: number;
   thumb_bar_position?: string;
   thumb_layout?: string;
+  thumb_sort_order?: string;
   thumbnail_frame_pct?: number;
   capture_video_thumbnails?: boolean;
   pill_size?: number;

--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -51,6 +51,7 @@ import {
   DEFAULT_SOURCE_MODE,
   DEFAULT_THUMB_BAR_POSITION,
   DEFAULT_THUMB_LAYOUT,
+  DEFAULT_THUMB_SORT_ORDER,
   DEFAULT_THUMBNAIL_FRAME_PCT,
   DEFAULT_LIVE_LAYOUT,
   LIVE_LAYOUTS,
@@ -68,6 +69,7 @@ import {
   START_MODES,
   THUMB_BAR_POSITIONS,
   THUMB_LAYOUTS,
+  THUMB_SORT_ORDERS,
   THUMB_SIZE,
   THUMB_SIZE_MAX,
   THUMB_SIZE_MIN,
@@ -193,6 +195,7 @@ export const cameraGalleryCardConfigStruct = type({
   thumb_size: defaulted(intInRange(THUMB_SIZE_MIN, THUMB_SIZE_MAX), THUMB_SIZE),
   thumb_bar_position: defaulted(enums(THUMB_BAR_POSITIONS), DEFAULT_THUMB_BAR_POSITION),
   thumb_layout: defaulted(enums(THUMB_LAYOUTS), DEFAULT_THUMB_LAYOUT),
+  thumb_sort_order: defaulted(enums(THUMB_SORT_ORDERS), DEFAULT_THUMB_SORT_ORDER),
   thumbnail_frame_pct: defaulted(
     intInRange(THUMBNAIL_FRAME_PCT_MIN, THUMBNAIL_FRAME_PCT_MAX),
     DEFAULT_THUMBNAIL_FRAME_PCT

--- a/src/const.ts
+++ b/src/const.ts
@@ -13,6 +13,7 @@ export const SOURCE_MODES = ["sensor", "media", "combined"] as const;
 export const PREVIEW_POSITIONS = ["top", "bottom"] as const;
 export const THUMB_BAR_POSITIONS = ["top", "bottom", "hidden"] as const;
 export const THUMB_LAYOUTS = ["horizontal", "vertical"] as const;
+export const THUMB_SORT_ORDERS = ["newest", "oldest"] as const;
 export const BAR_POSITIONS = ["top", "bottom", "hidden"] as const;
 export const START_MODES = ["gallery", "live"] as const;
 export const OBJECT_FITS = ["cover", "contain"] as const;
@@ -24,6 +25,7 @@ export type SourceMode = (typeof SOURCE_MODES)[number];
 export type PreviewPosition = (typeof PREVIEW_POSITIONS)[number];
 export type ThumbBarPosition = (typeof THUMB_BAR_POSITIONS)[number];
 export type ThumbLayout = (typeof THUMB_LAYOUTS)[number];
+export type ThumbSortOrder = (typeof THUMB_SORT_ORDERS)[number];
 export type BarPosition = (typeof BAR_POSITIONS)[number];
 export type StartMode = (typeof START_MODES)[number];
 export type ObjectFit = (typeof OBJECT_FITS)[number];
@@ -193,6 +195,7 @@ export const DEFAULT_RESOLVE_BATCH = 32;
 export const DEFAULT_SOURCE_MODE = "sensor" satisfies SourceMode;
 export const DEFAULT_THUMB_BAR_POSITION = "bottom" satisfies ThumbBarPosition;
 export const DEFAULT_THUMB_LAYOUT = "horizontal" satisfies ThumbLayout;
+export const DEFAULT_THUMB_SORT_ORDER = "newest" satisfies ThumbSortOrder;
 export const DEFAULT_THUMBNAIL_FRAME_PCT = 0; // 0% = first frame, 100% = last frame
 export const DEFAULT_VISIBLE_OBJECT_FILTERS: readonly ObjectFilter[] = [];
 

--- a/src/index.js
+++ b/src/index.js
@@ -667,6 +667,10 @@ class CameraGalleryCard extends LitElement {
       return b.idx - a.idx;
     });
 
+    if (this.config?.thumb_sort_order === "oldest") {
+      withDt.reverse();
+    }
+
     const allWithDay = withDt.map((x) => ({ dayKey: x.dayKey, src: x.src, dtMs: x.dtMs }));
     const days = this._allKnownDays(allWithDay);
     const newestDay = days[0] ?? null;
@@ -3781,11 +3785,13 @@ class CameraGalleryCard extends LitElement {
    * applied — both call sites consume this stage.
    */
   _computeBaseList() {
+    const sortOrder = this.config?.thumb_sort_order === "oldest" ? "oldest" : "newest";
     if (
       this._cachedBaseList &&
       this._cachedBaseListItemsRev === this._itemsRev &&
       this._cachedBaseListSelectedDay === this._selectedDay &&
-      this._cachedBaseListObjFilters === this._objectFilters
+      this._cachedBaseListObjFilters === this._objectFilters &&
+      this._cachedBaseListSortOrder === sortOrder
     ) {
       return this._cachedBaseList;
     }
@@ -3806,6 +3812,7 @@ class CameraGalleryCard extends LitElement {
       this._cachedBaseListItemsRev = this._itemsRev;
       this._cachedBaseListSelectedDay = this._selectedDay;
       this._cachedBaseListObjFilters = this._objectFilters;
+      this._cachedBaseListSortOrder = sortOrder;
       return empty;
     }
 
@@ -3823,6 +3830,10 @@ class CameraGalleryCard extends LitElement {
       if (!aOk && bOk) return 1;
       return b.idx - a.idx;
     });
+
+    if (this.config?.thumb_sort_order === "oldest") {
+      withDt.reverse();
+    }
 
     const allWithDay = withDt.map((x) => ({ dayKey: x.dayKey, src: x.src, dtMs: x.dtMs }));
     const days = this._allKnownDays(allWithDay);
@@ -3859,6 +3870,7 @@ class CameraGalleryCard extends LitElement {
     this._cachedBaseListItemsRev = this._itemsRev;
     this._cachedBaseListSelectedDay = this._selectedDay;
     this._cachedBaseListObjFilters = this._objectFilters;
+    this._cachedBaseListSortOrder = sortOrder;
     return result;
   }
 
@@ -4118,6 +4130,10 @@ class CameraGalleryCard extends LitElement {
       if (!aOk && bOk) return 1;
       return b.idx - a.idx;
     });
+
+    if (this.config?.thumb_sort_order === "oldest") {
+      withDt.reverse();
+    }
 
     const allWithDay = withDt.map((x) => ({ dayKey: x.dayKey, src: x.src, dtMs: x.dtMs }));
     const days = this._allKnownDays(allWithDay);
@@ -8814,6 +8830,11 @@ class CameraGalleryCardEditor extends HTMLElement {
       return v === "vertical" ? "vertical" : "horizontal";
     })();
 
+    const thumbSortOrder = (() => {
+      const v = String(c.thumb_sort_order || "newest").toLowerCase().trim();
+      return v === "oldest" ? "oldest" : "newest";
+    })();
+
     const thumbSizeMuted = thumbLayout === "vertical";
 
     const allServices = this._hass?.services || {};
@@ -9687,6 +9708,14 @@ class CameraGalleryCardEditor extends HTMLElement {
                   <button class="seg ${thumbBarPos === "top" ? "on" : ""}" data-tbpos="top">Top</button>
                   <button class="seg ${thumbBarPos === "bottom" ? "on" : ""}" data-tbpos="bottom">Bottom</button>
                   <button class="seg ${thumbBarPos === "hidden" ? "on" : ""}" data-tbpos="hidden">Hidden</button>
+                </div>
+              </div>
+
+              <div class="row">
+                <div class="lbl">Sort order</div>
+                <div class="segwrap">
+                  <button class="seg ${thumbSortOrder === "newest" ? "on" : ""}" data-tsort="newest">Newest first</button>
+                  <button class="seg ${thumbSortOrder === "oldest" ? "on" : ""}" data-tsort="oldest">Oldest first</button>
                 </div>
               </div>
 
@@ -11944,6 +11973,13 @@ if (oldPanel && tmp.firstElementChild) {
     this.shadowRoot.querySelectorAll(".seg[data-tlayout]").forEach((btn) => {
       btn.addEventListener("click", () => {
         this._set("thumb_layout", btn.dataset.tlayout);
+        btn.closest(".segwrap")?.querySelectorAll(".seg").forEach((s) => s.classList.toggle("on", s === btn));
+      });
+    });
+
+    this.shadowRoot.querySelectorAll(".seg[data-tsort]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        this._set("thumb_sort_order", btn.dataset.tsort);
         btn.closest(".segwrap")?.querySelectorAll(".seg").forEach((s) => s.classList.toggle("on", s === btn));
       });
     });


### PR DESCRIPTION
## Summary

New "Sort order" option in the editor's Thumbs tab — choose between
*Newest first* (default) and *Oldest first*. Reverses the thumb
order within the active day. The date picker itself stays
newest-first.

## Test plan

- [x] Editor → Thumbs tab → "Sort order" with two options
- [x] Default is "Newest first" — no change vs current behavior
- [x] Switch to "Oldest first" → thumbs flip, oldest at the top
- [x] Date picker stays newest-first
- [x] Setting persists across page reload
- [x] Works in sensor, media, and combined source modes