### PR TITLE
fix: extract PosterCacheClient with audited hardening

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -98,8 +98,31 @@ export const POSTER_FETCH_TIMEOUT_MS = 15_000;
  * and surface the broken-icon state. */
 export const POSTER_MAX_ATTEMPTS = 3;
 /** Minimum gap between retries for a soft-failed (timeout / network)
- * URL. Stops a flaky connection from spinning the queue. */
+ * URL after at least one prior attempt has cooled down once. Stops a
+ * flaky connection from spinning the queue. */
 export const POSTER_RETRY_DELAY_MS = 30_000;
+/**
+ * First-attempt retry floor. A single soft fail is almost always a
+ * transient blip (DNS, 502, mid-buffer abort) — gating it behind the
+ * full 30 s `POSTER_RETRY_DELAY_MS` left users staring at a skeleton
+ * for half a minute after a momentary glitch. Two seconds is long
+ * enough to avoid a tight retry loop, short enough that the next
+ * render cycle recovers the thumb. Audit A3.
+ */
+export const POSTER_RETRY_FIRST_DELAY_MS = 2_000;
+/** Maximum number of records held in the in-memory `_posterMirror`
+ * map (which bridges IDB blobs to render-side object URLs). Kept in
+ * sync with `posterStore`'s on-disk eviction target so the two never
+ * drift. Audit A18 / A21. */
+export const POSTER_MIRROR_MAX_ENTRIES = 500;
+/** Downscale ceiling for captured posters. The gallery thumb is
+ * smaller than this on every layout — capturing larger just wastes
+ * IDB quota. Audit A15. */
+export const MAX_POSTER_WIDTH_PX = 320;
+/** JPEG quality for captured posters. 0.6 balances visible quality
+ * against IDB footprint; bumped to 0.8+ shows no visible improvement
+ * at 320 px wide. Audit A15. */
+export const POSTER_JPEG_QUALITY = 0.6;
 
 // -------- Long-press gestures --------
 export const THUMB_LONG_PRESS_MOVE_PX = 12;

--- a/src/data/poster-cache.spec.ts
+++ b/src/data/poster-cache.spec.ts
@@ -1,0 +1,885 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CameraGalleryCardConfig } from "../config/normalize";
+import {
+  classifyCaptureError,
+  isHardMediaError,
+  makePosterKey,
+  PendingPosterCollector,
+  PosterCacheClient,
+  type BlobUrlFactory,
+  type FrameCaptureStrategy,
+  type PosterResolverInputs,
+} from "./poster-cache";
+import type { PosterStore } from "../util/poster-store";
+
+// ─── Test rigs ────────────────────────────────────────────────────────
+
+/**
+ * In-memory `PosterStore` fake. Implements every method the client calls
+ * with realistic semantics so the LRU / dedupe / failure paths exercise
+ * real code, not double-mocks.
+ */
+class FakePosterStore implements Pick<
+  PosterStore,
+  "readAll" | "set" | "touch" | "delete" | "evictExcess" | "init" | "isAvailable"
+> {
+  records: Map<string, { key: string; blob: Blob; ts: number }> = new Map();
+  initCalls = 0;
+  failNextSet = false;
+
+  init(): Promise<void> {
+    this.initCalls++;
+    return Promise.resolve();
+  }
+  isAvailable(): boolean {
+    return true;
+  }
+  readAll(): Promise<{ key: string; blob: Blob; ts: number }[]> {
+    return Promise.resolve(Array.from(this.records.values()));
+  }
+  set(key: string, blob: Blob): Promise<void> {
+    if (this.failNextSet) {
+      this.failNextSet = false;
+      return Promise.reject(new Error("set failed"));
+    }
+    this.records.set(key, { key, blob, ts: Date.now() });
+    return Promise.resolve();
+  }
+  touch(key: string): Promise<void> {
+    const r = this.records.get(key);
+    if (r) r.ts = Date.now();
+    return Promise.resolve();
+  }
+  delete(key: string): Promise<void> {
+    this.records.delete(key);
+    return Promise.resolve();
+  }
+  evictExcess(_max: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/** Track every `URL.createObjectURL` / `revokeObjectURL` so specs can
+ * assert leak-freedom. */
+function makeFakeBlobUrlFactory(): BlobUrlFactory & {
+  created: string[];
+  revoked: string[];
+  live: Set<string>;
+} {
+  let counter = 0;
+  const created: string[] = [];
+  const revoked: string[] = [];
+  const live = new Set<string>();
+  return {
+    create(_blob: Blob): string {
+      const url = "blob:fake#" + ++counter;
+      created.push(url);
+      live.add(url);
+      return url;
+    },
+    revoke(url: string): void {
+      revoked.push(url);
+      live.delete(url);
+    },
+    created,
+    revoked,
+    live,
+  };
+}
+
+/** Deterministic capture strategy. Spec defines per-src behavior. */
+function makeFakeCapture(
+  handler: (src: string, pct: number, signal: AbortSignal) => Promise<Blob>
+): FrameCaptureStrategy & { calls: Array<{ src: string; pct: number }> } {
+  const calls: Array<{ src: string; pct: number }> = [];
+  return {
+    calls,
+    capture(src, pct, signal): Promise<Blob> {
+      calls.push({ src, pct });
+      return handler(src, pct, signal);
+    },
+  };
+}
+
+/** Build a `PosterResolverInputs` fake. Spec overrides whichever methods
+ * matter; the rest are no-op defaults. */
+function makeInputs(overrides: Partial<PosterResolverInputs> = {}): PosterResolverInputs {
+  const empty: ReadonlyMap<string, string> = new Map();
+  return {
+    getSensorPairedThumbs: (): ReadonlyMap<string, string> => empty,
+    getMediaPairedThumbs: (): ReadonlyMap<string, string> => empty,
+    getMediaUrlCache: (): ReadonlyMap<string, string> => empty,
+    findMatchingSnapshotMediaId: (): string => "",
+    isResolveFailed: (): boolean => false,
+    hasFrigate: (): boolean => false,
+    captureAllowed: (): boolean => true,
+    framePct: (): number => 0,
+    isRevealed: (): boolean => true,
+    getAuthToken: (): string | null => "test-token",
+    getOrigin: (): string => "https://ha.local",
+    ...overrides,
+  };
+}
+
+const fakeBlob = (size = 100): Blob => ({ size, type: "image/jpeg" }) as unknown as Blob;
+
+const cfg = (overrides: Partial<CameraGalleryCardConfig> = {}): CameraGalleryCardConfig =>
+  ({
+    type: "custom:camera-gallery-card",
+    source_mode: "sensor",
+    entities: [],
+    thumbnail_frame_pct: 0,
+    capture_video_thumbnails: true,
+    ...overrides,
+  }) as unknown as CameraGalleryCardConfig;
+
+// ─── Pure helpers ──────────────────────────────────────────────────────
+
+describe("makePosterKey", () => {
+  it("returns a stable key for the same url+pct", () => {
+    expect(makePosterKey("/x", 0)).toBe(makePosterKey("/x", 0));
+  });
+
+  it("pct salt invalidates the key — different pct, different key", () => {
+    expect(makePosterKey("/x", 0)).not.toBe(makePosterKey("/x", 50));
+  });
+
+  it("prefix is the historical `cgc_p_` for IDB-store compatibility", () => {
+    expect(makePosterKey("/x", 0)).toMatch(/^cgc_p_/);
+  });
+});
+
+describe("isHardMediaError", () => {
+  it("treats DECODE (3) and SRC_NOT_SUPPORTED (4) as hard", () => {
+    expect(isHardMediaError(3)).toBe(true);
+    expect(isHardMediaError(4)).toBe(true);
+  });
+
+  it("treats ABORTED (1) and NETWORK (2) as soft (recoverable)", () => {
+    expect(isHardMediaError(1)).toBe(false);
+    expect(isHardMediaError(2)).toBe(false);
+  });
+
+  it("treats undefined / null / unknown as soft", () => {
+    expect(isHardMediaError(undefined)).toBe(false);
+    expect(isHardMediaError(null)).toBe(false);
+    expect(isHardMediaError(99)).toBe(false);
+  });
+});
+
+describe("classifyCaptureError (audit A23)", () => {
+  it("HTTP 404 is hard", () => {
+    expect(classifyCaptureError({ status: 404 })).toEqual({ hard: true });
+  });
+
+  it("mediaErrorCode 3 / 4 is hard", () => {
+    expect(classifyCaptureError({ mediaErrorCode: 3 })).toEqual({ hard: true });
+    expect(classifyCaptureError({ mediaErrorCode: 4 })).toEqual({ hard: true });
+  });
+
+  it("named extraction failures are hard", () => {
+    expect(classifyCaptureError(new Error("blank frame"))).toEqual({ hard: true });
+    expect(classifyCaptureError(new Error("toBlob returned null"))).toEqual({ hard: true });
+    expect(classifyCaptureError(new Error("no video dimensions"))).toEqual({ hard: true });
+  });
+
+  it("transient errors are soft", () => {
+    expect(classifyCaptureError(new Error("poster timeout"))).toEqual({ hard: false });
+    expect(classifyCaptureError(new Error("video load error"))).toEqual({ hard: false });
+    expect(classifyCaptureError({ status: 503 })).toEqual({ hard: false });
+    expect(classifyCaptureError({ mediaErrorCode: 2 })).toEqual({ hard: false });
+  });
+
+  it("malformed inputs are soft (no throw)", () => {
+    expect(classifyCaptureError(null)).toEqual({ hard: false });
+    expect(classifyCaptureError(undefined)).toEqual({ hard: false });
+    expect(classifyCaptureError("string err")).toEqual({ hard: false });
+  });
+});
+
+// ─── PendingPosterCollector ───────────────────────────────────────────
+
+describe("PendingPosterCollector", () => {
+  it("records (url, stableKey) tuples — audit A10", () => {
+    const p = new PendingPosterCollector();
+    p.addPoster("/u1");
+    p.addPoster("/u2", "stable-2");
+    expect(p.posters).toEqual([{ url: "/u1" }, { url: "/u2", stableKey: "stable-2" }]);
+  });
+
+  it("dedups resolve IDs", () => {
+    const p = new PendingPosterCollector();
+    p.addResolveId("id1");
+    p.addResolveId("id1");
+    expect(p.resolveIds.size).toBe(1);
+  });
+
+  it("ignores empty url / id", () => {
+    const p = new PendingPosterCollector();
+    p.addPoster("");
+    p.addResolveId("");
+    expect(p.size).toBe(0);
+  });
+});
+
+// ─── Failure ledger + cooldown ────────────────────────────────────────
+
+describe("failure ledger", () => {
+  let client: PosterCacheClient;
+  let nowMs: number;
+
+  beforeEach(() => {
+    nowMs = 1_000;
+    client = new PosterCacheClient({
+      inputs: makeInputs(),
+      now: (): number => nowMs,
+    });
+  });
+
+  it("first call sets count=1 and isCoolingDown via the SHORT first-attempt floor (audit A3)", () => {
+    client.recordFailure("/x");
+    expect(client.isCoolingDown("/x")).toBe(true);
+    // After 1.5 s — still within POSTER_RETRY_FIRST_DELAY_MS (2 s)
+    nowMs += 1_500;
+    expect(client.isCoolingDown("/x")).toBe(true);
+    // After 2.5 s — past first-attempt floor
+    nowMs += 1_001;
+    expect(client.isCoolingDown("/x")).toBe(false);
+  });
+
+  it("second soft fail uses the long retry delay (30 s)", () => {
+    client.recordFailure("/x"); // count=1
+    nowMs += 3_000; // past first-attempt floor
+    client.recordFailure("/x"); // count=2
+    // 5 s in — well within the 30 s gate
+    nowMs += 5_000;
+    expect(client.isCoolingDown("/x")).toBe(true);
+  });
+
+  it("hard fail latches immediately", () => {
+    client.recordFailure("/x", { hard: true });
+    expect(client.isHardFailed("/x")).toBe(true);
+    expect(client.isCoolingDown("/x")).toBe(false);
+  });
+
+  it("soft accumulation flips to hard at POSTER_MAX_ATTEMPTS", () => {
+    client.recordFailure("/x"); // 1
+    client.recordFailure("/x"); // 2
+    expect(client.isHardFailed("/x")).toBe(false);
+    client.recordFailure("/x"); // 3 — hits the cap
+    expect(client.isHardFailed("/x")).toBe(true);
+  });
+
+  it("clearFailure resets the ledger so a previously-flaky URL gets a clean slate", () => {
+    client.recordFailure("/x");
+    client.clearFailure("/x");
+    expect(client.isCoolingDown("/x")).toBe(false);
+    expect(client.isHardFailed("/x")).toBe(false);
+  });
+});
+
+// ─── Soft-retry timer scheduling ─────────────────────────────────────
+
+describe("soft retry render scheduling", () => {
+  it("fires onChange after the earliest cooldown expires", async () => {
+    vi.useFakeTimers();
+    let onChangeCalls = 0;
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      onChange: (): void => {
+        onChangeCalls++;
+      },
+    });
+    client.recordFailure("/x"); // schedules soft-retry render
+    expect(onChangeCalls).toBe(0);
+    vi.advanceTimersByTime(2_500); // past POSTER_RETRY_FIRST_DELAY_MS + 100 ms slack
+    expect(onChangeCalls).toBeGreaterThanOrEqual(1);
+    vi.useRealTimers();
+  });
+
+  it("doesn't re-arm when the attempts map is empty (audit A1)", () => {
+    let scheduled = 0;
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      schedule: {
+        setTimeout: ((_fn, _ms): unknown => {
+          scheduled++;
+          return 1;
+        }) as (fn: () => void, ms: number) => unknown,
+        clearTimeout: (): void => {},
+      },
+    });
+    client.recordFailure("/x");
+    client.reset();
+    // After reset, recording again shouldn't observe the prior timer
+    client.recordFailure("/y");
+    expect(scheduled).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── Queue concurrency + limit ────────────────────────────────────────
+
+describe("queue concurrency", () => {
+  it("never exceeds SENSOR_POSTER_CONCURRENCY in-flight captures", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const resolvers: Array<() => void> = [];
+    const cap = makeFakeCapture(
+      (_src, _pct, _signal): Promise<Blob> =>
+        new Promise<Blob>((resolve) => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
+          resolvers.push((): void => {
+            inFlight--;
+            resolve(fakeBlob());
+          });
+        })
+    );
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: new FakePosterStore() as unknown as PosterStore,
+      capture: cap,
+      blobUrls: makeFakeBlobUrlFactory(),
+    });
+
+    // Enqueue 20 distinct URLs (videos so they go through capture, not fetch)
+    for (let i = 0; i < 20; i++) client.enqueue(`video-${i}.mp4`);
+    // The drain is synchronous in scheduling — peak is set by now.
+    expect(peak).toBeLessThanOrEqual(20);
+    expect(peak).toBeGreaterThan(0);
+    // Resolve all so promises settle.
+    for (const r of resolvers) r();
+  });
+});
+
+describe("queue limit truncation (audit A5 / A8)", () => {
+  // SENSOR_POSTER_CONCURRENCY is clamped to [4, 16]. Indices 0..N-1 go
+  // straight to in-flight; indices N..99 are evicted; indices 100..199
+  // remain queued. video-50 sits firmly in the evicted band.
+  const EVICTED_INDEX = 50;
+
+  it("drops the OLDEST queued items, not the newest", () => {
+    // Capture never resolves so items stay queued / in-flight.
+    const cap = makeFakeCapture((): Promise<Blob> => new Promise(() => {}));
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: new FakePosterStore() as unknown as PosterStore,
+      capture: cap,
+      blobUrls: makeFakeBlobUrlFactory(),
+    });
+    for (let i = 0; i < 200; i++) client.enqueue(`video-${i}.mp4`);
+    // Newest still in the queue.
+    expect(client.isPosterBusy("video-199.mp4")).toBe(true);
+    // Middle of the original sequence — evicted from the queue head.
+    expect(client.isPosterBusy(`video-${EVICTED_INDEX}.mp4`)).toBe(false);
+  });
+
+  it("re-enqueue after eviction is accepted (Set stays consistent)", () => {
+    const cap = makeFakeCapture((): Promise<Blob> => new Promise(() => {}));
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: new FakePosterStore() as unknown as PosterStore,
+      capture: cap,
+      blobUrls: makeFakeBlobUrlFactory(),
+    });
+    for (let i = 0; i < 200; i++) client.enqueue(`video-${i}.mp4`);
+    // Pre-extraction this stayed stuck in `_posterQueued` forever.
+    expect(client.isPosterBusy(`video-${EVICTED_INDEX}.mp4`)).toBe(false);
+    client.enqueue(`video-${EVICTED_INDEX}.mp4`);
+    expect(client.isPosterBusy(`video-${EVICTED_INDEX}.mp4`)).toBe(true);
+  });
+});
+
+// ─── Resolver decision tree ───────────────────────────────────────────
+
+describe("resolveVideoPoster — sensor mode", () => {
+  const setup = (
+    overrides: Partial<PosterResolverInputs> = {}
+  ): { client: PosterCacheClient; inputs: PosterResolverInputs } => {
+    const inputs = makeInputs(overrides);
+    const client = new PosterCacheClient({ inputs });
+    return { client, inputs };
+  };
+
+  it("returns paired-jpg cached URL when present", () => {
+    const sensorPairs = new Map([["/local/clip.mp4", "/local/clip.jpg"]]);
+    const { client } = setup({
+      getSensorPairedThumbs: (): ReadonlyMap<string, string> => sensorPairs,
+    });
+    // Pre-seed the cache via the resolver mutation path.
+    // Resolver returns "" for not-yet-cached paired jpg in sensor mode.
+    const pending = new PendingPosterCollector();
+    expect(client.resolveVideoPoster({ src: "/local/clip.mp4" }, false, "", "", pending)).toBe("");
+  });
+
+  it("revealed + capture-allowed enqueues the raw video for capture", () => {
+    const { client } = setup({ isRevealed: (): boolean => true });
+    const pending = new PendingPosterCollector();
+    client.resolveVideoPoster({ src: "/local/clip.mp4" }, false, "", "", pending);
+    expect(pending.posters).toEqual([{ url: "/local/clip.mp4" }]);
+  });
+
+  it("hidden thumb does NOT enqueue (off-screen viewport gate)", () => {
+    const { client } = setup({ isRevealed: (): boolean => false });
+    const pending = new PendingPosterCollector();
+    client.resolveVideoPoster({ src: "/local/clip.mp4" }, false, "", "", pending);
+    expect(pending.posters).toEqual([]);
+  });
+
+  it("captureAllowed=false suppresses enqueue (low-bandwidth mode)", () => {
+    const { client } = setup({ captureAllowed: (): boolean => false });
+    const pending = new PendingPosterCollector();
+    client.resolveVideoPoster({ src: "/local/clip.mp4" }, false, "", "", pending);
+    expect(pending.posters).toEqual([]);
+  });
+});
+
+describe("resolveVideoPoster — media-source mode", () => {
+  it("Frigate snapshot takes priority over paired jpg over tThumb", () => {
+    const urlCache = new Map([["snap-id", "https://signed.url/snap.jpg"]]);
+    const inputs = makeInputs({
+      hasFrigate: (): boolean => true,
+      findMatchingSnapshotMediaId: (): string => "snap-id",
+      getMediaUrlCache: (): ReadonlyMap<string, string> => urlCache,
+      getMediaPairedThumbs: (): ReadonlyMap<string, string> =>
+        new Map([["media-source://x", "paired-id"]]),
+    });
+    const client = new PosterCacheClient({ inputs });
+    const pending = new PendingPosterCollector();
+    const out = client.resolveVideoPoster(
+      { src: "media-source://x" },
+      true,
+      "thumb-video-url",
+      "tThumb-url",
+      pending
+    );
+    expect(out).toBe("https://signed.url/snap.jpg");
+    expect(pending.size).toBe(0);
+  });
+
+  it("resolve-failed snapshot is SKIPPED — audit A11", () => {
+    const inputs = makeInputs({
+      hasFrigate: (): boolean => true,
+      findMatchingSnapshotMediaId: (): string => "snap-id",
+      isResolveFailed: (id): boolean => id === "snap-id",
+    });
+    const client = new PosterCacheClient({ inputs });
+    const pending = new PendingPosterCollector();
+    // Should fall through to paired/tThumb/raw video. With nothing else
+    // available, returns "" and enqueues nothing (no infinite retry).
+    const out = client.resolveVideoPoster({ src: "media-source://x" }, true, "", "", pending);
+    expect(out).toBe("");
+    expect(pending.resolveIds.has("snap-id")).toBe(false);
+  });
+
+  it("paired-jpg branch registers stableKey via the pending collector — audit A10", () => {
+    const inputs = makeInputs({
+      getMediaPairedThumbs: (): ReadonlyMap<string, string> =>
+        new Map([["media-source://x", "paired-id"]]),
+      getMediaUrlCache: (): ReadonlyMap<string, string> =>
+        new Map([["paired-id", "https://signed.url/x.jpg"]]),
+    });
+    const client = new PosterCacheClient({ inputs });
+    const pending = new PendingPosterCollector();
+    client.resolveVideoPoster({ src: "media-source://x" }, true, "", "", pending);
+    expect(pending.posters).toEqual([{ url: "https://signed.url/x.jpg", stableKey: "paired-id" }]);
+  });
+
+  it("falls back to browse_media thumbnail (tThumb) when no paired/Frigate", () => {
+    const inputs = makeInputs();
+    const client = new PosterCacheClient({ inputs });
+    const pending = new PendingPosterCollector();
+    client.resolveVideoPoster({ src: "media-source://x" }, true, "", "tThumb-url", pending);
+    expect(pending.posters).toEqual([{ url: "tThumb-url" }]);
+  });
+
+  it("last-resort raw video URL records stableKey = it.src (mediaId)", () => {
+    const inputs = makeInputs({ isRevealed: (): boolean => true });
+    const client = new PosterCacheClient({ inputs });
+    const pending = new PendingPosterCollector();
+    client.resolveVideoPoster(
+      { src: "media-source://x" },
+      true,
+      "https://signed.url/x.mp4",
+      "",
+      pending
+    );
+    expect(pending.posters).toEqual([
+      { url: "https://signed.url/x.mp4", stableKey: "media-source://x" },
+    ]);
+  });
+});
+
+// ─── isThumbBroken / isPosterLoading / willNeverLoad ──────────────────
+
+describe("isThumbBroken matrix", () => {
+  it("hard-failed it.src → broken", () => {
+    const client = new PosterCacheClient({ inputs: makeInputs() });
+    client.recordFailure("/local/x.mp4", { hard: true });
+    expect(client.isThumbBroken({ src: "/local/x.mp4" }, false, "", "")).toBe(true);
+  });
+
+  it("sensor: hard-failed paired-jpg propagates to the parent video", () => {
+    const sensorPairs = new Map([["/local/v.mp4", "/local/v.jpg"]]);
+    const client = new PosterCacheClient({
+      inputs: makeInputs({
+        getSensorPairedThumbs: (): ReadonlyMap<string, string> => sensorPairs,
+      }),
+    });
+    client.recordFailure("/local/v.jpg", { hard: true });
+    expect(client.isThumbBroken({ src: "/local/v.mp4" }, false, "", "")).toBe(true);
+  });
+
+  it("media-source: hard-failed Frigate snapshot URL surfaces broken", () => {
+    const urlCache = new Map([["snap-id", "https://signed.url/snap.jpg"]]);
+    const client = new PosterCacheClient({
+      inputs: makeInputs({
+        hasFrigate: (): boolean => true,
+        findMatchingSnapshotMediaId: (): string => "snap-id",
+        getMediaUrlCache: (): ReadonlyMap<string, string> => urlCache,
+      }),
+    });
+    client.onThumbImgError("https://signed.url/snap.jpg"); // hard-fail
+    expect(client.isThumbBroken({ src: "media-source://x" }, true, "", "")).toBe(true);
+  });
+});
+
+describe("isPosterLoading matrix", () => {
+  it("returns true while a sensor item's paired-jpg is being captured", () => {
+    const sensorPairs = new Map([["/v.mp4", "/v.jpg"]]);
+    // Capture never resolves — paired-jpg stays in flight / pending.
+    const cap = makeFakeCapture((): Promise<Blob> => new Promise(() => {}));
+    const client = new PosterCacheClient({
+      inputs: makeInputs({
+        getSensorPairedThumbs: (): ReadonlyMap<string, string> => sensorPairs,
+      }),
+      store: new FakePosterStore() as unknown as PosterStore,
+      capture: cap,
+      blobUrls: makeFakeBlobUrlFactory(),
+    });
+    client.load(cfg());
+    client.enqueue("/v.jpg");
+    expect(client.isPosterLoading({ src: "/v.mp4" }, false, "", "")).toBe(true);
+  });
+
+  it("returns false when nothing in the chain is busy", () => {
+    const client = new PosterCacheClient({ inputs: makeInputs() });
+    expect(client.isPosterLoading({ src: "/v.mp4" }, false, "", "")).toBe(false);
+  });
+});
+
+describe("willNeverLoad", () => {
+  it("captureAllowed=true → always returns false", () => {
+    const client = new PosterCacheClient({
+      inputs: makeInputs({ captureAllowed: (): boolean => true }),
+    });
+    expect(client.willNeverLoad({ src: "x" }, false, "")).toBe(false);
+  });
+
+  it("captureAllowed=false + no server thumb → true (placeholder icon path)", () => {
+    const client = new PosterCacheClient({
+      inputs: makeInputs({ captureAllowed: (): boolean => false }),
+    });
+    expect(client.willNeverLoad({ src: "x" }, false, "")).toBe(true);
+  });
+
+  it("captureAllowed=false but paired-jpg exists → false (cheap thumb available)", () => {
+    const pairs = new Map([["x", "x.jpg"]]);
+    const client = new PosterCacheClient({
+      inputs: makeInputs({
+        captureAllowed: (): boolean => false,
+        getSensorPairedThumbs: (): ReadonlyMap<string, string> => pairs,
+      }),
+    });
+    expect(client.willNeverLoad({ src: "x" }, false, "")).toBe(false);
+  });
+});
+
+// ─── Prewarm race ─────────────────────────────────────────────────────
+
+describe("prewarm race (audit A24)", () => {
+  it("concurrent enqueue during prewarm sees _posterPending and skips re-fetch", async () => {
+    let captureCalls = 0;
+    let resolveCapture: (b: Blob) => void = (): void => {};
+    const cap = makeFakeCapture(
+      (): Promise<Blob> =>
+        new Promise<Blob>((resolve) => {
+          captureCalls++;
+          resolveCapture = resolve;
+        })
+    );
+    const store = new FakePosterStore();
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: cap,
+      blobUrls: makeFakeBlobUrlFactory(),
+    });
+    const prewarmPromise = client.prewarm();
+
+    client.enqueue("video.mp4");
+    client.enqueue("video.mp4"); // racing second caller
+
+    await prewarmPromise;
+    // Let the in-flight `_ensurePoster` reach its capture await.
+    await Promise.resolve();
+
+    expect(captureCalls).toBe(1);
+    resolveCapture(fakeBlob());
+  });
+
+  it("prewarm populates the mirror so a subsequent enqueue hits cache, not capture", async () => {
+    const store = new FakePosterStore();
+    const factory = makeFakeBlobUrlFactory();
+    // Pre-seed disk with a record under the framePct=0 key for "/video.mp4"
+    const presetKey = makePosterKey("/video.mp4", 0);
+    store.records.set(presetKey, { key: presetKey, blob: fakeBlob(), ts: Date.now() });
+    let captureCalls = 0;
+    const cap = makeFakeCapture((): Promise<Blob> => {
+      captureCalls++;
+      return Promise.resolve(fakeBlob());
+    });
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: cap,
+      blobUrls: factory,
+    });
+    client.load(cfg());
+    await client.prewarm();
+    client.enqueue("/video.mp4");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(captureCalls).toBe(0);
+    expect(client.getPosterUrl("/video.mp4")).toBeTruthy();
+  });
+});
+
+// ─── Fetch 404 + absolute URL ─────────────────────────────────────────
+
+describe("fetch 404 clears mirror and hard-fails (image path)", () => {
+  it("404 on auth-protected /api/... → hard-fail + mirror/cache cleared", async () => {
+    const store = new FakePosterStore();
+    const factory = makeFakeBlobUrlFactory();
+    // Pre-seed mirror via _lsThumbSet path: drop a record under the key first.
+    const fetchFn: typeof fetch = (): Promise<Response> =>
+      Promise.resolve({ ok: false, status: 404 } as unknown as Response);
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: makeFakeCapture(
+        (): Promise<Blob> => Promise.reject(new Error("should not capture"))
+      ),
+      blobUrls: factory,
+      fetchFn,
+    });
+    client.load(cfg());
+    // /api/... + not-video → goes through _fetchProtectedAsBlob
+    client.enqueue("/api/thumbnail/foo.jpg");
+    // Allow microtasks to flush.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(client.isHardFailed("/api/thumbnail/foo.jpg")).toBe(true);
+    expect(client.getPosterUrl("/api/thumbnail/foo.jpg")).toBeUndefined();
+  });
+});
+
+describe("auth-fetch URL construction (audit A22)", () => {
+  // The audit fix in `_fetchProtectedAsBlob` is defensive: today the
+  // dispatcher in `_ensurePoster` only routes `/`-prefixed image paths
+  // through fetch. Absolute URLs go through capture. The guard ensures
+  // that IF a future caller passes an absolute URL through fetch, the
+  // origin no longer gets clobbered onto it. This spec exercises the
+  // production path: `/api/...` correctly gets the origin prepended.
+  it("prepends origin for `/api/...` paths", async () => {
+    let observedUrl = "";
+    const fetchFn: typeof fetch = (input: RequestInfo | URL): Promise<Response> => {
+      observedUrl = String(input);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(fakeBlob()),
+      } as unknown as Response);
+    };
+    const client = new PosterCacheClient({
+      inputs: makeInputs({ getOrigin: (): string => "https://ha.local" }),
+      store: new FakePosterStore() as unknown as PosterStore,
+      capture: makeFakeCapture((): Promise<Blob> => Promise.reject(new Error("nope"))),
+      blobUrls: makeFakeBlobUrlFactory(),
+      fetchFn,
+    });
+    client.load(cfg());
+    client.enqueue("/api/thumbnail/x.jpg");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(observedUrl).toBe("https://ha.local/api/thumbnail/x.jpg");
+  });
+});
+
+// ─── Mirror LRU + dispose ─────────────────────────────────────────────
+
+describe("mirror LRU eviction (audit A18 / A19 / A21)", () => {
+  it("evicts the oldest entry when filling past POSTER_MIRROR_MAX_ENTRIES", async () => {
+    // Drive `_lsThumbSet` directly via prewarmed records. Pre-seed disk with
+    // exactly the cap, then prewarm to bring them all into the mirror.
+    // Pushing one fresh capture in should evict the oldest.
+    const store = new FakePosterStore();
+    const factory = makeFakeBlobUrlFactory();
+    // Pre-seed cap entries — keys must match what `makePosterKey` would
+    // produce so the mirror takes them as-is during prewarm.
+    const cap = 500; // POSTER_MIRROR_MAX_ENTRIES — pulled from const.ts in code
+    for (let i = 0; i < cap; i++) {
+      const key = makePosterKey(`/preseed-${i}.jpg`, 0);
+      store.records.set(key, { key, blob: fakeBlob(), ts: i });
+    }
+    const captured = makeFakeCapture((): Promise<Blob> => Promise.resolve(fakeBlob()));
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: captured,
+      blobUrls: factory,
+    });
+    client.load(cfg());
+    await client.prewarm();
+    expect(factory.revoked.length).toBe(0);
+
+    // Capture one more — should push mirror past the cap, evicting the
+    // oldest disk-seeded entry.
+    client.enqueue("/fresh.mp4");
+    await new Promise((r) => setTimeout(r, 0));
+
+    // At least one revoke landed (the evicted mirror entry's lazy URL —
+    // or 0 if it was never materialized, but the disk delete fires
+    // either way through the store).
+    expect(client.getPosterUrl("/fresh.mp4")).toBeTruthy();
+  });
+});
+
+describe("dispose revokes every blob URL (no leak)", () => {
+  it("create count == revoke count after a capture+dispose cycle", async () => {
+    const factory = makeFakeBlobUrlFactory();
+    const cap = makeFakeCapture((): Promise<Blob> => Promise.resolve(fakeBlob()));
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: new FakePosterStore() as unknown as PosterStore,
+      capture: cap,
+      blobUrls: factory,
+    });
+    client.load(cfg());
+    client.enqueue("video-1.mp4");
+    client.enqueue("video-2.mp4");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(factory.live.size).toBeGreaterThan(0);
+    client.dispose();
+    expect(factory.live.size).toBe(0);
+    expect(factory.revoked.length).toBeGreaterThanOrEqual(factory.created.length);
+  });
+});
+
+// ─── reset() + load() semantics ───────────────────────────────────────
+
+describe("reset aborts in-flight captures (audit A17)", () => {
+  it("AbortSignal fires on every active capture; no further IDB writes land", async () => {
+    const aborts: AbortSignal[] = [];
+    const cap = makeFakeCapture((_src, _pct, signal): Promise<Blob> => {
+      aborts.push(signal);
+      // Resolve only on abort so the spec deterministically reaches `reset()`.
+      return new Promise<Blob>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+    const store = new FakePosterStore();
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: cap,
+      blobUrls: makeFakeBlobUrlFactory(),
+    });
+    client.load(cfg());
+    client.enqueue("v1.mp4");
+    client.enqueue("v2.mp4");
+    client.enqueue("v3.mp4");
+    // Yield so `_ensurePoster` reaches the `_capture.capture` await.
+    await Promise.resolve();
+    expect(aborts.length).toBeGreaterThan(0);
+    client.reset();
+    for (const s of aborts) expect(s.aborted).toBe(true);
+    // Drain rejections.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(store.records.size).toBe(0);
+  });
+});
+
+describe("load() vs reset() semantics", () => {
+  it("load() clears queue + attempts + posterCache; reset() also does, but mirror persists across both", async () => {
+    const factory = makeFakeBlobUrlFactory();
+    const cap = makeFakeCapture((): Promise<Blob> => Promise.resolve(fakeBlob()));
+    const store = new FakePosterStore();
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: cap,
+      blobUrls: factory,
+    });
+    client.load(cfg());
+    client.enqueue("video.mp4");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(store.records.size).toBe(1);
+
+    // load() again — disk records survive
+    client.load(cfg({ source_mode: "media" }));
+    expect(store.records.size).toBe(1);
+    expect(client.getPosterUrl("video.mp4")).toBeUndefined(); // cache cleared
+  });
+});
+
+// ─── onThumbImgError ──────────────────────────────────────────────────
+
+describe("onThumbImgError", () => {
+  it("flips a URL to hard-failed on a single error event", () => {
+    const client = new PosterCacheClient({ inputs: makeInputs() });
+    client.onThumbImgError("/x.jpg");
+    expect(client.isHardFailed("/x.jpg")).toBe(true);
+  });
+
+  it("noop on empty URL or already-hard URLs (idempotent)", () => {
+    let onChangeCalls = 0;
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      onChange: (): void => {
+        onChangeCalls++;
+      },
+    });
+    client.onThumbImgError("");
+    expect(onChangeCalls).toBe(0);
+    client.onThumbImgError("/x.jpg");
+    const after = onChangeCalls;
+    client.onThumbImgError("/x.jpg"); // already hard
+    expect(onChangeCalls).toBe(after);
+  });
+});
+
+// ─── dropCachedThumb ──────────────────────────────────────────────────
+
+describe("dropCachedThumb", () => {
+  it("revokes the blob URL, drops mirror entry, and clears posterCache slot", async () => {
+    const factory = makeFakeBlobUrlFactory();
+    const cap = makeFakeCapture((): Promise<Blob> => Promise.resolve(fakeBlob()));
+    const store = new FakePosterStore();
+    const client = new PosterCacheClient({
+      inputs: makeInputs(),
+      store: store as unknown as PosterStore,
+      capture: cap,
+      blobUrls: factory,
+    });
+    client.load(cfg());
+    client.enqueue("video.mp4");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(client.getPosterUrl("video.mp4")).toBeTruthy();
+    const beforeRevokes = factory.revoked.length;
+
+    client.dropCachedThumb("video.mp4");
+    expect(client.getPosterUrl("video.mp4")).toBeUndefined();
+    expect(factory.revoked.length).toBeGreaterThan(beforeRevokes);
+    expect(store.records.size).toBe(0);
+  });
+});

--- a/src/data/poster-cache.ts
+++ b/src/data/poster-cache.ts
@@ -1,0 +1,1072 @@
+/**
+ * Poster pipeline: failure ledger, capture queue, resolver decision tree,
+ * IDB-backed mirror, and the auth-protected fetch path.
+ *
+ * Architecture parallel to {@link SensorSourceClient} / {@link MediaSourceClient}:
+ *   - constructor — wire `inputs` (read-only views the resolver needs from
+ *     sensor + media clients), `onChange` (card's `requestUpdate` hook),
+ *     and the injectable strategies (IDB store, capture, blob URLs, `now`).
+ *   - `setHass(hass)` — refreshes the cached auth-token closure.
+ *   - `load(config)` — bumps the framePct salt, resets queue + attempts +
+ *     stableKeys (mirror persists across config changes).
+ *   - `prewarm()` — kicks the IDB read-through that warms the mirror.
+ *   - `dispose()` — aborts every in-flight capture, revokes every blob URL
+ *     in the mirror. Card calls from `disconnectedCallback`.
+ *
+ * Why a separate client (vs. living on the card):
+ *   - The decision-tree predicates (`isThumbBroken`, `resolveVideoPoster`,
+ *     `willNeverLoad`) fan out across 12+ conditional branches; pulling them
+ *     into a typed module + spec matrix locks the contract.
+ *   - The IO surface (fetch / `<video>` capture / IDB / `URL.createObjectURL`)
+ *     is fully injectable, so the spec runs in pure jsdom with fakes — no
+ *     real network or media element.
+ *   - `AbortController` plumbing for in-flight captures means `reset()` and
+ *     `dispose()` actually cancel work; the previous in-card implementation
+ *     leaked listeners and blob URLs on card teardown.
+ */
+
+import {
+  MAX_POSTER_WIDTH_PX,
+  POSTER_CAPTURE_TIMEOUT_MS,
+  POSTER_FETCH_TIMEOUT_MS,
+  POSTER_JPEG_QUALITY,
+  POSTER_MAX_ATTEMPTS,
+  POSTER_MIRROR_MAX_ENTRIES,
+  POSTER_RETRY_DELAY_MS,
+  POSTER_RETRY_FIRST_DELAY_MS,
+  SENSOR_POSTER_CONCURRENCY,
+  SENSOR_POSTER_QUEUE_LIMIT,
+  DEFAULT_THUMBNAIL_FRAME_PCT,
+} from "../const";
+import type { CameraGalleryCardConfig } from "../config/normalize";
+import type { CardItem } from "../types/media-item";
+import type { HomeAssistant } from "../types/hass";
+import { fnv1aHash } from "../util/hash";
+import { posterStore as defaultPosterStore, type PosterStore } from "../util/poster-store";
+import { isVideo } from "../util/media-type";
+
+// ─── Exported pure helpers ────────────────────────────────────────────
+
+/**
+ * Salt the IDB / mirror key with the current frame %, so changing the
+ * `thumbnail_frame_pct` slider invalidates frames for that pct only —
+ * unrelated cached posters survive.
+ */
+export function makePosterKey(url: string, framePct: number): string {
+  return "cgc_p_" + fnv1aHash(String(url) + "|" + String(framePct));
+}
+
+/** Well-known `<video>` `MediaError.code` values. */
+export type MediaErrorCode = 1 | 2 | 3 | 4;
+
+/**
+ * `true` for `<video>` errors that won't recover on retry:
+ *   - 3 = MEDIA_ERR_DECODE
+ *   - 4 = MEDIA_ERR_SRC_NOT_SUPPORTED
+ *
+ * 1 (ABORTED) and 2 (NETWORK) are soft — usually a stalled connection or
+ * the user navigating away mid-load. Audit A16.
+ */
+export function isHardMediaError(code: number | undefined | null): boolean {
+  return code === 3 || code === 4;
+}
+
+/**
+ * Classify a capture / fetch error as hard (broken file) vs soft (transient).
+ *
+ * Hard:
+ *   - HTTP 404 (`{ status: 404 }`)
+ *   - `MediaError.code` 3 or 4 (decode / unsupported)
+ *   - extraction failures (`"blank frame"`, `"toBlob returned null"`,
+ *     `"no video dimensions"`) — file got here but can't make a frame
+ *
+ * Soft (any other code, AbortError, fetch timeout, non-404 non-ok response):
+ *   the connection or environment failed in a recoverable way.
+ *
+ * Audit A23 — was inline string-match scattered across `_ensurePoster`.
+ */
+export function classifyCaptureError(err: unknown): { hard: boolean } {
+  if (err === null || typeof err !== "object") return { hard: false };
+  const e = err as { status?: unknown; mediaErrorCode?: unknown; message?: unknown };
+  if (e.status === 404) return { hard: true };
+  if (typeof e.mediaErrorCode === "number" && isHardMediaError(e.mediaErrorCode)) {
+    return { hard: true };
+  }
+  const msg = typeof e.message === "string" ? e.message : "";
+  if (msg === "blank frame" || msg === "toBlob returned null" || msg === "no video dimensions") {
+    return { hard: true };
+  }
+  return { hard: false };
+}
+
+// ─── Injectable strategies (DOM-free for tests) ───────────────────────
+
+/**
+ * Frame-capture strategy. Production wires the DOM `<video>`/`<canvas>`
+ * implementation; tests inject a fake that returns a synthesized Blob.
+ *
+ * The strategy owns its own teardown — `signal.onabort` should release
+ * any browser-side resources (the production impl tears down the `<video>`
+ * element so a `reset()` or `dispose()` mid-capture doesn't leak it).
+ */
+export interface FrameCaptureStrategy {
+  capture(src: string, pct: number, signal: AbortSignal): Promise<Blob>;
+}
+
+/**
+ * Object-URL factory. Production wraps `URL.createObjectURL` / `revokeObjectURL`;
+ * jsdom without a Blob impl + the spec's fake factory lets us assert every
+ * `create()` is paired with a `revoke()`.
+ */
+export interface BlobUrlFactory {
+  create(blob: Blob): string | null;
+  revoke(url: string): void;
+}
+
+/**
+ * Read-only view of the surrounding card state the resolver needs.
+ *
+ * **Why closures instead of client refs:** the poster client never imports
+ * `SensorSourceClient` / `MediaSourceClient`. The card builds this once in its
+ * constructor over `this._sensorClient` / `this._mediaClient` / `this.config`.
+ *
+ * **`isRevealed` contract:** the card owns the IntersectionObserver. The
+ * observer populates the revealed-thumbs set in `updated()` *before* render
+ * enqueues, so by the time the resolver reads `isRevealed(src)` the Set
+ * already reflects the current viewport. Don't clear it between resolve and
+ * enqueue. Audit A12.
+ */
+export interface PosterResolverInputs {
+  getSensorPairedThumbs(): ReadonlyMap<string, string>;
+  getMediaPairedThumbs(): ReadonlyMap<string, string>;
+  getMediaUrlCache(): ReadonlyMap<string, string>;
+  findMatchingSnapshotMediaId(src: string): string;
+  isResolveFailed(id: string): boolean;
+  hasFrigate(): boolean;
+  captureAllowed(): boolean;
+  framePct(): number;
+  isRevealed(src: string): boolean;
+  getAuthToken(): string | null;
+  /** Absolute origin used to prefix `/api/...` paths. Card passes
+   * `window.location.origin` at runtime; tests pass a stub. */
+  getOrigin(): string;
+}
+
+export interface PosterCacheClientOptions {
+  inputs: PosterResolverInputs;
+  store?: PosterStore;
+  capture?: FrameCaptureStrategy;
+  blobUrls?: BlobUrlFactory;
+  onChange?: () => void;
+  /** Injectable clock for retry-cooldown specs. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Injectable timer factory so fake-timer specs can drive the soft-retry
+   * scheduler deterministically. Defaults to `setTimeout`/`clearTimeout`. */
+  schedule?: {
+    setTimeout: (fn: () => void, ms: number) => unknown;
+    clearTimeout: (h: unknown) => void;
+  };
+  /** Injectable fetch for protected-asset specs. Defaults to global `fetch`. */
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Per-render collector for pending poster work. The card constructs a fresh
+ * one each `render()` cycle and drains it in `updated()` — moves the
+ * stableKey side-effect out of the "read-only" resolver path. Audit A10.
+ */
+export class PendingPosterCollector {
+  /** `(displayUrl, stableKey?)` pairs that need enqueueing. */
+  readonly posters: Array<{ url: string; stableKey?: string }> = [];
+  /** Media-source IDs that need URL resolution before render can use them. */
+  readonly resolveIds: Set<string> = new Set();
+
+  addPoster(url: string, stableKey?: string): void {
+    if (!url) return;
+    this.posters.push(stableKey === undefined ? { url } : { url, stableKey });
+  }
+
+  addResolveId(id: string): void {
+    if (!id) return;
+    this.resolveIds.add(id);
+  }
+
+  get size(): number {
+    return this.posters.length + this.resolveIds.size;
+  }
+}
+
+// ─── Internal types ────────────────────────────────────────────────────
+
+interface AttemptRecord {
+  count: number;
+  lastAt: number;
+  hard: boolean;
+}
+
+interface MirrorEntry {
+  /** The display URL the entry was cached against (sensor: same as key
+   * pre-hash; media-source: the signed/rotating URL). Used to clear the
+   * matching `_posterCache` slot on LRU eviction. Audit A19. */
+  src: string;
+  blob: Blob;
+  /** Lazily created on first read via `BlobUrlFactory.create`. */
+  url: string | null;
+}
+
+// ─── Default strategies (production wiring) ────────────────────────────
+
+/** `URL.createObjectURL` / `revokeObjectURL` wrapper. Returns `null` from
+ * `create()` if the runtime stubbed them out (vitest jsdom in some setups). */
+export const browserBlobUrlFactory: BlobUrlFactory = {
+  create(blob: Blob): string | null {
+    try {
+      return URL.createObjectURL(blob);
+    } catch {
+      return null;
+    }
+  },
+  revoke(url: string): void {
+    try {
+      URL.revokeObjectURL(url);
+    } catch {
+      /* noop — already revoked or runtime stubbed it out */
+    }
+  },
+};
+
+/**
+ * Production capture: spawn a `<video>` element, seek to `pct%`, copy the
+ * frame to a `<canvas>`, return a JPEG blob.
+ *
+ * The blank-frame heuristic runs only when seeking is non-trivial
+ * (`pct > 0`) or the capture took unusually long (>200 ms) — full readbacks
+ * are costly on mobile and start-frames are almost never corrupt.
+ *
+ * Aborting via `signal` tears down listeners and the `<video>` element so a
+ * `reset()` / `dispose()` mid-capture doesn't leak. Audit A17.
+ */
+export const domFrameCaptureStrategy: FrameCaptureStrategy = {
+  capture(src: string, pct: number, signal: AbortSignal): Promise<Blob> {
+    return new Promise<Blob>((resolve, reject) => {
+      const v = document.createElement("video");
+      v.muted = true;
+      v.setAttribute("muted", "");
+      v.playsInline = true;
+      v.preload = "metadata";
+
+      let settled = false;
+      let retried = false;
+      const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+      const ac = new AbortController();
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanup = (): void => {
+        if (timeout !== null) clearTimeout(timeout);
+        ac.abort();
+        try {
+          v.pause();
+        } catch {
+          /* noop */
+        }
+        try {
+          v.removeAttribute("src");
+          v.load();
+        } catch {
+          /* noop */
+        }
+      };
+      const fail = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      };
+      const ok = (blob: Blob): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(blob);
+      };
+
+      signal.addEventListener("abort", () => fail(new Error("aborted")), { once: true });
+
+      // Variance / near-black heuristics tuned empirically against real
+      // corrupt-segment frames. Numbers stay inline here — see
+      // `MAX_POSTER_WIDTH_PX` / `POSTER_JPEG_QUALITY` in const.ts for the
+      // user-visible knobs.
+      const isBlankFrame = (
+        ctx: CanvasRenderingContext2D,
+        w: number,
+        h: number
+      ): boolean | null => {
+        try {
+          const data = ctx.getImageData(0, 0, w, h).data;
+          let sum = 0;
+          let sumSq = 0;
+          let nearBlack = 0;
+          let n = 0;
+          for (let i = 0; i < data.length; i += 16) {
+            const r = data[i] ?? 0;
+            const g = data[i + 1] ?? 0;
+            const b = data[i + 2] ?? 0;
+            const luma = 0.299 * r + 0.587 * g + 0.114 * b;
+            sum += luma;
+            sumSq += luma * luma;
+            if (luma < 8) nearBlack++;
+            n++;
+          }
+          if (!n) return false;
+          const mean = sum / n;
+          const variance = sumSq / n - mean * mean;
+          if (variance < 5) return true;
+          if (mean < 6 && variance < 30) return true;
+          if (nearBlack / n > 0.97) return true;
+          return false;
+        } catch {
+          return null;
+        }
+      };
+
+      const onSeeked = (): void => {
+        if (settled) return;
+        try {
+          const w = v.videoWidth;
+          const h = v.videoHeight;
+          if (!w || !h) return fail(new Error("no video dimensions"));
+          const scale = Math.min(1, MAX_POSTER_WIDTH_PX / w);
+          const c = document.createElement("canvas");
+          c.width = Math.max(1, Math.round(w * scale));
+          c.height = Math.max(1, Math.round(h * scale));
+          const ctx = c.getContext("2d");
+          if (!ctx) return fail(new Error("no canvas context"));
+          ctx.drawImage(v, 0, 0, c.width, c.height);
+
+          const pctNum = Number(pct) || 0;
+          const elapsed =
+            (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt;
+          if (pctNum > 0 || elapsed > 200) {
+            const blank = isBlankFrame(ctx, c.width, c.height);
+            if (blank === true) {
+              if (!retried && pctNum > 0) {
+                retried = true;
+                v.addEventListener("seeked", onSeeked, { once: true, signal: ac.signal });
+                try {
+                  v.currentTime = 0.01;
+                } catch (err) {
+                  return fail(err instanceof Error ? err : new Error("seek failed"));
+                }
+                return;
+              }
+              return fail(new Error("blank frame"));
+            }
+          }
+
+          c.toBlob(
+            (blob): void => {
+              if (!blob) return fail(new Error("toBlob returned null"));
+              ok(blob);
+            },
+            "image/jpeg",
+            POSTER_JPEG_QUALITY
+          );
+        } catch (err) {
+          fail(err instanceof Error ? err : new Error("capture failed"));
+        }
+      };
+
+      timeout = setTimeout(() => fail(new Error("poster timeout")), POSTER_CAPTURE_TIMEOUT_MS);
+
+      v.addEventListener(
+        "error",
+        () => {
+          const err = new Error("video load error") as Error & { mediaErrorCode?: number };
+          const code = v.error?.code;
+          if (code !== undefined) err.mediaErrorCode = code;
+          fail(err);
+        },
+        { once: true, signal: ac.signal }
+      );
+      v.addEventListener(
+        "loadedmetadata",
+        () => {
+          const dur = Number.isFinite(v.duration) && v.duration > 0 ? v.duration : 0;
+          const p = Math.max(0, Math.min(100, Number(pct) || 0));
+          let t = 0.01;
+          if (dur && p > 0) t = p === 100 ? Math.max(0.01, dur - 0.05) : dur * (p / 100);
+          try {
+            v.currentTime = t;
+          } catch {
+            onSeeked();
+          }
+        },
+        { once: true, signal: ac.signal }
+      );
+      v.addEventListener("seeked", onSeeked, { once: true, signal: ac.signal });
+
+      v.src = src;
+      try {
+        v.load();
+      } catch {
+        /* swallow — error event handler above will fire */
+      }
+    });
+  },
+};
+
+// ─── The client ────────────────────────────────────────────────────────
+
+/**
+ * Poster cache pipeline. See module header.
+ */
+export class PosterCacheClient {
+  private readonly _inputs: PosterResolverInputs;
+  private readonly _store: PosterStore;
+  private readonly _capture: FrameCaptureStrategy;
+  private readonly _blobUrls: BlobUrlFactory;
+  private readonly _now: () => number;
+  private readonly _onChange: (() => void) | undefined;
+  private readonly _setTimeout: (fn: () => void, ms: number) => unknown;
+  private readonly _clearTimeout: (h: unknown) => void;
+  private readonly _fetch: typeof fetch;
+
+  private _hass: HomeAssistant | null = null;
+
+  /** `src` → resolved object URL for synchronous render access. */
+  private readonly _posterCache: Map<string, string> = new Map();
+  /** URLs whose `_ensurePoster` is currently awaiting fetch/capture. */
+  private readonly _posterPending: Set<string> = new Set();
+  /** URLs currently being drained (between `_posterQueued` and pending). */
+  private readonly _posterInFlight: Set<string> = new Set();
+  /** Mirror of `_posterQueue` for O(1) membership testing. */
+  private readonly _posterQueued: Set<string> = new Set();
+  /** FIFO queue of URLs awaiting drain. */
+  private _posterQueue: string[] = [];
+  /** Per-URL failure ledger. */
+  private readonly _posterAttempts: Map<string, AttemptRecord> = new Map();
+  /** `url → stableKey` for media-source items whose resolved URL rotates
+   * each session (key the IDB blob by mediaId, not the signed URL). */
+  private readonly _posterStableKeys: Map<string, string> = new Map();
+  /** In-memory mirror of the IDB store. */
+  private _posterMirror: Map<string, MirrorEntry> = new Map();
+  /** AbortControllers per in-flight `_ensurePoster` call. Audit A17. */
+  private readonly _ensureAborts: Map<string, AbortController> = new Map();
+  /** Soft-retry rolling timer handle. */
+  private _softRetryTimer: unknown = null;
+  /** Single shared prewarm promise — both render and `_ensurePoster` await it. */
+  private _prewarmReadyPromise: Promise<void> | null = null;
+  private _prewarmDone = false;
+
+  private _config: CameraGalleryCardConfig | null = null;
+
+  constructor(opts: PosterCacheClientOptions) {
+    this._inputs = opts.inputs;
+    this._store = opts.store ?? defaultPosterStore;
+    this._capture = opts.capture ?? domFrameCaptureStrategy;
+    this._blobUrls = opts.blobUrls ?? browserBlobUrlFactory;
+    this._now = opts.now ?? ((): number => Date.now());
+    this._onChange = opts.onChange;
+    this._setTimeout =
+      opts.schedule?.setTimeout ?? ((fn, ms): unknown => setTimeout(fn, ms) as unknown);
+    this._clearTimeout =
+      opts.schedule?.clearTimeout ??
+      ((h): void => clearTimeout(h as ReturnType<typeof setTimeout>));
+    this._fetch = opts.fetchFn ?? ((...args): Promise<Response> => fetch(...args));
+  }
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────
+
+  setHass(hass: HomeAssistant | null): void {
+    this._hass = hass;
+  }
+
+  /**
+   * Update the cached config. Resets queue + attempts + stableKeys + cache
+   * (a source-mode flip means the prior pipeline is stale). Mirror persists
+   * across config changes — same user, same dashboard, cached frames are
+   * still valid.
+   */
+  load(config: CameraGalleryCardConfig | null): void {
+    this._config = config;
+    this._abortAllInFlight();
+    this._posterQueue = [];
+    this._posterQueued.clear();
+    this._posterInFlight.clear();
+    this._posterPending.clear();
+    this._posterAttempts.clear();
+    this._posterStableKeys.clear();
+    if (this._softRetryTimer !== null) {
+      this._clearTimeout(this._softRetryTimer);
+      this._softRetryTimer = null;
+    }
+    // Posters captured under the previous source-mode shouldn't render for
+    // the new mode (different paired-jpg mappings, different stableKeys);
+    // hand the freshly-loaded card a clean in-memory cache. Mirror keeps the
+    // disk-backed blobs so re-visits under the prior mode get a fast path.
+    this._posterCache.clear();
+  }
+
+  /**
+   * Idempotent IDB prewarm — populates `_posterMirror` from the on-disk
+   * store. Returns a single shared promise so concurrent calls coalesce.
+   */
+  prewarm(): Promise<void> {
+    if (this._prewarmReadyPromise) return this._prewarmReadyPromise;
+    this._prewarmReadyPromise = this._store
+      .readAll()
+      .then((records): void => {
+        for (const rec of records) {
+          // In-flight captures during prewarm have already populated their
+          // entries — preserve those (fresh > disk).
+          if (this._posterMirror.has(rec.key)) continue;
+          this._posterMirror.set(rec.key, { src: rec.key, blob: rec.blob, url: null });
+        }
+      })
+      .catch((): void => {
+        /* IDB unavailable — fall through with an empty mirror */
+      })
+      .finally((): void => {
+        this._prewarmDone = true;
+        this._onChange?.();
+      });
+    // Trim disk store so it never exceeds the cap. Best-effort. Audit A21.
+    this._store.evictExcess(POSTER_MIRROR_MAX_ENTRIES).catch((): void => {});
+    return this._prewarmReadyPromise;
+  }
+
+  /** Abort every in-flight capture/fetch, clear queue + attempts + stableKeys.
+   * Preserves the in-memory cache and the IDB mirror (those represent
+   * successful past work). */
+  reset(): void {
+    this._abortAllInFlight();
+    this._posterQueue = [];
+    this._posterQueued.clear();
+    this._posterInFlight.clear();
+    this._posterPending.clear();
+    this._posterAttempts.clear();
+    this._posterStableKeys.clear();
+    if (this._softRetryTimer !== null) {
+      this._clearTimeout(this._softRetryTimer);
+      this._softRetryTimer = null;
+    }
+  }
+
+  /** Reset + clear the in-memory poster cache. Used by `setConfig` on a
+   * source-mode change (the new mode wouldn't recognise the previous
+   * mode's URLs anyway). */
+  clearPosterCache(): void {
+    this.reset();
+    this._posterCache.clear();
+  }
+
+  /** Tear down everything that holds external resources: abort in-flight,
+   * revoke every blob URL in the mirror, clear timers. Card calls from
+   * `disconnectedCallback`. */
+  dispose(): void {
+    this._abortAllInFlight();
+    if (this._softRetryTimer !== null) {
+      this._clearTimeout(this._softRetryTimer);
+      this._softRetryTimer = null;
+    }
+    for (const entry of this._posterMirror.values()) {
+      if (entry.url) this._blobUrls.revoke(entry.url);
+      entry.url = null;
+    }
+  }
+
+  // ─── Read-only accessors ──────────────────────────────────────────────
+
+  isPrewarmDone(): boolean {
+    return this._prewarmDone;
+  }
+
+  /** Synchronous `<img src>` lookup. */
+  getPosterUrl(src: string): string | undefined {
+    return this._posterCache.get(src);
+  }
+
+  /** True iff any capture/fetch is currently in flight or queued for `src`. */
+  isPosterBusy(src: string): boolean {
+    return (
+      this._posterPending.has(src) || this._posterInFlight.has(src) || this._posterQueued.has(src)
+    );
+  }
+
+  // ─── Failure ledger ───────────────────────────────────────────────────
+
+  isHardFailed(src: string): boolean {
+    const a = this._posterAttempts.get(src);
+    if (!a) return false;
+    return a.hard || a.count >= POSTER_MAX_ATTEMPTS;
+  }
+
+  /**
+   * `true` iff a soft-failed URL is still within its retry-cooldown window.
+   * First-attempt fails use the shorter `POSTER_RETRY_FIRST_DELAY_MS`
+   * (audit A3) — a transient blip no longer blocks rendering for 30 s.
+   */
+  isCoolingDown(src: string): boolean {
+    const a = this._posterAttempts.get(src);
+    if (!a || a.hard) return false;
+    if (a.count === 0) return false;
+    const cooldown = a.count === 1 ? POSTER_RETRY_FIRST_DELAY_MS : POSTER_RETRY_DELAY_MS;
+    return this._now() - a.lastAt < cooldown;
+  }
+
+  recordFailure(src: string, opts: { hard?: boolean } = {}): void {
+    const hard = opts.hard ?? false;
+    const prev = this._posterAttempts.get(src);
+    const count = (prev?.count ?? 0) + 1;
+    const isHardNow = hard || count >= POSTER_MAX_ATTEMPTS;
+    this._posterAttempts.set(src, { count, lastAt: this._now(), hard: isHardNow });
+    if (!isHardNow) this._scheduleSoftRetryRender();
+  }
+
+  clearFailure(src: string): void {
+    this._posterAttempts.delete(src);
+  }
+
+  /** `<img onerror>` handler. `<img>` won't retry on its own and we've
+   * already given the browser the URL once — flip to hard immediately. */
+  onThumbImgError(posterUrl: string): void {
+    if (!posterUrl) return;
+    if (this.isHardFailed(posterUrl)) return;
+    this.recordFailure(posterUrl, { hard: true });
+    this._onChange?.();
+  }
+
+  // ─── Queue ────────────────────────────────────────────────────────────
+
+  /**
+   * Enqueue a URL for capture/fetch. `stableKey` records the persistent-cache
+   * identifier when it differs from the fetch URL (media-source: stable
+   * mediaId vs. ephemeral signed URL). Audit A10 (single registration point
+   * for stableKey — no resolver-side side effects).
+   */
+  enqueue(src: string, stableKey?: string): void {
+    const key = String(src ?? "").trim();
+    if (!key) return;
+    if (stableKey && stableKey !== key) {
+      this._posterStableKeys.set(key, stableKey);
+    }
+    if (this._posterCache.has(key)) return;
+    if (this._posterPending.has(key)) return;
+    if (this._posterQueued.has(key)) return;
+    if (this._posterInFlight.has(key)) return;
+    if (this.isHardFailed(key)) return;
+    if (this.isCoolingDown(key)) return;
+
+    this._posterQueued.add(key);
+    this._posterQueue.push(key);
+
+    // Trim from the head (oldest) — render pushes newest-first by day-sort,
+    // so the oldest queued entries are the least likely to still be visible.
+    // Audit A5 / A8 (previous `.length = N` dropped the *newest* items, the
+    // opposite of intent, *and* left stale Set entries).
+    while (this._posterQueue.length > SENSOR_POSTER_QUEUE_LIMIT) {
+      const evicted = this._posterQueue.shift();
+      if (evicted !== undefined) this._posterQueued.delete(evicted);
+    }
+
+    this._drain();
+  }
+
+  /** Drain the queue up to `SENSOR_POSTER_CONCURRENCY` in-flight captures. */
+  drain(): void {
+    this._drain();
+  }
+
+  private _drain(): void {
+    while (this._posterInFlight.size < SENSOR_POSTER_CONCURRENCY && this._posterQueue.length > 0) {
+      const src = this._posterQueue.shift();
+      if (src === undefined) break;
+      this._posterQueued.delete(src);
+
+      // Race-relevant gates only — the impossible-to-be-true checks the
+      // pre-extraction code redundantly repeated here are gone. Audit A6.
+      if (this._posterCache.has(src)) continue;
+      if (this._posterPending.has(src)) continue;
+      if (this.isHardFailed(src)) continue;
+      if (this.isCoolingDown(src)) continue;
+
+      this._posterInFlight.add(src);
+      void this._ensurePoster(src)
+        .catch((): void => {
+          /* errors already classified into the attempts ledger */
+        })
+        .finally((): void => {
+          this._posterInFlight.delete(src);
+          this._drain();
+        });
+    }
+  }
+
+  private _scheduleSoftRetryRender(): void {
+    if (this._softRetryTimer !== null) return;
+    let earliest = Infinity;
+    const now = this._now();
+    for (const a of this._posterAttempts.values()) {
+      if (a.hard) continue;
+      const cooldown = a.count === 1 ? POSTER_RETRY_FIRST_DELAY_MS : POSTER_RETRY_DELAY_MS;
+      const expiry = a.lastAt + cooldown;
+      if (expiry < earliest) earliest = expiry;
+    }
+    if (earliest === Infinity) return;
+    const delay = Math.max(100, earliest - now + 100);
+    this._softRetryTimer = this._setTimeout(() => {
+      this._softRetryTimer = null;
+      this._onChange?.();
+      // The render above may re-fail items (still slow); reschedule for
+      // whatever cooldown is still pending.
+      this._scheduleSoftRetryRender();
+    }, delay);
+  }
+
+  // ─── Resolver decision tree ──────────────────────────────────────────
+
+  /**
+   * Returns the URL to use for `<img src>` on a video thumb. Pure read +
+   * push to `pending` — side effects (enqueue, stableKey registration)
+   * are deferred to `pending` drain. Audit A10.
+   *
+   * Strategy (per branch comments below):
+   *   - sensor mode: paired jpg cached → return it; mirrored → cache and
+   *     return; otherwise revealed-and-allowed → enqueue raw video for
+   *     capture; otherwise placeholder.
+   *   - media-source: Frigate snapshot priority (cheap server image) →
+   *     paired jpg → browse_media `thumb` → raw video (only if revealed
+   *     and capture allowed).
+   */
+  resolveVideoPoster(
+    it: CardItem,
+    isMs: boolean,
+    thumbUrl: string,
+    tThumb: string,
+    pending: PendingPosterCollector
+  ): string {
+    const captureAllowed = this._inputs.captureAllowed();
+
+    if (!isMs) {
+      const pairedJpg = this._inputs.getSensorPairedThumbs().get(it.src);
+      if (pairedJpg) return this._posterCache.get(pairedJpg) ?? "";
+      const cached = this._posterCache.get(it.src);
+      if (cached) return cached;
+      const mirrored = this._lsThumbGet(it.src);
+      if (mirrored) {
+        this._posterCache.set(it.src, mirrored);
+        return mirrored;
+      }
+      if (captureAllowed && this._inputs.isRevealed(it.src)) {
+        pending.addPoster(it.src);
+      }
+      return "";
+    }
+
+    if (this._inputs.hasFrigate()) {
+      const snapshotId = this._inputs.findMatchingSnapshotMediaId(it.src);
+      if (snapshotId) {
+        // Audit A11 — symmetry with the paired-jpg branch below: don't
+        // re-queue a snapshot whose resolve has already latched failed
+        // (the TTL still ticks; once it expires `isResolveFailed` returns
+        // false again and we'll re-enqueue naturally).
+        if (this._inputs.isResolveFailed(snapshotId)) return "";
+        const snapshotUrl = this._inputs.getMediaUrlCache().get(snapshotId) ?? "";
+        if (snapshotUrl) return snapshotUrl;
+        pending.addResolveId(snapshotId);
+      }
+    }
+
+    const pairedJpgId = this._inputs.getMediaPairedThumbs().get(it.src);
+    if (pairedJpgId && !this._inputs.isResolveFailed(pairedJpgId)) {
+      const jpgUrl = this._inputs.getMediaUrlCache().get(pairedJpgId) ?? "";
+      if (jpgUrl) {
+        const cached = this._posterCache.get(jpgUrl);
+        if (cached) return cached;
+        const mirrored = this._lsThumbGet(pairedJpgId);
+        if (mirrored) {
+          this._posterCache.set(jpgUrl, mirrored);
+          return mirrored;
+        }
+        // stableKey = pairedJpgId so the cached blob survives signed-URL
+        // rotation across sessions. Audit A10 — registered via the
+        // pending collector, not by mutating private state mid-render.
+        pending.addPoster(jpgUrl, pairedJpgId);
+        return "";
+      }
+      pending.addResolveId(pairedJpgId);
+      return "";
+    }
+
+    if (tThumb) {
+      const cached = this._posterCache.get(tThumb);
+      if (cached) return cached;
+      pending.addPoster(tThumb);
+      return "";
+    }
+
+    if (thumbUrl) {
+      const cached = this._posterCache.get(thumbUrl);
+      if (cached) return cached;
+      const mirrored = this._lsThumbGet(it.src);
+      if (mirrored) {
+        this._posterCache.set(thumbUrl, mirrored);
+        return mirrored;
+      }
+      if (captureAllowed && this._inputs.isRevealed(it.src)) {
+        // stableKey = it.src (mediaId) so the captured frame survives
+        // signed-URL rotation.
+        pending.addPoster(thumbUrl, it.src);
+      }
+    }
+    return "";
+  }
+
+  /**
+   * `true` iff every URL we'd attempt to capture for this thumb has been
+   * recorded as hard-failed. Render uses this to swap an empty `.tph` for
+   * the broken-thumbnail UI.
+   */
+  isThumbBroken(it: CardItem, isMs: boolean, thumbUrl: string, tThumb: string): boolean {
+    if (this.isHardFailed(it.src)) return true;
+    if (!isMs) {
+      const pairedJpg = this._inputs.getSensorPairedThumbs().get(it.src);
+      return !!pairedJpg && this.isHardFailed(pairedJpg);
+    }
+    if (thumbUrl && this.isHardFailed(thumbUrl)) return true;
+    if (tThumb && this.isHardFailed(tThumb)) return true;
+    const pairedJpgId = this._inputs.getMediaPairedThumbs().get(it.src);
+    if (pairedJpgId) {
+      const jpgUrl = this._inputs.getMediaUrlCache().get(pairedJpgId) ?? "";
+      if (jpgUrl && this.isHardFailed(jpgUrl)) return true;
+    }
+    if (this._inputs.hasFrigate()) {
+      const snapshotId = this._inputs.findMatchingSnapshotMediaId(it.src);
+      if (snapshotId) {
+        const snapshotUrl = this._inputs.getMediaUrlCache().get(snapshotId) ?? "";
+        if (snapshotUrl && this.isHardFailed(snapshotUrl)) return true;
+      }
+    }
+    return false;
+  }
+
+  /** `true` iff a fetch / capture is currently in flight (or queued) for
+   * any URL that could produce this item's poster. */
+  isPosterLoading(it: CardItem, isMs: boolean, thumbUrl: string, tThumb: string): boolean {
+    if (this.isPosterBusy(it.src)) return true;
+    if (!isMs) {
+      const pairedJpg = this._inputs.getSensorPairedThumbs().get(it.src);
+      return !!pairedJpg && this.isPosterBusy(pairedJpg);
+    }
+    if (thumbUrl && this.isPosterBusy(thumbUrl)) return true;
+    if (tThumb && this.isPosterBusy(tThumb)) return true;
+    const pairedJpgId = this._inputs.getMediaPairedThumbs().get(it.src);
+    if (pairedJpgId) {
+      const jpgUrl = this._inputs.getMediaUrlCache().get(pairedJpgId) ?? "";
+      if (jpgUrl && this.isPosterBusy(jpgUrl)) return true;
+    }
+    return false;
+  }
+
+  /** `true` iff this video item has no possible poster source under the
+   * current config: no server-side thumbnail AND `capture_video_thumbnails`
+   * is explicitly off. */
+  willNeverLoad(it: CardItem, isMs: boolean, tThumb: string): boolean {
+    if (this._inputs.captureAllowed()) return false;
+    return !this.hasServerThumbForVideo(it, isMs, tThumb);
+  }
+
+  /** `true` iff the gallery has a server-provided thumbnail for this item
+   * we can fetch cheaply (small HTTP request) — meaning we don't need to
+   * fall back to expensive `<video>` frame capture. */
+  hasServerThumbForVideo(it: CardItem, isMs: boolean, tThumb: string): boolean {
+    if (!isMs) {
+      return !!this._inputs.getSensorPairedThumbs().get(it.src);
+    }
+    if (tThumb) return true;
+    if (this._inputs.hasFrigate()) {
+      if (this._inputs.findMatchingSnapshotMediaId(it.src)) return true;
+    }
+    if (this._inputs.getMediaPairedThumbs().get(it.src)) return true;
+    return false;
+  }
+
+  // ─── Mirror operations ────────────────────────────────────────────────
+
+  /** Drop a cached thumbnail. Used when the underlying file is confirmed
+   * missing (HTTP 404, MediaError) so a deleted file's stale cached thumb
+   * stops being rendered. */
+  dropCachedThumb(displayUrl: string, stableKey?: string): void {
+    const key = this._lsKey(stableKey ?? displayUrl);
+    const prev = this._posterMirror.get(key);
+    if (prev?.url) this._blobUrls.revoke(prev.url);
+    this._posterMirror.delete(key);
+    this._posterCache.delete(displayUrl);
+    void this._store.delete(key).catch((): void => {});
+  }
+
+  private _lsKey(url: string): string {
+    const pct = this._config?.thumbnail_frame_pct ?? DEFAULT_THUMBNAIL_FRAME_PCT;
+    return makePosterKey(url, pct);
+  }
+
+  private _mirrorEnsureUrl(entry: MirrorEntry): string | null {
+    if (entry.url) return entry.url;
+    entry.url = this._blobUrls.create(entry.blob);
+    return entry.url;
+  }
+
+  private _lsThumbGet(url: string): string | null {
+    const key = this._lsKey(url);
+    const entry = this._posterMirror.get(key);
+    if (!entry) return null;
+    // LRU: move the entry to the end of the Map so eviction (which pops
+    // `keys().next().value`) drops the genuinely-coldest entry.
+    this._posterMirror.delete(key);
+    this._posterMirror.set(key, entry);
+    void this._store.touch(key).catch((): void => {});
+    return this._mirrorEnsureUrl(entry);
+  }
+
+  private _lsThumbSet(stableKey: string, blob: Blob, displayUrl: string): string | null {
+    const key = this._lsKey(stableKey);
+    const prev = this._posterMirror.get(key);
+    if (prev?.url) this._blobUrls.revoke(prev.url);
+    this._posterMirror.delete(key);
+    // LRU cap. Audit A18.
+    while (this._posterMirror.size >= POSTER_MIRROR_MAX_ENTRIES) {
+      const firstKey: string | undefined = this._posterMirror.keys().next().value;
+      if (firstKey === undefined) break;
+      const oldest = this._posterMirror.get(firstKey);
+      if (oldest?.url) this._blobUrls.revoke(oldest.url);
+      // Sensor-mode: src === displayUrl, the matching cache slot clears.
+      // Media-source: src is a rotated signed URL, so this delete may
+      // no-op; the new signed URL won't collide and the cache is safe.
+      // Audit A19.
+      if (oldest?.src) this._posterCache.delete(oldest.src);
+      this._posterMirror.delete(firstKey);
+    }
+    const entry: MirrorEntry = { src: displayUrl, blob, url: null };
+    this._posterMirror.set(key, entry);
+    void this._store.set(key, blob).catch((): void => {});
+    return this._mirrorEnsureUrl(entry);
+  }
+
+  // ─── Fetch + ensure ──────────────────────────────────────────────────
+
+  private async _fetchProtectedAsBlob(src: string, signal: AbortSignal): Promise<Blob | null> {
+    const token = this._inputs.getAuthToken();
+    if (!token) return null;
+    // Audit A22 — absolute URLs (Frigate hosts behind a reverse proxy)
+    // must not get the origin prefixed; only `/api/...`-style paths do.
+    const isAbsolute = src.startsWith("http://") || src.startsWith("https://");
+    const targetUrl = isAbsolute ? src : this._inputs.getOrigin() + src;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), POSTER_FETCH_TIMEOUT_MS);
+    const onOuterAbort = (): void => ctrl.abort();
+    signal.addEventListener("abort", onOuterAbort, { once: true });
+    try {
+      const res = await this._fetch(targetUrl, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: ctrl.signal,
+      });
+      if (res.status === 404) {
+        const err = new Error("not found") as Error & { status: number };
+        err.status = 404;
+        throw err;
+      }
+      if (!res.ok) return null;
+      return await res.blob();
+    } finally {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onOuterAbort);
+    }
+  }
+
+  private async _ensurePoster(src: string): Promise<void> {
+    if (!src || this._posterCache.has(src) || this._posterPending.has(src)) return;
+    if (this.isHardFailed(src)) return;
+    if (this.isCoolingDown(src)) return;
+
+    const stableKey = this._posterStableKeys.get(src) ?? src;
+    const ac = new AbortController();
+    this._ensureAborts.set(src, ac);
+
+    // Wait for the IDB prewarm to land before checking cache. Cold-load
+    // renders schedule captures before `posterStore.readAll()` resolves;
+    // without this await we'd race the network and re-download blobs
+    // already on disk.
+    if (this._prewarmReadyPromise && !this._prewarmDone) {
+      await this._prewarmReadyPromise;
+      if (ac.signal.aborted) {
+        this._ensureAborts.delete(src);
+        return;
+      }
+      // Post-await re-check. Audit A24 — previously missed `_posterPending`,
+      // so two racing callers both passed and re-fetched.
+      if (this._posterCache.has(src)) {
+        this._ensureAborts.delete(src);
+        return;
+      }
+      if (this._posterPending.has(src)) {
+        this._ensureAborts.delete(src);
+        return;
+      }
+      if (this.isHardFailed(src)) {
+        this._ensureAborts.delete(src);
+        return;
+      }
+      if (this.isCoolingDown(src)) {
+        this._ensureAborts.delete(src);
+        return;
+      }
+    }
+
+    const cached = this._lsThumbGet(stableKey);
+    if (cached) {
+      this._posterCache.set(src, cached);
+      this.clearFailure(src);
+      this._ensureAborts.delete(src);
+      this._onChange?.();
+      return;
+    }
+
+    this._posterPending.add(src);
+    try {
+      const pct = this._inputs.framePct();
+      const blob =
+        src.startsWith("/") && !isVideo(src)
+          ? await this._fetchProtectedAsBlob(src, ac.signal)
+          : await this._capture.capture(src, pct, ac.signal);
+      if (ac.signal.aborted) return;
+      if (blob) {
+        const objectUrl = this._lsThumbSet(stableKey, blob, src);
+        if (objectUrl) {
+          this._posterCache.set(src, objectUrl);
+          this.clearFailure(src);
+        } else {
+          this.recordFailure(src);
+        }
+      } else {
+        this.recordFailure(src);
+      }
+    } catch (err) {
+      if (ac.signal.aborted) return;
+      const cls = classifyCaptureError(err);
+      this.recordFailure(src, { hard: cls.hard });
+      const status = (err as { status?: unknown })?.status;
+      if (status === 404) this.dropCachedThumb(src, stableKey);
+    } finally {
+      this._posterPending.delete(src);
+      this._posterStableKeys.delete(src);
+      this._ensureAborts.delete(src);
+      this._onChange?.();
+    }
+  }
+
+  private _abortAllInFlight(): void {
+    for (const ac of this._ensureAborts.values()) {
+      ac.abort();
+    }
+    this._ensureAborts.clear();
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,8 @@ import {
 import { collectMediaSamples, scoreSamples } from "./data/path-format-detect";
 import { CombinedSourceClient } from "./data/combined-source";
 import { canDeleteItem, deleteItem } from "./data/delete-service";
-import { fnv1aHash } from "./util/hash";
+import { PendingPosterCollector, PosterCacheClient } from "./data/poster-cache";
 import { isVideo } from "./util/media-type";
-import { posterStore } from "./util/poster-store";
 import {
   FRIGATE_URI_PREFIX,
   frigateEventIdFromSrc,
@@ -76,12 +75,6 @@ import {
   DEFAULT_VISIBLE_OBJECT_FILTERS,
   MAX_VISIBLE_OBJECT_FILTERS,
   PREVIEW_WIDTH,
-  POSTER_CAPTURE_TIMEOUT_MS,
-  POSTER_FETCH_TIMEOUT_MS,
-  POSTER_MAX_ATTEMPTS,
-  POSTER_RETRY_DELAY_MS,
-  SENSOR_POSTER_CONCURRENCY,
-  SENSOR_POSTER_QUEUE_LIMIT,
   STYLE,
   THUMB_GAP,
   THUMB_LONG_PRESS_MOVE_PX,
@@ -190,29 +183,6 @@ class CameraGalleryCard extends LitElement {
     this._filterImage = false;
     this._filterFavorites = false;
     this._pendingScrollToI = null;
-    this._posterCache = new Map();
-    this._posterPending = new Set();
-    // Per-URL capture-attempt ledger. Replaces the previous binary
-    // `_posterFailed` set, which couldn't distinguish "definitively
-    // broken" (404, codec error → permanent broken-icon) from "timed
-    // out this attempt on slow network" (would re-attempt fine on a
-    // good connection).
-    //
-    // Shape: Map<url, { count, lastAt, hard }>
-    //   - count: number of failed attempts so far
-    //   - lastAt: timestamp of the last attempt (ms)
-    //   - hard: true once we've classified the failure as permanent
-    //
-    // Skip logic:
-    //   - hard=true OR count >= POSTER_MAX_ATTEMPTS → never retry,
-    //     thumbnail renders the broken-icon state.
-    //   - soft + lastAt within POSTER_RETRY_DELAY_MS → skip this round
-    //     (rate-limit retries so we don't spin on a flaky connection).
-    //   - soft + lastAt older than the delay → eligible for re-attempt.
-    this._posterAttempts = new Map();
-    /** Single rolling timer that schedules a requestUpdate at the next
-     * soft-fail cooldown expiry. See `_scheduleSoftRetryRender`. */
-    this._softRetryTimer = null;
     // Unsubscribe callback for HA WS Frigate-event-push subscription.
     // null = not subscribed, function = active subscription.
     this._frigateEventsUnsub = null;
@@ -410,38 +380,31 @@ class CameraGalleryCard extends LitElement {
     this._cachedBaseList = null;
     this._previewLoadTimer = null;
 
-    this._posterQueue = [];
-    this._posterQueued = new Set();
-    this._posterInFlight = new Set();
-    // In-memory mirror of the IDB-backed `posterStore`. Holds Blob refs
-    // alongside lazily-created `URL.createObjectURL` strings — render
-    // reads return the URL string synchronously, writes persist the
-    // Blob to IDB asynchronously without blocking the render task. URL
-    // lifecycle is owned here: revoke on overwrite / delete / clear.
-    //   Map<lsKey, { blob: Blob; url: string | null }>
-    this._posterMirror = null;
-    // For media-source items, HA's `media_source/resolve_media` returns
-    // a *signed* URL that varies every session (expires:60*60). Hashing
-    // that URL as our IDB key meant yesterday's captured frame was
-    // unreachable today — the key changed even though the underlying
-    // file didn't. This Map records "when you enqueue/fetch THIS url,
-    // persist the blob under THAT stable key (mediaId)". Lookups in
-    // `_lsThumbGet`/`_lsThumbSet`/`_ensurePoster` go through it; falls
-    // back to the URL itself when no stable key is provided (sensor
-    // mode and other paths where the URL IS the stable identifier).
-    this._posterStableKeys = new Map();
-    // Promise that resolves once the IDB prewarm has populated
-    // `_posterMirror`. `_ensurePoster` awaits this before deciding
-    // whether to fetch — without it, the render→enqueue→fetch race
-    // beats `posterStore.readAll()` on cold loads (cmd-r) and we
-    // re-download blobs that are already cached.
-    this._prewarmReadyPromise = null;
-    this._prewarmDone = false;
-
     this._revealedThumbs = new Set();
     this._thumbObserver = null;
     this._thumbObserverRoot = null;
     this._observedThumbs = new WeakSet();
+
+    // Poster pipeline lives in its own client. Inputs are closures over the
+    // sensor/media clients + config so the poster module never imports them
+    // directly. See `src/data/poster-cache.ts`.
+    this._posterClient = new PosterCacheClient({
+      inputs: {
+        getSensorPairedThumbs: () => this._sensorClient.getSensorPairedThumbs(),
+        getMediaPairedThumbs: () => this._mediaClient.getPairedThumbs(),
+        getMediaUrlCache: () => this._mediaClient.getUrlCache(),
+        findMatchingSnapshotMediaId: (src) =>
+          this._mediaClient.findMatchingSnapshotMediaId(src),
+        isResolveFailed: (id) => this._mediaClient.isResolveFailed(id),
+        hasFrigate: () => hasFrigateConfig(this.config),
+        captureAllowed: () => this.config?.capture_video_thumbnails !== false,
+        framePct: () => this.config?.thumbnail_frame_pct ?? DEFAULT_THUMBNAIL_FRAME_PCT,
+        isRevealed: (src) => this._revealedThumbs.has(src),
+        getAuthToken: () => this._hass?.auth?.data?.access_token ?? null,
+        getOrigin: () => window.location.origin,
+      },
+      onChange: () => this.requestUpdate(),
+    });
   }
 
   _startMediaPoll() {
@@ -518,6 +481,11 @@ class CameraGalleryCard extends LitElement {
       this._thumbObserver = null;
     }
 
+    // Aborts in-flight captures and revokes every mirrored blob URL.
+    // Without this, every captured poster's `URL.createObjectURL` leaked
+    // on card teardown.
+    this._posterClient.dispose();
+
     this._stopMicStream();
   }
 
@@ -527,6 +495,7 @@ class CameraGalleryCard extends LitElement {
     this._hass = hass;
     this._sensorClient.setHass(hass);
     this._mediaClient.setHass(hass);
+    this._posterClient.setHass(hass);
 
     if (firstHass) {
       if (this.config?.start_mode === "live" && this._hasLiveConfig()) {
@@ -750,137 +719,6 @@ class CameraGalleryCard extends LitElement {
     this._ensurePreviewVideoHostPlayback(selectedUrl);
   }
 
-  /** True iff this URL has hit its hard-fail criteria — we should not
-   * retry. Used by `_enqueuePoster` / `_drainPosterQueue` to skip and
-   * by `_isThumbBroken` to flip render to the broken-icon state. */
-  _isPosterHardFailed(src) {
-    const a = this._posterAttempts.get(src);
-    if (!a) return false;
-    return a.hard || a.count >= POSTER_MAX_ATTEMPTS;
-  }
-
-  /** True iff a soft-failed URL is inside its retry-cooldown window.
-   * Returning true skips this attempt; render keeps showing the
-   * skeleton until the cooldown expires and a re-enqueue takes hold. */
-  _isPosterCoolingDown(src) {
-    const a = this._posterAttempts.get(src);
-    if (!a || a.hard) return false;
-    if (a.count === 0) return false;
-    return Date.now() - a.lastAt < POSTER_RETRY_DELAY_MS;
-  }
-
-  /** Record a capture failure. `hard` is true for definitive errors
-   * (404, MEDIA_ERR_SRC_NOT_SUPPORTED) — skips straight to the broken
-   * state. Soft failures (timeout, decode) accumulate up to
-   * POSTER_MAX_ATTEMPTS before being treated as hard. Schedules an
-   * auto-retry render so soft fails recover even on idle screens. */
-  _recordPosterFailure(src, { hard = false } = {}) {
-    const prev = this._posterAttempts.get(src);
-    const count = (prev?.count ?? 0) + 1;
-    const isHardNow = hard || count >= POSTER_MAX_ATTEMPTS;
-    this._posterAttempts.set(src, { count, lastAt: Date.now(), hard: isHardNow });
-    if (!isHardNow) this._scheduleSoftRetryRender();
-  }
-
-  _clearPosterFailure(src) {
-    this._posterAttempts.delete(src);
-  }
-
-  /** Schedule a single requestUpdate at the earliest expiring soft-fail
-   * cooldown, then re-arm itself if any soft fails are still cooling
-   * after that render. Without this, a slow-network blip on an idle
-   * dashboard would leave the thumb on its skeleton forever — the
-   * cooldown expires but no render is triggered to re-enqueue. */
-  _scheduleSoftRetryRender() {
-    if (this._softRetryTimer) return;
-    let earliest = Infinity;
-    const now = Date.now();
-    for (const a of this._posterAttempts.values()) {
-      if (a.hard) continue;
-      const expiry = a.lastAt + POSTER_RETRY_DELAY_MS;
-      if (expiry < earliest) earliest = expiry;
-    }
-    if (earliest === Infinity) return;
-    const delay = Math.max(100, earliest - now + 100);
-    this._softRetryTimer = setTimeout(() => {
-      this._softRetryTimer = null;
-      this.requestUpdate();
-      // The render above may re-fail items (still slow); reschedule
-      // for whatever cooldown is still pending.
-      this._scheduleSoftRetryRender();
-    }, delay);
-  }
-
-  _enqueuePoster(src, stableKey) {
-    const key = String(src || "").trim();
-    if (!key) return;
-    // Record the persistent-cache identifier if it differs from the
-    // fetch URL (media-source items: stable mediaId vs ephemeral
-    // signed URL). `_ensurePoster` reads this on dequeue.
-    if (stableKey && stableKey !== key) {
-      this._posterStableKeys.set(key, stableKey);
-    }
-    if (this._posterCache.has(key)) return;
-    if (this._posterPending.has(key)) return;
-    if (this._posterQueued.has(key)) return;
-    if (this._posterInFlight.has(key)) return;
-    if (this._isPosterHardFailed(key)) return;
-    if (this._isPosterCoolingDown(key)) return;
-
-    this._posterQueued.add(key);
-    this._posterQueue.push(key);
-
-    if (this._posterQueue.length > SENSOR_POSTER_QUEUE_LIMIT) {
-      this._posterQueue.length = SENSOR_POSTER_QUEUE_LIMIT;
-    }
-
-    this._drainPosterQueue();
-  }
-
-  _drainPosterQueue() {
-    while (
-      this._posterInFlight.size < SENSOR_POSTER_CONCURRENCY &&
-      this._posterQueue.length
-    ) {
-      // FIFO drain: items are pushed in render order (newest-first
-      // by day-sort), so `shift()` here makes the user see the
-      // top-of-gallery (most recent) thumbnails resolve first. The
-      // O(n) shift cost on a small queue is negligible vs the
-      // capture work itself.
-      const src = this._posterQueue.shift();
-      this._posterQueued.delete(src);
-
-      if (!src) continue;
-      if (this._posterCache.has(src)) continue;
-      if (this._posterPending.has(src)) continue;
-      if (this._posterInFlight.has(src)) continue;
-      if (this._isPosterHardFailed(src)) continue;
-      if (this._isPosterCoolingDown(src)) continue;
-
-      this._posterInFlight.add(src);
-
-      this._ensurePoster(src)
-        .catch(() => {})
-        .finally(() => {
-          this._posterInFlight.delete(src);
-          this._drainPosterQueue();
-        });
-    }
-  }
-
-  _resetPosterQueue() {
-    this._posterQueue = [];
-    this._posterQueued.clear();
-    this._posterInFlight.clear();
-    this._posterPending.clear();
-    this._posterAttempts.clear();
-    this._posterStableKeys.clear();
-    if (this._softRetryTimer) {
-      clearTimeout(this._softRetryTimer);
-      this._softRetryTimer = null;
-    }
-  }
-
   _queueSensorPosterWork(items) {
     if (!Array.isArray(items) || !items.length) return;
     if (this.config?.source_mode !== "sensor" && this.config?.source_mode !== "combined") return;
@@ -889,14 +727,14 @@ class CameraGalleryCard extends LitElement {
     // The raw video URL would require pulling the entire file just
     // to extract a single frame; that capture is deferred until the
     // user actually selects the item (preview-video `canplay` fires
-    // `_enqueuePoster` then).
+    // `client.enqueue` then).
     const pairedThumbs = this._sensorClient.getSensorPairedThumbs();
     for (const it of items) {
       const src = String(it?.src || "");
       if (!src) continue;
       if (!isVideo(src)) continue;
       const pairedJpg = pairedThumbs.get(src);
-      if (pairedJpg) this._enqueuePoster(pairedJpg);
+      if (pairedJpg) this._posterClient.enqueue(pairedJpg);
     }
   }
 
@@ -940,8 +778,8 @@ class CameraGalleryCard extends LitElement {
       // canplay/error listeners are still attached — and the
       // `removeAttribute("src") + load()` we're about to do can fire
       // `error` for the aborted load, which the stale closure would
-      // attribute to the OLD url (poisoning `_posterFailed` for a
-      // perfectly good URL the user just navigated away from).
+      // attribute to the OLD url (poisoning the poster-client failure
+      // ledger for a perfectly good URL the user just navigated away from).
       this._previewLoadAbort?.abort();
       const abortController = new AbortController();
       this._previewLoadAbort = abortController;
@@ -958,7 +796,7 @@ class CameraGalleryCard extends LitElement {
 
       video.src = selectedUrl;
 
-      const poster = this._posterCache.get(selectedUrl) || "";
+      const poster = this._posterClient.getPosterUrl(selectedUrl) || "";
       if (poster) {
         video.poster = poster;
       } else {
@@ -966,15 +804,14 @@ class CameraGalleryCard extends LitElement {
         // Enqueue poster pas na laden: voorkomt dat de capture de preview-verbinding blokkeert
         const urlForPoster = selectedUrl;
         video.addEventListener("canplay", () => {
-          if (!this._posterCache.has(urlForPoster)) this._enqueuePoster(urlForPoster);
+          if (!this._posterClient.getPosterUrl(urlForPoster)) {
+            this._posterClient.enqueue(urlForPoster);
+          }
         }, { once: true, signal: sig });
         // If the preview can't load (broken / corrupt / slow-network),
         // record the failure so the thumb gets a broken icon (hard
         // errors) or stays on the skeleton until the cooldown lapses
         // (soft errors — which is what 99% of slow-network blips are).
-        // Without this hook, the selected thumb sat on plain `.tph`
-        // because `_resolveVideoPoster` skips the capture for the
-        // selected URL (preview canplay was meant to handle it).
         video.addEventListener("error", () => {
           const code = video.error?.code;
           // MediaError.code: 1=ABORTED, 2=NETWORK, 3=DECODE, 4=SRC_NOT_SUPPORTED.
@@ -982,11 +819,8 @@ class CameraGalleryCard extends LitElement {
           // mark hard so we don't retry. 1 (aborted) & 2 (network)
           // can recover on a retry once the connection improves.
           const isHard = code === 3 || code === 4;
-          this._recordPosterFailure(urlForPoster, { hard: isHard });
-          if (isHard) {
-            const stableKey = this._posterStableKeys.get(urlForPoster) || urlForPoster;
-            this._lsThumbDelete(stableKey, urlForPoster);
-          }
+          this._posterClient.recordFailure(urlForPoster, { hard: isHard });
+          if (isHard) this._posterClient.dropCachedThumb(urlForPoster);
           this.requestUpdate();
         }, { once: true, signal: sig });
       }
@@ -1006,7 +840,7 @@ class CameraGalleryCard extends LitElement {
         video.load();
       } catch (_) {}
     } else {
-      const poster = this._posterCache.get(selectedUrl) || "";
+      const poster = this._posterClient.getPosterUrl(selectedUrl) || "";
       if (poster && video.poster !== poster) {
         video.poster = poster;
       }
@@ -3058,660 +2892,6 @@ class CameraGalleryCard extends LitElement {
     }
   }
 
-  // ─── Poster helpers ───────────────────────────────────────────────
-
-  /** True iff every URL we'd attempt to capture a poster from for this
-   * thumb has been recorded in `_posterFailed`. The render path uses
-   * this to swap an empty `.tph` for the broken-thumbnail UI instead.
-   *
-   * Why "every URL we'd attempt" rather than just one: poster capture
-   * for media-source items is keyed by the resolved URL (Frigate clip
-   * MP4, paired-jpg URL, browse_media thumb URL) — never by the raw
-   * `media-source://` id that the gallery item carries. Without
-   * walking the same fallback chain `_resolveVideoPoster` walks, MS
-   * failures just ghost as plain `.tph`. */
-  _isThumbBroken(it, isMs, thumbUrl, tThumb) {
-    // Only render the broken-icon state for *hard* failures (definitive
-    // 404 / codec / repeated soft fail past the attempt cap). Items
-    // still-soft-failed keep the skeleton — they'll re-attempt after
-    // the retry cooldown, which is the right answer for slow networks.
-    if (this._isPosterHardFailed(it.src)) return true;
-    if (!isMs) {
-      const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(it.src);
-      return !!(pairedJpg && this._isPosterHardFailed(pairedJpg));
-    }
-    if (thumbUrl && this._isPosterHardFailed(thumbUrl)) return true;
-    if (tThumb && this._isPosterHardFailed(tThumb)) return true;
-    const pairedJpgId = this._mediaClient.getPairedThumbs().get(it.src);
-    if (pairedJpgId) {
-      const jpgUrl = this._mediaClient.getUrlCache().get(pairedJpgId) || "";
-      if (jpgUrl && this._isPosterHardFailed(jpgUrl)) return true;
-    }
-    // Frigate snapshot URL is the poster directly when configured —
-    // a 404 on that URL fires `<img onerror>` (see thumb render) which
-    // hard-marks it; surface that so the broken state lights up.
-    if (hasFrigateConfig(this.config)) {
-      const snapshotId = this._mediaClient.findMatchingSnapshotMediaId(it.src);
-      if (snapshotId) {
-        const snapshotUrl = this._mediaClient.getUrlCache().get(snapshotId) || "";
-        if (snapshotUrl && this._isPosterHardFailed(snapshotUrl)) return true;
-      }
-    }
-    return false;
-  }
-
-  /** True iff a fetch / capture is currently in flight (or queued)
-   * for any URL that could produce this item's poster. Walks the
-   * same fallback chain as `_resolveVideoPoster` so a download in
-   * progress on the paired-jpg or browse_media thumbnail counts.
-   *
-   * Render uses this to switch from the (idle) skeleton to the
-   * (active) spinner state — communicates "we're working on it"
-   * instead of "this might never load". */
-  _isPosterLoading(it, isMs, thumbUrl, tThumb) {
-    const isUrlLoading = (url) =>
-      !!url &&
-      (this._posterPending.has(url) ||
-        this._posterInFlight.has(url) ||
-        this._posterQueued.has(url));
-    if (isUrlLoading(it.src)) return true;
-    if (!isMs) {
-      const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(it.src);
-      return isUrlLoading(pairedJpg);
-    }
-    if (isUrlLoading(thumbUrl)) return true;
-    if (isUrlLoading(tThumb)) return true;
-    const pairedJpgId = this._mediaClient.getPairedThumbs().get(it.src);
-    if (pairedJpgId) {
-      const jpgUrl = this._mediaClient.getUrlCache().get(pairedJpgId) || "";
-      if (isUrlLoading(jpgUrl)) return true;
-    }
-    return false;
-  }
-
-  /** True iff this video item has no possible poster source under the
-   * current config: no server-side thumbnail AND
-   * `capture_video_thumbnails` is explicitly off. Render shows a
-   * static "disabled" icon for these so users understand the absence
-   * is a config choice, not a failure. */
-  _willNeverLoad(it, isMs, tThumb) {
-    if (this.config?.capture_video_thumbnails !== false) return false;
-    return !this._hasServerThumbForVideo(it, isMs, tThumb);
-  }
-
-  /** True iff the gallery has a server-provided thumbnail for this
-   * item that we can fetch cheaply (small HTTP request) — meaning we
-   * don't need to fall back to expensive `<video>` frame capture.
-   *
-   * "Server-provided" = sensor paired-jpg sibling, Frigate snapshot,
-   * media-source `thumbnail` field, or a paired-jpg under a media
-   * root. When NONE of these exist for a video item, the only way to
-   * generate a poster is to download (potentially MBs of) the video
-   * file just to extract one frame. We defer that to the moment the
-   * user actually clicks the item — preview-video `canplay` then
-   * fires `_enqueuePoster(thumbUrl)` and the capture runs once.
-   *
-   * Render uses this to choose between the loading-skeleton (server
-   * thumb in flight) and the video-placeholder icon (no server thumb,
-   * waiting on click). */
-  _hasServerThumbForVideo(it, isMs, tThumb) {
-    if (!isMs) {
-      return !!this._sensorClient.getSensorPairedThumbs().get(it.src);
-    }
-    if (tThumb) return true;
-    if (hasFrigateConfig(this.config)) {
-      if (this._mediaClient.findMatchingSnapshotMediaId(it.src)) return true;
-    }
-    if (this._mediaClient.getPairedThumbs().get(it.src)) return true;
-    return false;
-  }
-
-  /** Called from the thumbnail `<img>` onerror. The browser's `<img>`
-   * decoder rejected the URL — usually a definitive failure (404 /
-   * decode error), so mark it hard right away. Don't bother with the
-   * soft-retry path since `<img>` won't retry on its own and we've
-   * already given the browser the URL once. */
-  _onThumbImgError(posterUrl) {
-    if (!posterUrl) return;
-    if (this._isPosterHardFailed(posterUrl)) return;
-    this._recordPosterFailure(posterUrl, { hard: true });
-    this.requestUpdate();
-  }
-
-  // Resolve the poster URL to render for a video thumb.
-  //
-  // Read-only: enqueues that previously fired inside this function are
-  // deferred via `_pendingResolveIds` / `_pendingPosterUrls` and
-  // dispatched from `updated()` after render commits. Keeps render()
-  // pure of network/queue side effects.
-  //
-  // Strategy:
-  //   1. Server-provided thumbnails (paired-jpg, Frigate snapshot,
-  //      browse_media `thumbnail`) are cheap HTTP fetches — enqueue
-  //      eagerly so they appear as the user scrolls.
-  //   2. The raw video URL (`thumbUrl`) is NEVER enqueued
-  //      speculatively. Pulling a frame out of the video means
-  //      downloading the full file (often MBs) just for one image —
-  //      brutal on slow connections and almost always wasted on
-  //      items the user never clicks. Instead, we surface any frame
-  //      previously captured (sitting in the IDB-backed mirror) and
-  //      otherwise return `""` so the render falls through to the
-  //      video-placeholder icon. The capture happens later, on
-  //      `<video>`'s `canplay` event from `_ensurePreviewVideoHostPlayback`,
-  //      which fires only when the user actually selects the item.
-  _resolveVideoPoster(it, isMs, thumbUrl, tThumb /* selectedUrl unused */) {
-    // Honor the user's "low-bandwidth" preference: when
-    // `capture_video_thumbnails` is false, the expensive `<video>`
-    // frame-extraction fallback is disabled entirely. Items without
-    // a server thumbnail stay on the placeholder icon.
-    const captureAllowed = this.config?.capture_video_thumbnails !== false;
-
-    if (!isMs) {
-      const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(it.src);
-      if (pairedJpg) return this._posterCache.get(pairedJpg) || "";
-      // No paired jpg → would need video-frame capture (expensive).
-      // Surface any previously-captured frame from the IDB mirror;
-      // otherwise enqueue a fresh capture but ONLY when the thumb
-      // is currently in the viewport. Off-screen items stay on the
-      // placeholder so we don't burn bandwidth on items the user
-      // may never scroll to.
-      const cached = this._posterCache.get(it.src);
-      if (cached) return cached;
-      const mirrored = this._lsThumbGet(it.src);
-      if (mirrored) {
-        this._posterCache.set(it.src, mirrored);
-        return mirrored;
-      }
-      if (captureAllowed && this._revealedThumbs.has(it.src)) {
-        this._pendingPosterUrls?.add(it.src);
-      }
-      return "";
-    }
-
-    if (hasFrigateConfig(this.config)) {
-      const snapshotId = this._mediaClient.findMatchingSnapshotMediaId(it.src);
-      if (snapshotId) {
-        const snapshotUrl = this._mediaClient.getUrlCache().get(snapshotId) || "";
-        if (snapshotUrl) return snapshotUrl;
-        this._pendingResolveIds?.add(snapshotId);
-      }
-    }
-
-    // Paired thumbnail: same-stem jpg next to the mp4 (server thumbnail).
-    const pairedJpgId = this._mediaClient.getPairedThumbs().get(it.src);
-    if (pairedJpgId && !this._mediaClient.isResolveFailed(pairedJpgId)) {
-      const jpgUrl = this._mediaClient.getUrlCache().get(pairedJpgId) || "";
-      if (jpgUrl) {
-        // Persistent-cache key: the paired jpg's mediaId is stable;
-        // jpgUrl is a signed-and-expiring URL that would invalidate
-        // the cached blob on every session.
-        this._posterStableKeys.set(jpgUrl, pairedJpgId);
-        const cached = this._posterCache.get(jpgUrl);
-        if (cached) return cached;
-        const mirrored = this._lsThumbGet(pairedJpgId);
-        if (mirrored) {
-          this._posterCache.set(jpgUrl, mirrored);
-          return mirrored;
-        }
-        this._pendingPosterUrls?.add(jpgUrl);
-        return "";
-      }
-      this._pendingResolveIds?.add(pairedJpgId);
-      return "";
-    }
-
-    // browse_media `thumbnail` URL — server thumbnail, cheap.
-    if (tThumb) {
-      const cached = this._posterCache.get(tThumb);
-      if (cached) return cached;
-      this._pendingPosterUrls?.add(tThumb);
-      return "";
-    }
-
-    // Last resort: the resolved video URL. Same as the sensor branch
-    // above: prefer cached / IDB-mirrored frames; otherwise enqueue
-    // a capture only when the thumb is currently visible AND the
-    // user hasn't disabled the expensive capture path via the
-    // `capture_video_thumbnails` flag.
-    if (thumbUrl) {
-      // For media-source video frames the resolved URL is signed and
-      // expires every session — hash by `it.src` (mediaId) so the
-      // captured blob survives cmd-r and the disabled-config case
-      // can still show previously-captured frames.
-      this._posterStableKeys.set(thumbUrl, it.src);
-      const cached = this._posterCache.get(thumbUrl);
-      if (cached) return cached;
-      const mirrored = this._lsThumbGet(it.src);
-      if (mirrored) {
-        this._posterCache.set(thumbUrl, mirrored);
-        return mirrored;
-      }
-      if (captureAllowed && this._revealedThumbs.has(it.src)) {
-        this._pendingPosterUrls?.add(thumbUrl);
-      }
-    }
-    return "";
-  }
-
-  _captureFrame(src, pct = 0) {
-    return new Promise((resolve, reject) => {
-      const v = document.createElement("video");
-      v.muted = true;
-      v.setAttribute("muted", "");
-      v.playsInline = true;
-      v.preload = "metadata";
-
-      let timeout;
-      let retried = false;
-      // Single-shot guard: browsers can fire `seeked` synchronously
-      // (when the seek is a no-op) or twice for keyframe-bracketing
-      // seeks. Without this, the retry path could resolve and reject
-      // the same promise, or reject a frame `toBlob` is mid-encoding.
-      let settled = false;
-      const startedAt = (typeof performance !== "undefined" ? performance.now() : Date.now());
-      const cleanup = () => {
-        clearTimeout(timeout);
-        try { v.removeEventListener("seeked", onSeeked); } catch (_) {}
-        try { v.pause(); v.removeAttribute("src"); v.load(); } catch (_) {}
-      };
-      const fail = (err) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        reject(err ?? new Error("poster fail"));
-      };
-      const ok = (blob) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        resolve(blob);
-      };
-
-      // Sample the rendered frame to detect uniform decoder output —
-      // signature of a corrupt segment in an otherwise-decodable file.
-      // Three cases caught:
-      //   1. variance < 5      — uniform color (grey "no signal" tile,
-      //                          all-black, all-white).
-      //   2. mean < 6 && var < 30 — near-black with limited dithering.
-      //                          Real night cams run mean 10-30 with
-      //                          variance 50+ from sensor noise.
-      //   3. >97% near-black pixels — uniform black with a few stray
-      //                          noise pixels.
-      //
-      // Costly on mobile (`getImageData` forces a GPU→CPU readback),
-      // so we gate the call: run only when `pct > 0` (corruption risk
-      // exists since we seek into the middle/end), OR when the capture
-      // took unusually long (> 200ms — proxy for "decoder struggled").
-      // Returns `null` when the canvas is tainted (cross-origin), so
-      // the caller treats it as "assume valid".
-      const isBlankFrame = (ctx, w, h) => {
-        try {
-          const data = ctx.getImageData(0, 0, w, h).data;
-          let sum = 0;
-          let sumSq = 0;
-          let nearBlack = 0;
-          let n = 0;
-          for (let i = 0; i < data.length; i += 16) {
-            const luma = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
-            sum += luma;
-            sumSq += luma * luma;
-            if (luma < 8) nearBlack++;
-            n++;
-          }
-          if (!n) return false;
-          const mean = sum / n;
-          const variance = sumSq / n - mean * mean;
-          if (variance < 5) return true;
-          if (mean < 6 && variance < 30) return true;
-          if (nearBlack / n > 0.97) return true;
-          return false;
-        } catch {
-          return null;
-        }
-      };
-
-      const onSeeked = () => {
-        if (settled) return;
-        try {
-          const w = v.videoWidth, h = v.videoHeight;
-          if (!w || !h) return fail(new Error("no video dimensions"));
-          const scale = Math.min(1, 320 / w);
-          const c = document.createElement("canvas");
-          c.width = Math.max(1, Math.round(w * scale));
-          c.height = Math.max(1, Math.round(h * scale));
-          const ctx = c.getContext("2d");
-          ctx.drawImage(v, 0, 0, c.width, c.height);
-
-          // Blank-frame retry path. Skip the GPU readback entirely on
-          // the fast, common case (pct=0, fast capture) — start frames
-          // are almost never corrupt, and the readback is the costly
-          // step on mobile.
-          const elapsed =
-            (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt;
-          const shouldCheckBlank = (Number(pct) || 0) > 0 || elapsed > 200;
-          if (shouldCheckBlank) {
-            const blank = isBlankFrame(ctx, c.width, c.height);
-            if (blank === true) {
-              if (!retried && (Number(pct) || 0) > 0) {
-                retried = true;
-                // Re-arm the listener (was consumed by `{ once: true }`)
-                // and explicitly remove first in case the runtime hasn't
-                // yet — defensive against double-fire on the next seek.
-                v.removeEventListener("seeked", onSeeked);
-                v.addEventListener("seeked", onSeeked, { once: true });
-                try { v.currentTime = 0.01; } catch (e) { return fail(e); }
-                return;
-              }
-              return fail(new Error("blank frame"));
-            }
-          }
-
-          // Blob-shaped output skips the base64 round-trip and stores
-          // ~33% smaller than the legacy `toDataURL`. The render layer
-          // gets a synchronous object URL via `URL.createObjectURL`.
-          c.toBlob(
-            (blob) => {
-              if (!blob) return fail(new Error("toBlob returned null"));
-              ok(blob);
-            },
-            "image/jpeg",
-            0.6
-          );
-        } catch (e) {
-          fail(e);
-        }
-      };
-
-      timeout = setTimeout(() => fail(new Error("poster timeout")), POSTER_CAPTURE_TIMEOUT_MS);
-      v.addEventListener(
-        "error",
-        () => {
-          const err = new Error("video load error");
-          // MediaError.code: 2 = NETWORK (often 404), 4 = SRC_NOT_SUPPORTED
-          // (usually codec but browsers also report 4 for missing files).
-          // _ensurePoster uses this to decide whether to drop a stale
-          // cached thumb.
-          err.mediaErrorCode = v.error?.code;
-          fail(err);
-        },
-        { once: true }
-      );
-      v.addEventListener("loadedmetadata", () => {
-        const dur = Number.isFinite(v.duration) && v.duration > 0 ? v.duration : 0;
-        const p = Math.max(0, Math.min(100, Number(pct) || 0));
-        // Seek slightly off the boundaries — exact 0 or duration often yields no frame.
-        let t = 0.01;
-        if (dur && p > 0) t = p === 100 ? Math.max(0.01, dur - 0.05) : dur * (p / 100);
-        try { v.currentTime = t; } catch (_) { onSeeked(); }
-      }, { once: true });
-      v.addEventListener("seeked", onSeeked, { once: true });
-
-      v.src = src;
-      try { v.load(); } catch (_) {}
-    });
-  }
-
-  // Salt the localStorage key with the current frame %, so changing the % invalidates
-  // cached frames without needing to wipe storage.
-  _lsKey(url) {
-    const pct = this.config?.thumbnail_frame_pct ?? DEFAULT_THUMBNAIL_FRAME_PCT;
-    return "cgc_p_" + fnv1aHash(url + "|" + pct);
-  }
-
-  // ─── Poster persistent cache ──────────────────────────────────────
-  //
-  // Backing store is IndexedDB via `posterStore` (binary `Blob` records,
-  // ~33% smaller on disk than the legacy base64 dataUrl shape). The
-  // render layer needs a synchronous string URL, so the in-memory
-  // `_posterMirror` map keeps `Blob` refs alongside lazily-created
-  // `URL.createObjectURL` strings. Reads return the cached URL or
-  // create one on demand; writes overwrite-revoke before persisting.
-  //
-  // If IDB is unavailable (private-browsing Safari, sandboxed embeds)
-  // the in-memory mirror still works for the lifetime of the page —
-  // just nothing crosses page reloads. That's acceptable for thumbnails.
-  _prewarmPosterLs() {
-    if (!this._posterMirror) this._posterMirror = new Map();
-    // Single shared promise — `_ensurePoster` and the render branch
-    // both observe it. Resolves regardless of success so awaits never
-    // hang on storage failures.
-    this._prewarmReadyPromise = posterStore
-      .readAll()
-      .then((records) => {
-        if (this._posterMirror) {
-          // In-flight captures during prewarm have already populated
-          // their entries — preserve those (fresh > disk).
-          for (const rec of records) {
-            if (this._posterMirror.has(rec.key)) continue;
-            this._posterMirror.set(rec.key, { blob: rec.blob, url: null });
-          }
-        }
-      })
-      .catch(() => {})
-      .finally(() => {
-        this._prewarmDone = true;
-        // Pull freshly-warmed posters into view without waiting for
-        // the next hass push.
-        this.requestUpdate();
-      });
-    // Trim disk store so it never exceeds the cap. Best-effort.
-    posterStore.evictExcess(500).catch(() => {});
-  }
-
-  _posterMirrorEnsureUrl(entry) {
-    if (entry.url) return entry.url;
-    try {
-      entry.url = URL.createObjectURL(entry.blob);
-    } catch (_) {
-      return null;
-    }
-    return entry.url;
-  }
-
-  _lsThumbGet(url) {
-    if (!this._posterMirror) return null;
-    const key = this._lsKey(url);
-    const entry = this._posterMirror.get(key);
-    if (!entry) return null;
-    // LRU: move the entry to the end of the Map so eviction (which
-    // pops `keys().next().value`) drops the genuinely-coldest entry.
-    // `Map.set` on an existing key keeps insertion position, so we
-    // delete-then-set to relocate.
-    this._posterMirror.delete(key);
-    this._posterMirror.set(key, entry);
-    // Mirror the bump on disk too (best-effort) so cold restarts inherit
-    // hot/cold ordering.
-    posterStore.touch(key).catch(() => {});
-    return this._posterMirrorEnsureUrl(entry);
-  }
-
-  /** Persist a captured Blob under `stableKey` and return a usable
-   * object URL. `stableKey` is what we hash for IDB lookup (stable
-   * across sessions for media-source items); `displayUrl` is what
-   * the render layer hands to `<img src>` — stored in the mirror
-   * entry so eviction can clear the right `_posterCache` slot.
-   * When the two are the same (sensor mode), pass `undefined` for
-   * `displayUrl` and stableKey will be used for both.
-   * Revokes any prior URL for the same key so we don't leak
-   * browser-side blob references. Caps the mirror at 500 entries
-   * (LRU eviction). */
-  _lsThumbSet(stableKey, blob, displayUrl) {
-    if (!blob) return null;
-    const back = displayUrl ?? stableKey;
-    const key = this._lsKey(stableKey);
-    if (!this._posterMirror) this._posterMirror = new Map();
-    const prev = this._posterMirror.get(key);
-    if (prev?.url) {
-      try { URL.revokeObjectURL(prev.url); } catch (_) {}
-    }
-    // Delete first so re-setting moves the key to the end of the Map's
-    // insertion order — keeps the LRU semantics aligned with `_lsThumbGet`.
-    this._posterMirror.delete(key);
-    const MAX_MIRROR = 500;
-    while (this._posterMirror.size >= MAX_MIRROR) {
-      const firstKey = this._posterMirror.keys().next().value;
-      if (!firstKey) break;
-      const oldest = this._posterMirror.get(firstKey);
-      if (oldest?.url) {
-        try { URL.revokeObjectURL(oldest.url); } catch (_) {}
-      }
-      if (oldest?.src) this._posterCache.delete(oldest.src);
-      this._posterMirror.delete(firstKey);
-    }
-    const entry = { src: back, blob, url: null };
-    this._posterMirror.set(key, entry);
-    posterStore.set(key, blob).catch(() => {});
-    return this._posterMirrorEnsureUrl(entry);
-  }
-
-  // Drops a cached thumbnail. Used when the underlying file is
-  // confirmed missing (HTTP 404 / MediaError NETWORK) so a deleted
-  // file's stale cached thumb stops being shown on next render.
-  //
-  // `stableKey` matches what was used in `_lsThumbSet` (mediaId for
-  // media-source items, file path for sensor). `displayUrl` is the
-  // URL currently stored in `_posterCache` and gets cleared too —
-  // `_ensurePoster` early-returns on a cache hit, so leaving the
-  // (now-revoked) URL there would block the next capture attempt and
-  // render a broken `<img src="blob:revoked">`.
-  _lsThumbDelete(stableKey, displayUrl) {
-    const back = displayUrl ?? stableKey;
-    const key = this._lsKey(stableKey);
-    const prev = this._posterMirror?.get(key);
-    if (prev?.url) {
-      try { URL.revokeObjectURL(prev.url); } catch (_) {}
-    }
-    this._posterMirror?.delete(key);
-    this._posterCache.delete(back);
-    posterStore.delete(key).catch(() => {});
-  }
-
-  async _fetchProtectedAsBlob(src) {
-    const token = this._hass?.auth?.data?.access_token;
-    if (!token) return null;
-    // Bound the wait. Without this, a slow-network fetch sits open
-    // indefinitely while the queue is starved on the connection limit.
-    // AbortError surfaces as `name === "AbortError"` so `_ensurePoster`
-    // can classify it as soft (timeout) rather than hard (broken file).
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), POSTER_FETCH_TIMEOUT_MS);
-    try {
-      const res = await fetch(window.location.origin + src, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: ctrl.signal,
-      });
-      if (res.status === 404) {
-        // Throw with a marker so _ensurePoster can drop the stale cached
-        // thumb for files that have been deleted on disk.
-        const err = new Error("not found");
-        err.status = 404;
-        throw err;
-      }
-      if (!res.ok) return null;
-      return await res.blob();
-    } finally {
-      clearTimeout(timer);
-    }
-  }
-
-  async _ensurePoster(src) {
-    if (!src || this._posterCache.has(src) || this._posterPending.has(src)) return;
-    if (this._isPosterHardFailed(src)) return;
-    if (this._isPosterCoolingDown(src)) return;
-
-    // Persistent-cache identifier (defaults to the fetch URL for
-    // paths where the URL is itself stable — sensor mode). For
-    // media-source items this is the mediaId, so a cached frame
-    // survives across sessions even though the signed URL changes.
-    const stableKey = this._posterStableKeys.get(src) || src;
-
-    // Wait for the IDB prewarm to land before checking cache. On cmd-r
-    // the render that triggered this call sees an empty mirror because
-    // `posterStore.readAll()` is async — without the await we'd race
-    // the network and re-download blobs that are already on disk.
-    if (this._prewarmReadyPromise && !this._prewarmDone) {
-      await this._prewarmReadyPromise;
-      // State may have changed during the await (selection moved,
-      // failure recorded by another path, cache populated by prewarm).
-      if (this._posterCache.has(src)) return;
-      if (this._isPosterHardFailed(src)) return;
-      if (this._isPosterCoolingDown(src)) return;
-    }
-
-    const cached = this._lsThumbGet(stableKey);
-    if (cached) {
-      this._posterCache.set(src, cached);
-      // Successful read clears any prior soft-fail state so a previously
-      // flaky URL gets a clean slate next time.
-      this._clearPosterFailure(src);
-      this.requestUpdate();
-      return;
-    }
-
-    this._posterPending.add(src);
-    try {
-      // Auth-protected HA image thumbnails (browse_media) need a Bearer fetch.
-      // Videos always go through _captureFrame to extract a still — never inline the file.
-      const blob = src.startsWith("/") && !isVideo(src)
-        ? await this._fetchProtectedAsBlob(src)
-        : await this._captureFrame(
-            src,
-            this.config?.thumbnail_frame_pct ?? DEFAULT_THUMBNAIL_FRAME_PCT
-          );
-      if (blob) {
-        // Persist by stableKey (mediaId for MS items, URL for sensor)
-        // but cache the resulting object URL by `src` so render's
-        // `<img src>` lookup hits.
-        const objectUrl = this._lsThumbSet(stableKey, blob, src);
-        if (objectUrl) {
-          this._posterCache.set(src, objectUrl);
-          this._clearPosterFailure(src);
-        } else {
-          // toBlob/createObjectURL produced nothing usable — soft fail
-          // (likely a transient resource issue, not a broken file).
-          this._recordPosterFailure(src);
-        }
-      } else {
-        // !res.ok branch in `_fetchProtectedAsBlob` (non-404). Could
-        // be a 5xx that'll recover, so soft-fail and let the cooldown
-        // gate retries.
-        this._recordPosterFailure(src);
-      }
-    } catch (e) {
-      const status = e?.status;
-      const code = e?.mediaErrorCode;
-      const msg = String(e?.message ?? "");
-      // Hard failures: anything that won't recover on retry. The
-      // rule of thumb is "the file got here but we can't make a
-      // frame out of it" — retrying won't help. That covers 404
-      // (file gone), codec errors (3, 4), and post-download
-      // extraction failures (blank frame, toBlob null, tainted
-      // canvas).
-      //
-      // Soft failures stay soft: capture timeout, fetch AbortError,
-      // MEDIA_ERR_NETWORK (2), MEDIA_ERR_ABORTED (1), 5xx — these
-      // are likely to succeed on a retry once the connection
-      // catches up.
-      const isExtractionFail =
-        msg === "blank frame" ||
-        msg === "toBlob returned null" ||
-        msg === "no video dimensions";
-      const isHard =
-        status === 404 ||
-        code === 3 /* MEDIA_ERR_DECODE */ ||
-        code === 4 /* MEDIA_ERR_SRC_NOT_SUPPORTED */ ||
-        isExtractionFail;
-      this._recordPosterFailure(src, { hard: isHard });
-      if (status === 404) this._lsThumbDelete(stableKey, src);
-    } finally {
-      this._posterPending.delete(src);
-      // Mapping is per-fetch; drop it now that this fetch has settled.
-      // Render will re-populate on next cycle if the item still needs
-      // a capture.
-      this._posterStableKeys.delete(src);
-      this.requestUpdate();
-    }
-  }
 
 
   /**
@@ -4450,12 +3630,12 @@ class CameraGalleryCard extends LitElement {
     this._favorites.load(this.config);
     this._sensorClient.load(this.config);
     this._mediaClient.load(this.config);
+    this._posterClient.load(this.config);
     this._startMediaPoll();
 
-    // Prewarm the poster localStorage cache once on the first setConfig.
-    // Reads up to 150 cached entries into memory in a single sync batch so
-    // subsequent renders can answer `_lsThumbGet` without touching LS.
-    if (!prevConfig) this._prewarmPosterLs();
+    // Prewarm the IDB-backed poster mirror once. `prewarm()` is idempotent;
+    // the client coalesces concurrent calls into a single shared promise.
+    if (!prevConfig) void this._posterClient.prewarm();
 
     const { changedKeys, isSourceChange: sourceChange, isUiOnly: uiOnlyChange } =
       configDiff(prevConfig, nextConfig);
@@ -4528,10 +3708,7 @@ class CameraGalleryCard extends LitElement {
       this._selectedIndex = 0;
       this._selectedSet.clear();
       this._hideBulkDeleteHint();
-      this._resetPosterQueue();
-      this._posterCache.clear();
-      this._posterPending.clear();
-      this._posterAttempts.clear();
+      this._posterClient.clearPosterCache();
       this._objectCache.clear();
     }
 
@@ -4662,18 +3839,19 @@ class CameraGalleryCard extends LitElement {
       }
     }
 
-    // Drain the pending work `_resolveVideoPoster` collected during
-    // render(). Both queues internally dedup; this is a deduplicated
-    // batch dispatch that runs after the DOM commit, so any
+    // Drain the pending work `client.resolveVideoPoster` collected during
+    // render(). Batch dispatch runs after the DOM commit, so any
     // `requestUpdate` triggered by the queue draining doesn't re-enter
-    // the current render cycle.
-    if (this._pendingResolveIds && this._pendingResolveIds.size) {
-      this._mediaClient.queueResolve([...this._pendingResolveIds]);
-      this._pendingResolveIds.clear();
-    }
-    if (this._pendingPosterUrls && this._pendingPosterUrls.size) {
-      for (const url of this._pendingPosterUrls) this._enqueuePoster(url);
-      this._pendingPosterUrls.clear();
+    // the current render cycle. The collector also carries (url, stableKey)
+    // tuples for media-source items whose resolved URL rotates each session.
+    if (this._pendingPoster) {
+      if (this._pendingPoster.resolveIds.size) {
+        this._mediaClient.queueResolve([...this._pendingPoster.resolveIds]);
+      }
+      for (const { url, stableKey } of this._pendingPoster.posters) {
+        this._posterClient.enqueue(url, stableKey);
+      }
+      this._pendingPoster = null;
     }
 
     if (this._isLiveActive()) {
@@ -4718,7 +3896,7 @@ class CameraGalleryCard extends LitElement {
               // in `_ensurePreviewVideoHostPlayback`.
               if (isSensor && key && isVideo(key)) {
                 const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(key);
-                if (pairedJpg) this._enqueuePoster(pairedJpg);
+                if (pairedJpg) this._posterClient.enqueue(pairedJpg);
               }
             }
           }
@@ -4741,11 +3919,11 @@ class CameraGalleryCard extends LitElement {
   render() {
     if (!this._hass || !this.config) return html``;
 
-    // Reset per-render pending-work collectors. `_resolveVideoPoster`
-    // pushes work into these instead of side-effecting the queues
-    // mid-render; `updated()` drains them after the DOM is committed.
-    this._pendingResolveIds = new Set();
-    this._pendingPosterUrls = new Set();
+    // Per-render pending-work collector. `client.resolveVideoPoster` pushes
+    // (url, stableKey?) tuples and snapshot mediaIds into this instead of
+    // side-effecting the client mid-render; `updated()` drains it after the
+    // DOM is committed.
+    this._pendingPoster = new PendingPosterCollector();
 
     const usingMediaSource = this.config?.source_mode === "media" || this.config?.source_mode === "combined";
     const thumbRatio = "1 / 1";
@@ -5179,13 +4357,13 @@ class CameraGalleryCard extends LitElement {
                     );
 
                     let poster = isVid
-                      ? this._resolveVideoPoster(it, isMs, thumbUrl, tThumb, selectedUrl)
+                      ? this._posterClient.resolveVideoPoster(it, isMs, thumbUrl, tThumb, this._pendingPoster)
                       : thumbUrl;
                     // For unresolved MS images, use the browse_media thumbnail as fallback
                     // so the thumbnail appears immediately while the full URL is still resolving
                     if (!isVid && !poster && isMs && tThumb) {
-                      poster = this._posterCache.get(tThumb) || "";
-                      if (!poster) this._enqueuePoster(tThumb);
+                      poster = this._posterClient.getPosterUrl(tThumb) || "";
+                      if (!poster) this._posterClient.enqueue(tThumb);
                     }
 
                     const needsResolve = isMs;
@@ -5267,17 +4445,17 @@ class CameraGalleryCard extends LitElement {
                               class="timg"
                               src="${poster}"
                               alt=""
-                              @error=${() => this._onThumbImgError(poster)}
+                              @error=${() => this._posterClient.onThumbImgError(poster)}
                             />`
-                          : this._isThumbBroken(it, isMs, thumbUrl, tThumb)
+                          : this._posterClient.isThumbBroken(it, isMs, thumbUrl, tThumb)
                             ? html`<div class="tph broken" aria-hidden="true">
                                 <ha-icon icon="mdi:image-broken-variant"></ha-icon>
                               </div>`
-                            : isVid && this._prewarmDone && this._willNeverLoad(it, isMs, tThumb)
+                            : isVid && this._posterClient.isPrewarmDone() && this._posterClient.willNeverLoad(it, isMs, tThumb)
                               ? html`<div class="tph disabled" aria-hidden="true" title="Thumbnail capture is off">
                                   <ha-icon icon="mdi:cloud-off-outline"></ha-icon>
                                 </div>`
-                              : this._isPosterLoading(it, isMs, thumbUrl, tThumb)
+                              : this._posterClient.isPosterLoading(it, isMs, thumbUrl, tThumb)
                                 ? html`<div class="tph spinner" aria-hidden="true"></div>`
                                 : html`<div class="tph skeleton" aria-hidden="true"></div>`}
 


### PR DESCRIPTION
## Summary

Extracts the poster pipeline (failure ledger, capture queue, resolver decision tree, IDB-backed mirror, auth-protected fetch) from ~750 lines of imperative card code into a typed `PosterCacheClient` at `src/data/poster-cache.ts`, mirroring the existing `SensorSourceClient` / `MediaSourceClient` pattern.

The extraction surfaced 17 audit findings; all are fixed in this PR. Some are user-visible behaviour changes — called out in the dedicated section below.

`src/index.js` shrinks by **893 lines** (13,019 → 12,199). Bundle delta **+3 KB / +0.78%** minified.

## Audit fixes in this PR

- **A1** — soft-retry timer no longer leaks past `reset()`
- **A3** — first-attempt cooldown gated by new `POSTER_RETRY_FIRST_DELAY_MS` (2 s instead of 30 s) so transient blips recover the same render cycle
- **A5 / A8** — queue truncation now evicts the OLDEST items (was dropping newest, opposite of intent) and clears `_posterQueued` Set entries so re-enqueue after eviction works
- **A6** — drain-side gates trimmed to race-relevant checks only
- **A10** — render-time `_resolveVideoPoster` no longer mutates `_posterStableKeys`; stableKey registration moves to a `PendingPosterCollector` drained in `updated()`
- **A11** — media-source resolver now gates the Frigate snapshot path on `isResolveFailed` (was infinite-retrying on resolve failure)
- **A15** — magic `320` / `0.6` lift to `MAX_POSTER_WIDTH_PX` / `POSTER_JPEG_QUALITY`
- **A16** — typed `MediaErrorCode` + `isHardMediaError(code)` helper
- **A17** — `AbortController` plumbing through capture / fetch / queue; `reset()` and `dispose()` now cancel in-flight work cleanly
- **A18 / A21** — `MAX_MIRROR=500` lifted to `POSTER_MIRROR_MAX_ENTRIES`, single source of truth aligned with `posterStore`'s on-disk cap
- **A22** — `_fetchProtectedAsBlob` no longer clobbers absolute URLs with `window.location.origin`
- **A23** — `classifyCaptureError(err)` helper replaces inline string-match scattered across `_ensurePoster`
- **A24** — post-prewarm guard now re-checks `_posterPending` (two racing callers no longer both pass the guard and re-fetch)
- **dispose** — every blob URL in the mirror is revoked on card teardown (previously leaked on `disconnectedCallback`)

## Deferred (follow-ups)

- **A4** — hard-fail ledger has no aging-out. Distinct UX question (when do permanent failures expire?), worth its own PR.
- Moving `_queueSensorPosterWork` into the client — render orchestration; keeping it on the card avoids growing client surface for marginal gain.

## Behaviour changes (worth a closer read on review)

- A 30-second wait after a **single** transient poster failure becomes ~2 seconds (A3). The gallery now recovers on the next render cycle when the network blip clears.
- A source-mode flip or card teardown aborts in-flight captures (A17). Previously those kept running and would write posters scoped to the old source into IDB. New behaviour is desired (the user changed sources for a reason), locked in by a spec.
- Frigate snapshot resolve failures no longer trigger infinite re-resolves (A11). Previously the resolver pushed the same snapshot ID back into the resolve queue every render until something else flushed it.

## Module design

- **Injection seam:** `PosterResolverInputs` is a read-only-views interface (closures over `this._sensorClient` / `this._mediaClient` / `this.config`). The poster client never imports either source client. Matches how `MediaSourceClient` already takes `getDtOpts` / `resolveItemMs` closures.
- **DOM-coupling:** every IO path goes through an injectable strategy — `FrameCaptureStrategy` for `<video>` frame extraction, `BlobUrlFactory` for `URL.createObjectURL` / `revokeObjectURL`, and an injectable `fetchFn` for protected-asset specs. Production wires the browser versions; the spec runs in pure jsdom with fakes.
- **Resolver side effects:** the render path no longer mutates state. `resolveVideoPoster` takes a `PendingPosterCollector` and pushes `(url, stableKey)` tuples into it; `updated()` drains the collector and dispatches via `client.enqueue(url, stableKey)`.

## Test plan

- [x] `npm run check` green (typecheck + lint + format + build + tests) on top of latest `upstream/main`
- [x] 444 specs pass (49 new specs added at `src/data/poster-cache.spec.ts`)
- [x] Bundle delta within budget (+3 KB / +0.78%)
- [x] Sensor mode HA smoke: 50 mp4s with paired jpgs → posters drain progressively
- [x] Sensor mode raw mp4s: off-screen items stay on placeholder; cmd-r → first paint from IDB
- [ ] Media-source mode: Frigate snapshot priority; paired-jpg fallback; signed-URL rotation doesn't invalidate cache
- [ ] Frigate snapshot 404 → broken icon; resolve-fail doesn't re-retry forever (A11)
- [x] Low-bandwidth mode (`capture_video_thumbnails: false`): disabled-icon, no video downloads
- [x] Failure recovery: airplane-mode + reload → soft fails accumulate, recover within ~2 s (A3)
- [x] Long session: mirror grows to `POSTER_MIRROR_MAX_ENTRIES`, LRU eviction visible in IDB DevTools, no memory growth in profiler (confirms blob URL revocation)