### PR TITLE
fix: scale fixed-mode pills with --cgc-pill-size variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5538,7 +5538,7 @@ class CameraGalleryCard extends LitElement {
       .controls-bar-fixed .gallery-pill,
       .controls-bar-fixed .live-pill-btn {
         flex: 1;
-        height: 28px;
+        height: calc(var(--cgc-pill-size, 14px) * 2);
         min-width: 0;
         background: var(--cgc-obj-btn-bg, var(--cgc-ui-bg));
         border-radius: var(--cgc-obj-btn-radius, 10px);


### PR DESCRIPTION
## What this fixes

Pill height in `.controls-bar-fixed` was hardcoded to 28px, so when
users override `--cgc-pill-size` (default 14px) to make the pill text
larger, the container stayed cramped at 28px and clipped the bigger
text/icons.

## Fix

```diff
- height: 28px;
+ height: calc(var(--cgc-pill-size, 14px) * 2);
```

Default value still resolves to 28px (14 × 2), so **no behaviour change**
for users who leave the variable alone. Anyone bumping `--cgc-pill-size`
now gets a pill that grows with it.

## Test plan

- [x] Default config — pills render at 28px (unchanged)
- [x] Set `--cgc-pill-size: 20px` via card-mod or theme — pill height
      becomes 40px and content fits without clipping