### PR TITLE
fix: differentiate Direct API states in diagnostics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1307,7 +1307,19 @@ class CameraGalleryCard extends LitElement {
         ["Calendar days", String(calendarDays), calendarDays > 0 ? "ok" : null],
         ["Days loaded", String(dayCacheSize)],
         ["Last fetch", fmtTs(loadedAt), loadedAt && (Date.now() - loadedAt < 5 * 60 * 1000) ? "ok" : loadedAt ? "warn" : "bad"],
-        ["Direct API", ms.frigateApiFailed ? `failed (${ageS(failedAt)})` : "ok", ms.frigateApiFailed ? "warn" : "ok"],
+        ["Direct API", (() => {
+          // Three states: not configured (frigate_url empty) / failed / ok.
+          // Without this split, an empty `frigate_url` shows "ok" because
+          // the failure flag defaults to false — misleading users who don't
+          // even have direct REST enabled. And a stale flag from a prior
+          // `frigate_url` value persists after the URL is removed.
+          if (!cfg.frigate_url) return "not configured";
+          if (ms.frigateApiFailed) return `failed (${ageS(failedAt)})`;
+          return "ok";
+        })(), (() => {
+          if (!cfg.frigate_url) return null;
+          return ms.frigateApiFailed ? "warn" : "ok";
+        })()],
         ["WS subscribe (frigate/events)", this._frigateEventsUnsub ? "active" : "inactive", this._frigateEventsUnsub ? "ok" : (frigateInstalled ? "warn" : null)],
         ["Live card mounted", this._liveCard ? "yes" : "no", this._liveCard ? "ok" : (cfg.live_enabled && this._viewMode === "live" ? "warn" : null)],
         ["Live layout override", this._liveLayoutOverride || "—"],


### PR DESCRIPTION
The Direct API row in the diagnostics modal only had two states (ok / failed). Two problems:

1. When `frigate_url` is not configured, REST API is never tried — but
   the diagnostic still shows "ok" (false positive, implies the API is
   working when it's not even configured)
2. When `frigate_url` is removed after a prior failure, the
   `frigateApiFailed` flag persists. Diagnostic shows "failed"
   indefinitely until full reload

## Fix

Add a third state — **"not configured"** (neutral) — when `frigate_url`
is empty. The failure flag is only consulted when the URL is set.

| Situation | Before | After |
|---|---|---|
| `frigate_url` empty | "ok" (green) ❌ misleading | "not configured" (neutral) |
| `frigate_url` set, working | "ok" (green) | "ok" (green) |
| `frigate_url` set, failing | "failed" (warn) | "failed" (warn) |
| `frigate_url` removed after failure | "failed" (sticky) ❌ stale | "not configured" |

## Test plan

- [x] Remove `frigate_url` from config → diagnostic shows "not configured"
- [x] Set `frigate_url` to a reachable URL → "ok"
- [x] Set `frigate_url` to unreachable URL (or HTTPS dashboard + HTTP frigate) → "failed (Ns ago)"
- [x] Toggle URL set → unset → state correctly switches from failed/ok to not-configured