### PR TITLE
fix: preserve custom names in object_filters

### DIFF
--- a/src/config/normalize.spec.ts
+++ b/src/config/normalize.spec.ts
@@ -347,12 +347,12 @@ describe("object_filters loose input shape", () => {
     expect(customIcons).toEqual({ person: "mdi:walk" });
   });
 
-  it("silently drops unknown filter names (legacy behaviour)", () => {
+  it("preserves custom (non-canonical) filter names", () => {
     const { config } = normalizeConfig({
       ...minimalSensor,
       object_filters: ["person", "ufo", "car"],
     });
-    expect(config.object_filters).toEqual(["person", "car"]);
+    expect(config.object_filters).toEqual(["person", "ufo", "car"]);
   });
 });
 

--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -466,9 +466,9 @@ function preMigrateConfig(input: InputConfig): PreMigrated {
   }
 
   // object_filters: unwrap the loose `string | {name: icon}` input shape into
-  // a clean string array + a `customIcons` side-output. Unknown filter names
-  // are silently dropped (legacy behaviour preserved — old configs may
-  // reference filters that have since been renamed).
+  // a clean string array + a `customIcons` side-output. Custom names that are
+  // not in `KNOWN_FILTERS` are kept as-is so users can add their own labels
+  // (e.g. matching custom Frigate object types or filename tokens).
   const customIcons: Record<string, string> = {};
   const ofIn = out.object_filters;
   const ofRaw: ObjectFilterEntry[] = Array.isArray(ofIn) ? ofIn : ofIn ? [ofIn] : [];
@@ -488,7 +488,7 @@ function preMigrateConfig(input: InputConfig): PreMigrated {
         icon = first[1];
       }
     }
-    if (!name || ofSeen.has(name) || !KNOWN_FILTERS.has(name)) continue;
+    if (!name || ofSeen.has(name)) continue;
     ofSeen.add(name);
     ofOut.push(name);
     if (icon) customIcons[name] = icon;

--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -183,9 +183,9 @@ export const cameraGalleryCardConfigStruct = type({
   // ─── Object filters ────────────────────────────────────────
   // The loose `string | { name: icon }` input shape is unwrapped in
   // `normalize.ts`'s pre-migrate step, which splits it into:
-  //   - `object_filters: string[]` (just the canonical names, here)
+  //   - `object_filters: string[]` (canonical names + user-defined customs)
   //   - `customIcons: Record<string, string>` (returned alongside the config)
-  object_filters: defaulted(array(enums(AVAILABLE_OBJECT_FILTERS)), []),
+  object_filters: defaulted(array(string()), []),
   object_colors: defaulted(record(string(), string()), {}),
   entity_filter_map: defaulted(record(string(), enums(AVAILABLE_OBJECT_FILTERS)), {}),
 


### PR DESCRIPTION
## Summary
- Adding a custom object filter (name + icon) via the editor silently failed: the entry was dropped during config normalization because both the pre-migrate step and the struct validator required the name to be in `AVAILABLE_OBJECT_FILTERS`.
- This change relaxes both gates so user-defined filter names round-trip through YAML and render in the card.
- Runtime helpers (`objectIcon`, `getFilterAliases`, matcher) already handled unknown names gracefully — they use the user-supplied icon (or `mdi:magnify` fallback) and treat the name itself as a single matching alias.

## Changes
- `src/config/normalize.ts`: drop the `!KNOWN_FILTERS.has(name)` gate in `preMigrateConfig`; keep dedupe + lowercase.
- `src/config/structs.ts`: relax `object_filters` from `array(enums(AVAILABLE_OBJECT_FILTERS))` to `array(string())`.
- `src/config/normalize.spec.ts`: existing test flipped — custom names are now preserved, not dropped.

## Test plan
- [x] `npm test` — all 562 tests pass
- [x] Local dev test (`npm run dev`) — added a custom filter via the editor, name + icon persisted in the YAML and appeared as a button in the card
- [x] CI green