### PR TITLE
fix: undefined isVideo() reference throws on every sensor-source render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -749,7 +749,7 @@ class CameraGalleryCard extends LitElement {
     for (const it of items) {
       const src = String(it?.src || "");
       if (!src) continue;
-      if (!isVideo(src)) continue;
+      if (!this._isVideoForSrc(src)) continue;
       const pairedJpg = pairedThumbs.get(src);
       if (pairedJpg) this._posterClient.enqueue(pairedJpg);
     }
@@ -3558,7 +3558,7 @@ class CameraGalleryCard extends LitElement {
               // thumbnail (paired jpg). Raw video capture is deferred
               // until the user clicks the item — see the click-path
               // in `_ensurePreviewVideoHostPlayback`.
-              if (isSensor && key && isVideo(key)) {
+              if (isSensor && key && this._isVideoForSrc(key)) {
                 const pairedJpg = this._sensorClient.getSensorPairedThumbs().get(key);
                 if (pairedJpg) this._posterClient.enqueue(pairedJpg);
               }


### PR DESCRIPTION
Two places in `src/index.js` call a function called `isVideo(...)` that doesn't exist — it's not imported, not a method, just a bare reference. Every render in sensor- or combined-source mode hits one of these lines and Lit logs an `Uncaught (in promise) ReferenceError: isVideo is not defined`. The card stays partly usable because Lit catches the throw inside `updated()`, but the poster-prefetch and lazy-thumb work that those two checks gate never runs, and the browser console fills up.

Looks like a leftover from #85 (`extract pairing helpers and favorites storage`) — that PR introduced both call sites. The actual helper for "is this src a video?" exists on the card class itself as `_isVideoForSrc(src)`, which wraps the imported `viewIsVideoForSrc` together with the card's media-meta lookups. So the fix is a 1-to-1 rename at both call sites.

### Locations (against current main)

- `src/index.js:752` — inside `_queueSensorPosterWork`, decides whether a sensor item is a video before enqueuing its paired thumbnail for the poster cache
- `src/index.js:3561` — inside the lazy-thumb IntersectionObserver, decides whether to enqueue a poster as the thumb scrolls into view

Both now use `this._isVideoForSrc(...)` instead of the bare `isVideo(...)`.

### How I noticed

Spotted while testing #137 locally — the errors fired every few seconds in the console and were drowning out the actual mic-related logs I was trying to read. After confirming the same trace appears on plain `main` I split this off so it can go in independently.

### Verifying

1. Open a dashboard with a `camera-gallery-card` in `source_mode: sensor` (or `combined`) and at least one sensor entity with paired video files
2. Open browser DevTools → Console before this PR: ReferenceError fires repeatedly during render and when scrolling thumbnails into view
3. With this PR applied: console stays clean, paired-jpg posters still load as expected