### PR TITLE
refactor: glass-uniform look for live-view pills + chevrons

### DIFF
--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -126,6 +126,7 @@ export interface InputConfig {
 
   // ─── Layout / styling ──────────────────────────────────────
   bar_opacity?: number;
+  chevron_opacity?: number;
   bar_position?: string;
   thumb_size?: number;
   thumb_bar_position?: string;

--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -194,6 +194,7 @@ export const cameraGalleryCardConfigStruct = type({
 
   // ─── Layout / styling ──────────────────────────────────────
   bar_opacity: defaulted(intInRange(BAR_OPACITY_MIN, BAR_OPACITY_MAX), DEFAULT_BAR_OPACITY),
+  chevron_opacity: defaulted(intInRange(BAR_OPACITY_MIN, BAR_OPACITY_MAX), DEFAULT_BAR_OPACITY),
   bar_position: defaulted(enums(BAR_POSITIONS), DEFAULT_BAR_POSITION),
   thumb_size: defaulted(intInRange(THUMB_SIZE_MIN, THUMB_SIZE_MAX), THUMB_SIZE),
   thumb_bar_position: defaulted(enums(THUMB_BAR_POSITIONS), DEFAULT_THUMB_BAR_POSITION),

--- a/src/config/styling-config.ts
+++ b/src/config/styling-config.ts
@@ -300,6 +300,30 @@ export const STYLE_SECTIONS: readonly StyleSection[] = [
     ],
   },
   {
+    id: "live_navigation",
+    label: "Live navigation",
+    icon: "mdi:chevron-right",
+    controls: [
+      {
+        type: "color",
+        hostId: "chevron-bg-host",
+        variable: "--cgc-chevron-bg",
+        label: "Background",
+      },
+      {
+        type: "slider",
+        id: "chevronop",
+        valId: "chevronopval",
+        configKey: "chevron_opacity",
+        label: "Opacity",
+        min: BAR_OPACITY_MIN,
+        max: BAR_OPACITY_MAX,
+        default: DEFAULT_BAR_OPACITY,
+        unit: "%",
+      },
+    ],
+  },
+  {
     id: "layout",
     label: "Layout",
     icon: "mdi:format-line-spacing",

--- a/src/index.js
+++ b/src/index.js
@@ -3701,6 +3701,7 @@ class CameraGalleryCard extends LitElement {
     const rootVars = `
       --cgc-card-radius:10px;
       --cgc-bar-opacity:${this.config.bar_opacity};
+      --cgc-chevron-opacity:${this.config.chevron_opacity ?? this.config.bar_opacity};
       --cgc-thumb-row-h:${this.config.thumb_size}px;
       --cgc-thumb-empty-h:${this.config.thumb_size}px;
       --cgc-topbar-margin:${STYLE.topbar_margin};

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -782,17 +782,27 @@ export const cardStyles = css`
     width: 44px;
     height: 44px;
     border-radius: 999px;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.18) 0%, rgba(0, 0, 0, 0.28) 100%);
-    backdrop-filter: blur(16px) saturate(180%);
-    -webkit-backdrop-filter: blur(16px) saturate(180%);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    border: none;
+    background: transparent;
+    backdrop-filter: blur(16px) saturate(160%);
+    -webkit-backdrop-filter: blur(16px) saturate(160%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
     color: #fff;
     display: grid;
     place-items: center;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-    opacity: 0.9;
+    position: relative;
+    overflow: hidden;
+  }
+  .pnavbtn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--cgc-chevron-bg, var(--cgc-pill-bg));
+    opacity: calc(var(--cgc-chevron-opacity, var(--cgc-bar-opacity, 30)) / 100);
+    pointer-events: none;
   }
 
   .pnavbtn[disabled] {
@@ -805,6 +815,8 @@ export const cardStyles = css`
     --mdc-icon-size: var(--ha-icon-size);
     width: var(--ha-icon-size);
     height: var(--ha-icon-size);
+    position: relative;
+    z-index: 1;
   }
 
   .tsbar {
@@ -1066,6 +1078,9 @@ export const cardStyles = css`
     line-height: 1;
     position: relative;
     white-space: nowrap;
+    backdrop-filter: blur(16px) saturate(160%);
+    -webkit-backdrop-filter: blur(16px) saturate(160%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
 
     &::before {
       content: "";
@@ -1074,7 +1089,6 @@ export const cardStyles = css`
       border-radius: inherit;
       background: var(--cgc-pill-bg);
       opacity: calc(var(--cgc-bar-opacity, 30) / 100);
-      backdrop-filter: blur(4px);
       pointer-events: none;
     }
     & ha-icon,


### PR DESCRIPTION
Pills and the live-nav chevrons currently sit next to each other in the same controls bar but render in two unrelated styles:

- **Pills** — flat dark overlay: `var(--cgc-pill-bg)` solid + `bar_opacity` opacity, 4px backdrop blur, no border, no highlight.
- **Chevrons** — a hand-tuned light→dark gradient (`linear-gradient(135deg, rgba(255,255,255,0.18) 0%, rgba(0,0,0,0.28) 100%)`) with a 0.3 white border, 16px blur, and `opacity: 0.9` on top.

The two felt visually inconsistent sitting next to each other.

## What this PR does

Move both to the same glass tokens:

- `backdrop-filter: blur(16px) saturate(160%)`
- Inset highlight `inset 0 1px 0 rgba(255,255,255,0.14)`
- Tint via a configurable color variable on a `::before` overlay so pseudo-elements with `pointer-events: none` keep clicks reaching the button

For **pills**, the existing `--cgc-pill-bg` + `bar_opacity` keep their exact behaviour — no theme migration needed, themes that already set those vars look identical color-wise. The pill's 4px backdrop blur (which barely registered visually) is folded into the new 16px shared blur.

For **chevrons**, the hardcoded gradient and white border are replaced by a `::before` that reads two new vars:

- `--cgc-chevron-bg` (color) — falls back to `--cgc-pill-bg` if unset
- `chevron_opacity` (slider, 0-100%) — falls back to `bar_opacity` if unset

So a card with no extra config keeps looking identical to before in tint, but the visual grammar is now shared with the pills. The two new knobs are exposed in the Styling tab under a new "Live navigation" section so users can tune chevrons independently if they want (e.g. brighter chevrons for visibility on bright daytime camera feeds).

Existing borders and `opacity: 0.9` on chevrons removed — the glass tokens alone read clean enough and stay consistent with the rest of the overlay surface.

## Files

- `src/styles.ts` — `.gallery-pill` + `.pnavbtn` glass tokens, `.pnavbtn::before` tint overlay
- `src/index.js` — `--cgc-chevron-opacity` added to `rootVars`
- `src/config/structs.ts` — `chevron_opacity` slider field
- `src/config/normalize.ts` — `chevron_opacity?: number` on InputConfig
- `src/config/styling-config.ts` — new "Live navigation" section with color + opacity controls

## Verifying

1. Open a card with `live_enabled: true` and at least two live cameras (so the chevron picker is rendered)
2. Pills and chevrons should look like glass surfaces with the same blur character; no white border on chevrons, no faded `0.9` look
3. Editor → Styling tab → new "Live navigation" section appears with Background color + Opacity slider. Changing either updates chevrons live without touching pills.
4. Existing themes that set `--cgc-pill-bg` / `bar_opacity` keep looking the same (visual regression check)