### PR TITLE
fix: talkback bar swaps to top when pills are anchored at the bottom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2123,13 +2123,19 @@ class CameraGalleryCard extends LitElement {
           : err
             ? "rgba(127, 29, 29, 0.30)"
             : "transparent";
+    // Avoid stacking on top of the pill bar — when pills sit at the
+    // bottom (`bar_position: bottom`) flip the talkback bar to the top.
+    const placement =
+      this.config?.bar_position === "bottom"
+        ? "top:12px;bottom:auto"
+        : "bottom:12px;top:auto";
     return html`
       <div
         class="mic-talkback-bar ${cls}"
         role="button"
         tabindex="0"
         aria-label=${`Push-to-talk (${state})`}
-        style="position:absolute;left:12px;right:12px;bottom:12px;min-height:38px;height:38px;padding:0 16px;font-size:14px;display:flex;align-items:center;justify-content:center;gap:10px;border-radius:14px;color:#fff;font-weight:600;letter-spacing:0.02em;background:${bg};box-shadow:inset 0 1px 0 rgba(255,255,255,0.14);user-select:none;-webkit-user-select:none;touch-action:none;z-index:5;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%);text-shadow:0 1px 2px rgba(0,0,0,0.5);overflow:hidden;"
+        style="position:absolute;left:12px;right:12px;${placement};min-height:38px;height:38px;padding:0 16px;font-size:14px;display:flex;align-items:center;justify-content:center;gap:10px;border-radius:14px;color:#fff;font-weight:600;letter-spacing:0.02em;background:${bg};box-shadow:inset 0 1px 0 rgba(255,255,255,0.14);user-select:none;-webkit-user-select:none;touch-action:none;z-index:5;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%);text-shadow:0 1px 2px rgba(0,0,0,0.5);overflow:hidden;"
         @pointerdown=${this._onMicPointerDown}
         @pointerup=${this._onMicPointerUp}
         @pointercancel=${this._onMicPointerUp}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1130,7 +1130,13 @@ export const cardStyles = css`
   }
 
   /* Mic error toast — sits inside live-controls-bar so layout doesn't
-     shift; role=status + aria-live=polite announces via screen readers. */
+     shift; role=status + aria-live=polite announces via screen readers.
+     Hidden via display:none while empty so it doesn't claim layout
+     space above/below the pill row (only matters when bar_position
+     pushes the pills away from the controls-bar's anchor edge). */
+  .mic-error-toast:not(.visible) {
+    display: none;
+  }
   .mic-error-toast {
     display: flex;
     align-items: center;


### PR DESCRIPTION
With `bar_position: bottom` (Styling → Pills → Position), the live-controls pill row sits at the bottom of the preview. The talkback bar — also anchored at the bottom by default — landed in the same gutter, overlapping the pills. And even at `bar_position: top` the pills sat ~12-16px higher off the bottom edge than they did at the top edge, because the empty mic error toast inside the controls bar was claiming layout space.

## What this PR does

**1) Talkback bar swaps edges based on `bar_position`**

`_renderMicTalkbackBar` now reads `this.config.bar_position` and flips its own placement to `top: 12px` when pills are anchored at the bottom. For `top` and `hidden` it stays at the bottom (no behaviour change). The two surfaces are now always on opposite edges.

**2) Empty mic error toast no longer reserves layout space**

`_renderMicErrorToast` was rendering a `<div class=mic-error-toast>` as soon as `live_mic_streams` was configured, and toggled the `.visible` class on/off depending on whether there was an actual error. The empty `<div>` already had `opacity: 0` so it was invisible — but it still claimed ~12-16px of layout space inside `.live-controls-bar`, which pushed the pills off the anchor edge.

Added one CSS rule: `.mic-error-toast:not(.visible) { display: none; }`. The opacity transition only fires on the appear-on-error path now, which is the only direction that wants an animation anyway. Screen-reader announcement still works — `aria-live=polite` fires when the visible-toast node appears in the DOM with text content.

## Verifying

1. Card with `live_enabled: true` + at least one camera mapped in `live_mic_streams`
2. Editor → Styling → Pills → Position: switch between Top / Bottom
3. Pills move; talkback bar moves to the opposite edge in both cases; no overlap
4. Pill row sits flush against the chosen edge in both positions (same gutter to top as to bottom, modulo theme paddings)