### PR TITLE
feat: parse Unix epoch + start-end range filenames in path_datetime_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,10 @@ The card extracts timestamps from a single configurable pattern, `path_datetime_
 | HH | 2-digit hour (24h) |
 | mm | 2-digit minute |
 | ss | 2-digit second |
+| X | 10-digit Unix timestamp in seconds (decoded to local time) |
+| x | 13-digit Unix timestamp in milliseconds (decoded to local time) |
+
+**Range filenames (`start-end`).** When a format includes the same date/time token twice (or the `X` token twice), the **first** capture is used as the canonical timestamp and the second is treated as a structural anchor. This is what lets a single format string describe `start-end`-style filenames without picking the wrong instant.
 
 ### Layouts
 
@@ -442,6 +446,28 @@ path_datetime_format: YYYY/MM/DD/RLC_YYYYMMDDHHmmss.mp4
 ```
 
 (Reolink/FTP shape — see [issue #99](https://github.com/TheScubaDiver/camera-gallery-card/issues/99).)
+
+**D. Unix epoch in the filename**
+```
+/media/tapo/1706108297-1706108310.mp4
+            └──start──┘ └───end───┘
+path_datetime_format: X-X
+```
+
+Tapo Control writes `unix_start-unix_end.mp4`; `X-X` captures both but uses the start as the canonical time. A single epoch (`1706108297.mp4`) is just `X`. UniFi Protect's `.ubv` files encode the millisecond epoch — `B4FBE47EEF30_0_rotating_1642402659065.ubv` matches `x`.
+
+**E. Calendar-range filenames**
+```
+/media/reolink/cam_20240315083000_20240315083127.mp4
+                   └────start────┘└─────end────┘
+path_datetime_format: YYYYMMDDHHmmss_YYYYMMDDHHmmss
+
+/media/dahua/2024-03-15/ch1/dav/11/11.00.01-11.00.59[M][0@0][0].mp4
+                                   └─start─┘└──end──┘
+path_datetime_format: YYYY-MM-DD/HH.mm.ss-HH.mm.ss
+```
+
+Reolink SD-card exports and Dahua/Amcrest filenames carry two same-format timestamps; the first wins.
 
 ---
 

--- a/src/data/date-tokens.ts
+++ b/src/data/date-tokens.ts
@@ -7,7 +7,16 @@
 
 import { YEAR_2DIGIT_PIVOT } from "../const";
 
-export type DateField = "year" | "year2" | "month" | "day" | "hour" | "minute" | "second";
+export type DateField =
+  | "year"
+  | "year2"
+  | "month"
+  | "day"
+  | "hour"
+  | "minute"
+  | "second"
+  | "epochSec"
+  | "epochMs";
 
 export interface PartialDateFields {
   year?: number;
@@ -18,7 +27,12 @@ export interface PartialDateFields {
   second?: number;
 }
 
-/** Token → `(field, digit count)` pair. Single source of truth for the mini-language. */
+/** Token → `(field, digit count)` pair. Single source of truth for the mini-language.
+ *
+ * `X` / `x` mirror the moment.js / dayjs / luxon convention: `X` = Unix seconds
+ * (10 digits), `x` = Unix milliseconds (13 digits). Captured numbers are
+ * decoded to local-time year/month/day/hour/minute/second by `fillField`, so
+ * downstream merge / build code never sees an `epoch*` field. */
 const TOKEN_SPECS = {
   YYYY: { field: "year", digits: 4 },
   YY: { field: "year2", digits: 2 },
@@ -27,11 +41,16 @@ const TOKEN_SPECS = {
   HH: { field: "hour", digits: 2 },
   mm: { field: "minute", digits: 2 },
   ss: { field: "second", digits: 2 },
+  X: { field: "epochSec", digits: 10 },
+  x: { field: "epochMs", digits: 13 },
 } as const satisfies Record<string, { field: DateField; digits: number }>;
 
 type TokenName = keyof typeof TOKEN_SPECS;
 
-const TOKEN_RE = /(YYYY|YY|MM|DD|HH|mm|ss)/g;
+// Longest tokens first so the alternation greedily matches `YYYY` before `YY`.
+// Single-char tokens last; left-to-right alternation order is what `TOKEN_RE.exec`
+// relies on for unambiguous tokenization.
+const TOKEN_RE = /(YYYY|YY|MM|DD|HH|mm|ss|X|x)/g;
 const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export function buildFilenameDateRegex(
@@ -58,6 +77,39 @@ export function buildFilenameDateRegex(
   }
 }
 
+/** Write a captured token value into `out`, decoding compound tokens (year2,
+ * epochSec, epochMs) into their constituent calendar fields.
+ *
+ * **First-wins** on duplicates: if a target field is already set, this is a
+ * no-op. That's what makes range-style formats (`X-X` for Tapo,
+ * `YYYYMMDDHHmmss_YYYYMMDDHHmmss` for Reolink SD, `HH.mm.ss-HH.mm.ss` for
+ * Dahua) yield the start time — the second occurrence is a structural anchor
+ * that the parser still has to walk past, but its capture is discarded. */
+export function fillField(out: PartialDateFields, field: DateField, raw: string): void {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return;
+  if (field === "year") {
+    if (out.year === undefined) out.year = n;
+  } else if (field === "year2") {
+    if (out.year === undefined) out.year = YEAR_2DIGIT_PIVOT + n;
+  } else if (field === "epochSec" || field === "epochMs") {
+    // Already-decoded epoch wins over later captures (range start-time).
+    if (out.year !== undefined) return;
+    const ms = field === "epochSec" ? n * 1000 : n;
+    if (!Number.isFinite(ms)) return;
+    const d = new Date(ms);
+    if (Number.isNaN(d.getTime())) return;
+    out.year = d.getFullYear();
+    out.month = d.getMonth() + 1;
+    out.day = d.getDate();
+    out.hour = d.getHours();
+    out.minute = d.getMinutes();
+    out.second = d.getSeconds();
+  } else if (out[field] === undefined) {
+    out[field] = n;
+  }
+}
+
 export function parseRawDateFields(name: string, format: string): PartialDateFields | null {
   if (!name || !format) return null;
   const built = buildFilenameDateRegex(format);
@@ -69,11 +121,7 @@ export function parseRawDateFields(name: string, format: string): PartialDateFie
     const field = built.fields[i];
     const v = m[i + 1];
     if (!field || v === undefined) continue;
-    const n = Number(v);
-    if (!Number.isFinite(n)) continue;
-    if (field === "year") out.year = n;
-    else if (field === "year2") out.year = YEAR_2DIGIT_PIVOT + n;
-    else out[field] = n;
+    fillField(out, field, v);
   }
   return out;
 }

--- a/src/data/datetime-parsing.spec.ts
+++ b/src/data/datetime-parsing.spec.ts
@@ -142,6 +142,55 @@ describe("Three layouts via path_datetime_format", () => {
   });
 });
 
+describe("Unix epoch tokens (X / x)", () => {
+  it("X — single 10-digit Unix-seconds filename decodes to local time", () => {
+    // 1706108297 = 2024-01-24T14:18:17Z. Pick a fixed instant and assert
+    // the local-time round-trip is identity.
+    const ms = 1706108297 * 1000;
+    const expected = new Date(ms);
+    const result = extractDateTimeKey("/media/tapo/1706108297.mp4", opts("X"));
+    expect(result).not.toBeNull();
+    // Round-trip via new Date(dtKey) returns the original ms.
+    const back = new Date(result ?? "").getTime();
+    expect(back).toBe(expected.getTime());
+  });
+
+  it("X-X — Tapo-style start-end range pins canonical time to the start", () => {
+    // start=1706108297, end=1706108310 — should yield the start's ms.
+    const startMs = 1706108297 * 1000;
+    const ms = dtMsFromSrc("/media/tapo/1706108297-1706108310.mp4", opts("X-X"));
+    expect(ms).toBe(startMs);
+  });
+
+  it("x — UniFi Protect-style 13-digit milliseconds epoch decodes correctly", () => {
+    // Sub-second precision is dropped: we decode through year/month/day/hour/
+    // minute/second fields, which has no slot for ms. That's fine for sort and
+    // day-grouping — surveillance files don't need ms resolution.
+    const epochMs = 1642402659065;
+    const expectedMs = epochMs - (epochMs % 1000);
+    const ms = dtMsFromSrc(
+      "media-source://unifi/B4FBE47EEF30_0_rotating_1642402659065.ubv",
+      opts("x")
+    );
+    expect(ms).toBe(expectedMs);
+  });
+
+  it("first-wins for duplicate calendar tokens (Reolink SD card range)", () => {
+    // cam_20240315083000_20240315083127.mp4 — start vs end same day, different
+    // minutes. With first-wins the result is the start.
+    const ms = dtMsFromSrc(
+      "/media/reolink/cam_20240315083000_20240315083127.mp4",
+      opts("YYYYMMDDHHmmss_YYYYMMDDHHmmss")
+    );
+    expect(ms).toBe(new Date(2024, 2, 15, 8, 30, 0).getTime());
+  });
+
+  it("rejects non-finite or impossible epoch values gracefully", () => {
+    // `X` requires exactly 10 digits. A 9-digit run shouldn't match.
+    expect(dtMsFromSrc("/media/tapo/170610829.mp4", opts("X"))).toBeNull();
+  });
+});
+
 describe("Format string is cached on repeated calls", () => {
   it("repeated calls return the same result without recompiling", () => {
     const fmt = "YYYY/MM/DD/HHmmss";

--- a/src/data/path-format-detect.spec.ts
+++ b/src/data/path-format-detect.spec.ts
@@ -226,6 +226,36 @@ describe("collectMediaSamples", () => {
   });
 });
 
+describe("Unix epoch detection", () => {
+  it("detects Tapo Control-style X-X range filenames", () => {
+    // 1778741309 = 2026-05-13T22:48:29Z (within the sanity window).
+    // Use four files all in the X-X shape so the detector lands on it.
+    const samples = [
+      "media-source://media_source/tapo/1778741309-1778741415.mp4",
+      "media-source://media_source/tapo/1778742000-1778742090.mp4",
+      "media-source://media_source/tapo/1778750000-1778750200.mp4",
+      "media-source://media_source/tapo/1778760000-1778760100.mp4",
+    ];
+    const result = scoreSamples(samples);
+    expect(result.format).toBe("X-X");
+    expect(result.matches).toBe(4);
+  });
+
+  it("sanity-window rejects 10-digit non-epoch IDs from auto-detect", () => {
+    // 10-digit camera/asset IDs that resolve to a far-future or pre-2010 date
+    // must not auto-detect as epoch. A `999999999X`-style ID resolves to year
+    // 2286 — outside the sanity window.
+    const samples = [
+      "media-source://x/cam0000000000-0000000060.mp4",
+      "media-source://x/cam9999999999-9999999990.mp4",
+      "media-source://x/cam9999000000-9999000060.mp4",
+    ];
+    const result = scoreSamples(samples);
+    // No epoch candidate should win.
+    expect(result.format === "X-X" || result.format === "X").toBe(false);
+  });
+});
+
 describe("UniFi Protect — title-based detection", () => {
   // UniFi Protect returns a flat list of events with opaque IDs and
   // human-readable titles like `05/12/26 09:46:45 28s Object Detection - Person`.

--- a/src/data/path-format-detect.ts
+++ b/src/data/path-format-detect.ts
@@ -95,6 +95,21 @@ const CANDIDATES: readonly string[] = [
   "YYYYMMDD_HHmmss",
   "YYYYMMDD-HHmmss",
   "YYYYMMDDHHmmss",
+  // ─── Layout A — range-style calendar filenames. First-wins capture
+  // pins the canonical timestamp to the start; the duplicate token just
+  // anchors the literal between start and end. Reolink SD cards and
+  // Dahua/Amcrest write these. ───
+  "YYYYMMDDHHmmss_YYYYMMDDHHmmss",
+  "YYYYMMDDHHmmss-YYYYMMDDHHmmss",
+  "HH.mm.ss-HH.mm.ss",
+  // ─── Layout E — Unix epoch. Two-occurrence range patterns first so
+  // tie-break favours them over the single-epoch suggestion. `X` =
+  // seconds (10 digits), `x` = milliseconds (13 digits), per the
+  // moment.js / dayjs convention. ───
+  "X-X",
+  "X_X",
+  "X",
+  "x",
   // ─── Title-style — single segment with literal `/` (UniFi Protect,
   // any other integration that exposes the timestamp only in the
   // human-readable title). `\/` escapes the slash so the parser keeps
@@ -105,6 +120,22 @@ const CANDIDATES: readonly string[] = [
   "DD\\/MM\\/YY HH:mm:ss",
   "YYYY-MM-DD HH:mm:ss",
 ];
+
+/** Sanity window for auto-detect epoch matches: a 10-/13-digit run that
+ * resolves to a date outside this band is almost certainly a random ID, not
+ * a real timestamp. Explicit user configs bypass — only auto-detect cares
+ * about false positives. Lower bound is fixed (2010-01-01); upper bound is
+ * one year past the current local year. */
+const EPOCH_SANITY_YEAR_LOW = 2010;
+function epochSanityYearHigh(): number {
+  return new Date().getFullYear() + 1;
+}
+function isPlausibleEpochYear(year: number): boolean {
+  return year >= EPOCH_SANITY_YEAR_LOW && year <= epochSanityYearHigh();
+}
+function candidateUsesEpoch(format: string): boolean {
+  return /[Xx]/.test(format);
+}
 
 /**
  * Probe a single root: browse + walk a small set of branches, collect file
@@ -177,8 +208,15 @@ async function probeRoot(rootId: string, browse: BrowseFn): Promise<string[]> {
 }
 
 /** Score a candidate format against a list of sample paths. Returns the
- * count of paths that successfully extract a year+month+day from the format. */
-function scoreCandidate(samples: readonly string[], fmt: PathFormat): number {
+ * count of paths that successfully extract a year+month+day from the format.
+ *
+ * Epoch candidates carry an extra plausibility check: the resolved year must
+ * fall in `[EPOCH_SANITY_YEAR_LOW, currentYear+1]`. Without that, any list of
+ * 10-digit asset-IDs would auto-detect as `X` and any 13-digit hash run as
+ * `x`. Explicit user-typed formats skip this check entirely — the gate is
+ * scoped to the detector. */
+function scoreCandidate(samples: readonly string[], cand: string, fmt: PathFormat): number {
+  const epochGated = candidateUsesEpoch(cand);
   let hits = 0;
   for (const path of samples) {
     const fields = matchPathTail(path, fmt);
@@ -188,6 +226,7 @@ function scoreCandidate(samples: readonly string[], fmt: PathFormat): number {
       fields.month !== undefined &&
       fields.day !== undefined
     ) {
+      if (epochGated && !isPlausibleEpochYear(fields.year)) continue;
       hits++;
     }
   }
@@ -251,7 +290,7 @@ export function scoreSamples(samples: readonly string[]): DetectResult {
       allScored.push({ format: cand, matches: 0 });
       continue;
     }
-    allScored.push({ format: cand, matches: scoreCandidate(samples, fmt) });
+    allScored.push({ format: cand, matches: scoreCandidate(samples, cand, fmt) });
   }
 
   // Sort: most matches first; tie-break on candidate index (most-specific

--- a/src/data/path-format.spec.ts
+++ b/src/data/path-format.spec.ts
@@ -195,6 +195,36 @@ describe("matchPathTail — full-path matching", () => {
     expect(matchPathTail("media-source://x/y/z", fmt)).toBeNull();
   });
 
+  it("X-X — Tapo Unix-epoch range expands the start epoch into local-time fields", () => {
+    const fmt = parsePathFormat("X-X")!;
+    const fields = matchPathTail("/media/tapo/1706108297-1706108310.mp4", fmt);
+    const expected = new Date(1706108297 * 1000);
+    expect(fields).toEqual({
+      year: expected.getFullYear(),
+      month: expected.getMonth() + 1,
+      day: expected.getDate(),
+      hour: expected.getHours(),
+      minute: expected.getMinutes(),
+      second: expected.getSeconds(),
+    });
+  });
+
+  it("HH.mm.ss-HH.mm.ss — Dahua-style time-range range gives the start time (first-wins)", () => {
+    // Two-segment fixture to keep the format anchored at the path tail.
+    // The trailing `[M][0@0][0]` metadata is ignored by the unanchored-leaf
+    // boundary lookarounds.
+    const fmt = parsePathFormat("YYYY-MM-DD/HH.mm.ss-HH.mm.ss")!;
+    const fields = matchPathTail("/media/dahua/2024-03-15/11.00.01-11.00.59[M][0@0][0].mp4", fmt);
+    expect(fields).toEqual({
+      year: 2024,
+      month: 3,
+      day: 15,
+      hour: 11,
+      minute: 0,
+      second: 1,
+    });
+  });
+
   it("plain (non-URI) path also works (sensor-mode src shape)", () => {
     const fmt = parsePathFormat("YYYY/MM/DD/RLC_YYYYMMDDHHmmss.mp4")!;
     const fields = matchPathTail("/local/cams/2026/04/30/RLC_20260430120030.mp4", fmt);

--- a/src/data/path-format.ts
+++ b/src/data/path-format.ts
@@ -20,13 +20,30 @@
  * (HH/mm/ss) or a literal extension (`.mp4`/`.jpg`/…) ⇒ it's a file.
  */
 
-import { YEAR_2DIGIT_PIVOT } from "../const";
-import { buildFilenameDateRegex, type DateField, type PartialDateFields } from "./date-tokens";
+import {
+  buildFilenameDateRegex,
+  type DateField,
+  fillField,
+  type PartialDateFields,
+} from "./date-tokens";
 
 const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const TIME_TOKEN_RE = /HH|mm|ss/;
+// X/x are full instants (Unix seconds / ms) — treat them like time tokens for
+// the file-vs-directory heuristic so extension-less formats like `X-X` route
+// to the leaf-filename branch instead of being parsed as a directory pattern.
+const TIME_TOKEN_RE = /HH|mm|ss|X|x/;
 const FILE_EXT_RE = /\.[a-z0-9]{2,5}$/i;
+/** A trailing `.token` suffix on a leaf format (e.g. `HH.mm.ss-HH.mm.ss`
+ * ends in `.ss`) trips `FILE_EXT_RE` into thinking the format has a literal
+ * extension. Rule it out by checking the captured tail against the known
+ * date-token names — if the "extension" *is* a token, it isn't an extension. */
+const TOKEN_NAMES = new Set(["YYYY", "YY", "MM", "DD", "HH", "mm", "ss", "X", "x"]);
+function hasLiteralExtension(raw: string): boolean {
+  const m = raw.match(FILE_EXT_RE);
+  if (!m) return false;
+  return !TOKEN_NAMES.has(m[0].slice(1));
+}
 
 /** A single `/`-separated segment of the format, compiled to a regex. */
 export interface PathSegmentSpec {
@@ -88,7 +105,7 @@ function compileSegment(raw: string, unanchored: boolean): PathSegmentSpec | nul
 
 /** Heuristic: a segment is a filename if it carries time tokens or a literal extension. */
 function segmentLooksLikeFile(raw: string): boolean {
-  return TIME_TOKEN_RE.test(raw) || FILE_EXT_RE.test(raw);
+  return TIME_TOKEN_RE.test(raw) || hasLiteralExtension(raw);
 }
 
 /** Placeholder for escaped slashes during segment splitting. NUL byte is
@@ -119,7 +136,7 @@ export function parsePathFormat(format: string | null | undefined): PathFormat |
   if (rawSegs.length === 0) return null;
   const lastRaw = rawSegs[rawSegs.length - 1] ?? "";
   const leafIsFile = segmentLooksLikeFile(lastRaw);
-  const leafHasExtension = leafIsFile && FILE_EXT_RE.test(lastRaw);
+  const leafHasExtension = leafIsFile && hasLiteralExtension(lastRaw);
   const segs: PathSegmentSpec[] = [];
   for (let i = 0; i < rawSegs.length; i++) {
     const raw = rawSegs[i] ?? "";
@@ -148,11 +165,7 @@ function matchSegment(name: string, seg: PathSegmentSpec): PartialDateFields | n
     const field = seg.fields[i];
     const v = m[i + 1];
     if (!field || v === undefined) continue;
-    const n = Number(v);
-    if (!Number.isFinite(n)) continue;
-    if (field === "year") out.year = n;
-    else if (field === "year2") out.year = YEAR_2DIGIT_PIVOT + n;
-    else out[field] = n;
+    fillField(out, field, v);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Closes #135.

Tapo Control filenames (`1778741309-1778741415.mp4` — `unix_start-unix_end`) lost their timestamps after the v2.10 datetime-parsing refactor: everything fell into the "Other" group at 00:00 and sorting flipped (a downstream symptom of the zero-time fallback). This PR adds Unix-epoch support to `path_datetime_format` as a uniform extension of the existing token mini-language — no special-cased mode.

Research surfaced that range-style filenames aren't a Tapo quirk; they're a category that also covers Reolink SD-card exports (`cam_YYYYMMDDHHmmss_YYYYMMDDHHmmss.mp4`), Dahua / Amcrest (`HH.mm.ss-HH.mm.ss[M][0@0][0].mp4`), and UniFi Protect's millisecond-epoch `.ubv` files. The fix is two small, orthogonal changes that compose:

1. **Two new tokens**, mirroring the moment.js / dayjs / luxon convention:
   - `X` — 10-digit Unix seconds (Tapo)
   - `x` — 13-digit Unix milliseconds (UniFi Protect)
2. **First-wins on duplicate captures** within a single segment, so `X-X`, `YYYYMMDDHHmmss_YYYYMMDDHHmmss`, and `HH.mm.ss-HH.mm.ss` all pin the canonical timestamp to the start and treat the duplicate token as a structural anchor.

Auto-detect learns the new range shapes and a sanity-window guard (`[2010-01-01, currentYear+1]`) so 10-digit asset-IDs or 13-digit hash prefixes don't auto-detect as epochs.

Side-fix surfaced along the way: the `FILE_EXT_RE` heuristic mistook trailing `.ss` / `.mm` tokens for literal extensions, which anchored the leaf regex and rejected Dahua's trailing `[M][0@0][0]` metadata. Replaced with `hasLiteralExtension` that excludes known token names.

## Test plan

- [x] `npm run check` (typecheck + 681 vitest tests + lint + format + build) all pass
- [x] Manual: in HA, point a card at a folder of Tapo `unix_start-unix_end.mp4` recordings; paste `X-X` into Path datetime format; verify thumbnails show real start times, files group by day, and sort is descending (newest first)
- [x] Manual: clear the field, click **Auto-detect** — `X-X` wins with a near-100% score and appears in the scoreboard
- [x] Manual regression: spot-check a known calendar-token folder (`YYYY/MM/DD/HHmmss`) — no behaviour change
- [x] Manual: Reolink-SD-style filenames (`cam_20240315083000_20240315083127.mp4`) with format `YYYYMMDDHHmmss_YYYYMMDDHHmmss` parse to the start time (first-wins generalises beyond epoch)