### PR TITLE
fix: don't render offline placeholder over grid layout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2205,6 +2205,12 @@ class CameraGalleryCard extends LitElement {
   }
 
   _renderLiveInner() {
+    // Grid mode renders its own tiles into `#live-card-host` imperatively;
+    // the single-camera path (offline placeholder + live picker stage)
+    // doesn't apply there. Without this short-circuit, going single →
+    // grid while the active camera is unavailable leaves the offline
+    // placeholder showing on top of the grid until the next page-render.
+    if (isGridLayout(this.config, this._liveLayoutOverride)) return html``;
     const effectiveCam = this._getEffectiveLiveCamera();
     const isStreamUrl = !!this._getStreamEntryById(effectiveCam);
     if (!isStreamUrl) {


### PR DESCRIPTION
## Summary

- `_renderLiveInner` short-circuits in `isGridLayout(...)` so the
  single-camera offline placeholder never lands in the lit-template
  output when the grid view is active.

## Repro

1. Set `live_layout: grid` with multiple cameras (one of them
   unavailable).
2. Tap an offline grid tile → switches to single-camera mode → the
   `.live-offline` placeholder shows.
3. Return to grid → the placeholder remains on top of the grid tiles
   until the next page-render.

## Fix

The grid mount path (`_mountLiveGrid`) renders its tiles into
`#live-card-host` imperatively; the single-camera template that
includes the offline placeholder doesn't apply there. One-line guard
in the renderer keeps the placeholder template out of the DOM while
the grid is active.

## Test plan

- [x] Single-cam offline → tap tile → grid → placeholder is gone.
- [x] Single-cam offline (no grid configured) → placeholder still
  shows as before.
- [x] Grid → tap online tile → switch back to grid → no regression.