### PR TITLE
fix(thumbs): hide per-thumb star when show_favorite is off

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4302,6 +4302,7 @@ class CameraGalleryCard extends LitElement {
                           ? html`<div class="selOverlay ${isSel ? "on" : ""}"></div>`
                           : html``}
 
+                        ${this.config?.show_favorite === false ? html`` : html`
                         <div
                           class="fav-btn ${this._favorites.has(it.src) ? 'on' : ''}"
                           @click=${(e) => { e.stopPropagation(); this._favorites.toggle(it.src); }}
@@ -4311,6 +4312,7 @@ class CameraGalleryCard extends LitElement {
                         >
                           <ha-icon icon="${this._favorites.has(it.src) ? 'mdi:star' : 'mdi:star-outline'}"></ha-icon>
                         </div>
+                        `}
                       </button>
                     `;
                   })}


### PR DESCRIPTION
## Summary

- `show_favorite: false` already hides the toolbar favourites-filter button, but the per-thumbnail star icon kept rendering on every thumb — visually inconsistent ("filter gone but the toggle is everywhere").
- Same gate now suppresses the per-thumb `.fav-btn` render. Setting `show_favorite: false` removes the entire favourites surface (filter button + per-item stars).
- Default stays `true`, so existing configs see no change.

## Test plan

- [x] `show_favorite: true` (or unset) — stars visible on every thumb, toolbar favourites button visible. No regression.
- [x] `show_favorite: false` — stars gone, toolbar button gone. Consistent.
- [x] Toggle the value in the visual editor → flips both visibilities in real-time.
- [x] Favourites that were marked before disabling are preserved (state persisted; just not editable from the thumb while hidden).