### PR TITLE
feat(favorites): star-pop animation on tap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4447,7 +4447,7 @@ class CameraGalleryCard extends LitElement {
                                 e.currentTarget.animate(
                                   [
                                     { transform: "scale(1) rotate(0deg)",     filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
-                                    { transform: "scale(1.85) rotate(-14deg)", filter: "drop-shadow(0 0 22px gold) drop-shadow(0 0 10px gold) drop-shadow(0 1px 2px rgba(0,0,0,0.6))", offset: 0.45 },
+                                    { transform: "scale(2.2) rotate(-14deg)", filter: "drop-shadow(0 0 22px gold) drop-shadow(0 0 10px gold) drop-shadow(0 1px 2px rgba(0,0,0,0.6))", offset: 0.45 },
                                     { transform: "scale(1) rotate(0deg)",     filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
                                   ],
                                   { duration: 380, easing: "cubic-bezier(.34, 1.56, .64, 1)" }

--- a/src/index.js
+++ b/src/index.js
@@ -4446,11 +4446,11 @@ class CameraGalleryCard extends LitElement {
                               try {
                                 e.currentTarget.animate(
                                   [
-                                    { transform: "scale(1)",   filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
-                                    { transform: "scale(1.4)", filter: "drop-shadow(0 0 12px gold) drop-shadow(0 1px 2px rgba(0,0,0,0.6))", offset: 0.5 },
-                                    { transform: "scale(1)",   filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
+                                    { transform: "scale(1) rotate(0deg)",     filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
+                                    { transform: "scale(1.85) rotate(-14deg)", filter: "drop-shadow(0 0 22px gold) drop-shadow(0 0 10px gold) drop-shadow(0 1px 2px rgba(0,0,0,0.6))", offset: 0.45 },
+                                    { transform: "scale(1) rotate(0deg)",     filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
                                   ],
-                                  { duration: 200, easing: "cubic-bezier(.22, 1, .36, 1)" }
+                                  { duration: 380, easing: "cubic-bezier(.34, 1.56, .64, 1)" }
                                 );
                               } catch (_) { /* WAAPI not supported — silently skip */ }
                             }

--- a/src/index.js
+++ b/src/index.js
@@ -4436,7 +4436,25 @@ class CameraGalleryCard extends LitElement {
                         ${this.config?.show_favorite === false ? html`` : html`
                         <div
                           class="fav-btn ${this._favorites.has(it.src) ? 'on' : ''}"
-                          @click=${(e) => { e.stopPropagation(); this._favorites.toggle(it.src); }}
+                          @click=${(e) => {
+                            e.stopPropagation();
+                            const wasOn = this._favorites.has(it.src);
+                            this._favorites.toggle(it.src);
+                            // Star-pop animation when *adding* a favourite — skip on removal so
+                            // accidental clicks don't get a celebratory burst.
+                            if (!wasOn && !window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+                              try {
+                                e.currentTarget.animate(
+                                  [
+                                    { transform: "scale(1)",   filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
+                                    { transform: "scale(1.4)", filter: "drop-shadow(0 0 12px gold) drop-shadow(0 1px 2px rgba(0,0,0,0.6))", offset: 0.5 },
+                                    { transform: "scale(1)",   filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))" },
+                                  ],
+                                  { duration: 200, easing: "cubic-bezier(.22, 1, .36, 1)" }
+                                );
+                              } catch (_) { /* WAAPI not supported — silently skip */ }
+                            }
+                          }}
                           @pointerdown=${(e) => e.stopPropagation()}
                           role="button"
                           title="Favorite"


### PR DESCRIPTION
## Summary

- Tap a thumb's favorite-star → quick scale-pop with a small wiggle and a soft double glow
- Pure cosmetics — no config knobs, no behaviour change
- Idle star size unchanged; only the animation peak scales up