### PR TITLE
style(card): drop panel padding + border for flush layout

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -127,10 +127,10 @@ export const cardStyles = css`
 
   .panel {
     background: var(--cgc-card-bg, var(--card-background-color, #fff));
-    border: 1px solid var(--cgc-card-border-color, var(--divider-color, rgba(0, 0, 0, 0.12)));
+    border: none;
     border-radius: var(--cgc-card-radius);
     box-sizing: border-box;
-    padding: var(--cardPad, 4px 4px);
+    padding: 0;
     display: flex;
     flex-direction: column;
     gap: var(--cgc-row-gap, 8px);


### PR DESCRIPTION
## Summary
Removes the 4px panel padding and 1px border that visually inset the card's content from its outer ha-card chrome. With both gone the preview + thumbs strip render edge-to-edge inside the host card — matching Advanced Camera Card's full-bleed look.

## Before / after
On mobile especially the side margins felt redundant when ACC right next to it sits flush. The outer ha-card chrome (HA's grid gap + theme border) still applies, so the card doesn't escape its slot; only the inner double-margin goes away.

## ⚠️ Breaking (cosmetic only)
Dashboards that relied on the visible inner border or 4px panel padding will see content shift ~5px. No config / behaviour change. Easy revert in one Edit if it lands badly.

## Test plan
- [x] Card renders edge-to-edge inside its ha-card slot on mobile + desktop
- [x] Live view still scales correctly (no overlap with ha-card border)
- [x] Editor preview still renders correctly
- [x] Fullscreen mode unaffected