### PR TITLE
style(thumbs): instant on-tap — drop fade/scale transition on thumb selection

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1393,10 +1393,7 @@ export const cardStyles = css`
     user-select: none;
     opacity: 0.3;
     transform: scale(0.94);
-    transition:
-      transform 0.1s ease,
-      opacity 0.12s ease,
-      box-shadow 0.14s ease;
+    transition: none;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
## Summary
- De thumb-strip faded en scaled de geselecteerde tile in (~100–120ms). Voelde net even traag aan op snel scrubben/tappen.
- Verandering: `transition: none` op `.thumb` — opacity/scale springen instant naar de `.on` state.
- Geen JS-wijziging, geen impact op andere componenten.

## Test plan
- [x] Tap door thumbs heen — selectie voelt instant
- [x] Swipe-to-delete blijft soepel (gebruikt eigen overlay-transities)
- [x] Niet-geselecteerde thumbs houden `opacity: 0.3` + `scale(0.94)` als visuele cue