### PR TITLE
feat(frigate): optional bounding-box thumbs via snapshot endpoint

### DIFF
--- a/src/config/diff.ts
+++ b/src/config/diff.ts
@@ -21,6 +21,7 @@ const SOURCE_KEYS = new Set<ConfigKey>([
   "delete_service",
   "entities",
   "frigate_url",
+  "frigate_thumb_bbox",
   "max_media",
   "media_sources",
   // path_datetime_format is consumed by every dtMs/dayKey resolution. A

--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -92,6 +92,7 @@ export interface InputConfig {
   // ─── Media source ──────────────────────────────────────────
   media_sources?: string[] | string;
   frigate_url?: string;
+  frigate_thumb_bbox?: boolean;
 
   // ─── Datetime parsing ──────────────────────────────────────
   path_datetime_format?: string;

--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -41,6 +41,7 @@ import {
   DEFAULT_AUTOPLAY,
   DEFAULT_BAR_OPACITY,
   DEFAULT_BAR_POSITION,
+  DEFAULT_FRIGATE_THUMB_BBOX,
   DEFAULT_CONTROLS_MODE,
   DEFAULT_DELETE_CONFIRM,
   DEFAULT_DELETE_SERVICE,
@@ -183,6 +184,7 @@ export const cameraGalleryCardConfigStruct = type({
   // ─── Media source ──────────────────────────────────────────
   media_sources: defaulted(array(string()), []),
   frigate_url: optional(string()),
+  frigate_thumb_bbox: defaulted(boolean(), DEFAULT_FRIGATE_THUMB_BBOX),
 
   // ─── Datetime parsing ──────────────────────────────────────
   // Single format that matches the path tail. `/`-separated segments map

--- a/src/const.ts
+++ b/src/const.ts
@@ -240,6 +240,7 @@ export const DEFAULT_AUTOPLAY = false;
 export const DEFAULT_ASPECT_RATIO = "16:9" satisfies AspectRatio;
 export const DEFAULT_BAR_OPACITY = 30;
 export const DEFAULT_BAR_POSITION = "top" satisfies BarPosition;
+export const DEFAULT_FRIGATE_THUMB_BBOX = false;
 export const DEFAULT_CONTROLS_MODE = "overlay" satisfies ControlsMode;
 export const DEFAULT_BROWSE_TIMEOUT_MS = 10000;
 export const DEFAULT_CLEAN_MODE = false;

--- a/src/data/media-walker.ts
+++ b/src/data/media-walker.ts
@@ -760,8 +760,9 @@ export class MediaSourceClient {
    */
   private async _fetchFrigateWsItems(
     frigateRoots: readonly string[],
-    _config: CameraGalleryCardConfig
+    config: CameraGalleryCardConfig
   ): Promise<MsItem[]> {
+    const useBbox = !!config.frigate_thumb_bbox;
     const hass = this._hass;
     if (!hass) return [];
     const all: MsItem[] = [];
@@ -797,7 +798,9 @@ export class MediaSourceClient {
           title,
           cls: "video",
           mime: "video/mp4",
-          thumb: `/api/frigate/${inst}/notifications/${eventId}/thumbnail.jpg`,
+          thumb: useBbox
+            ? `/api/frigate/${inst}/notifications/${eventId}/snapshot.jpg?bbox=1&height=200`
+            : `/api/frigate/${inst}/notifications/${eventId}/thumbnail.jpg`,
           dtMs,
         });
       }
@@ -878,7 +881,9 @@ export class MediaSourceClient {
 
     const items: MsItem[] = [];
     for (const ev of events) {
-      const mapped = mapFrigateEventToItem(ev, base);
+      const mapped = mapFrigateEventToItem(ev, base, {
+        bbox: !!config.frigate_thumb_bbox,
+      });
       if (!mapped) continue;
       this.state.urlCache.set(mapped.item.id, mapped.clipUrl);
       items.push(mapped.item as MsItem);

--- a/src/util/frigate.ts
+++ b/src/util/frigate.ts
@@ -153,14 +153,23 @@ export async function fetchFrigateEvents(
  * clip URL the caller should register in its url cache. Returns null when
  * the event has no id (defensive — Frigate always supplies one).
  */
-export function mapFrigateEventToItem(ev: FrigateEvent, base: string): MappedFrigateItem | null {
+export function mapFrigateEventToItem(
+  ev: FrigateEvent,
+  base: string,
+  opts?: { bbox?: boolean }
+): MappedFrigateItem | null {
   const id = String(ev?.id || "");
   if (!id) return null;
   const trimmedBase = String(base ?? "")
     .trim()
     .replace(/\/+$/, "");
   const clipUrl = `${trimmedBase}/api/events/${id}/clip.mp4`;
-  const thumbUrl = `${trimmedBase}/api/events/${id}/thumbnail.jpg`;
+  // When `bbox` is enabled, use Frigate's full snapshot endpoint with
+  // bbox=1 and a height cap (server-side resize). The thumbnail endpoint
+  // bakes no bbox even if `snapshots.bounding_box: true` is set in Frigate.
+  const thumbUrl = opts?.bbox
+    ? `${trimmedBase}/api/events/${id}/snapshot.jpg?bbox=1&height=200`
+    : `${trimmedBase}/api/events/${id}/thumbnail.jpg`;
   const startSec = Number(ev.start_time);
   const ts = Number.isFinite(startSec) && startSec > 0 ? Math.round(startSec * 1000) : 0;
   const label = String(ev.label || "");


### PR DESCRIPTION
## Summary
- Nieuwe config-key `frigate_thumb_bbox` (boolean, default `false`).
- Wanneer `true`, gebruikt CGC Frigate's snapshot endpoint met bbox-overlay in plaats van de plain thumbnail. Werkt voor allebei de Frigate paden:
  - REST direct via `frigate_url` → `/api/events/<id>/snapshot.jpg?bbox=1&height=200`
  - HA-proxied media-source → `/api/frigate/<inst>/notifications/<id>/snapshot.jpg?bbox=1&height=200`
- `frigate_thumb_bbox` zit in `SOURCE_KEYS` zodat een toggle direct een refetch triggert en bestaande items meteen omschakelen.
- YAML-only voor nu — editor-toggle landt mee met #156 (feat/editor-v2).

Vereist Frigate camera config met `snapshots.bounding_box: true`. Server-side resize via `height=200` houdt de payload klein.

## Test plan
- [x] Zonder de key: thumbs blijven `/thumbnail.jpg` (geen bbox, geen regressie)
- [x] `frigate_thumb_bbox: true` in YAML: thumbs hebben bbox-overlay
- [x] Toggle aan ↔ uit triggert refetch (alle items wisselen, niet alleen nieuwe)
- [x] REST-pad (`frigate_url` gezet) en media-source-pad allebei testen