### PR TITLE
fix(editor): restore missing </style> closing tag — empty editor on v3.0.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10858,7 +10858,7 @@ details summary { user-select: none; }
           display: flex; align-items: flex-start; gap: 6px;
         }
         .cgc-inline-warn .cgc-svg-icon { flex-shrink: 0; margin-top: 1px; }
-
+      </style>
 
       <div class="wrap v2" style="${rootVars}">
 


### PR DESCRIPTION
## Critical regression — v3.0.0 ships with empty editor

The editor's \`<style>\` block in \`src/index.js\` (line 8946) is opened but never closed. As a result every browser parses the remainder of the editor template — the entire \`.wrap.v2\` div with the six tabs — as CSS, then silently discards it. The card-editor dialog opens with a blank Configuratie tab on every fresh install.

### Reproduction
1. Update CGC to v3.0.0 via HACS (or fresh install)
2. Open any dashboard → Edit dashboard → CGC card → Edit
3. Configuration tab is empty; only the HA chrome (tabs Configuratie/Zichtbaarheid/Indeling) is visible

100% reproducible on every install. Sessions with a still-cached pre-v3 bundle stay functional until first hard refresh.

### Root cause
The closing \`</style>\` tag was lost somewhere in \`feat/editor-v2\`'s history before the #156 squash. Verified via \`git show 9af6526:src/index.js | grep -c '</style>'\` → 0.

### Fix
One-line addition of \`</style>\` after the last CSS rule (\`.cgc-inline-warn .cgc-svg-icon\`), just before the \`<div class="wrap v2">\` opens.

### Verification
- Local diff: 1 file, 1 insertion, 1 deletion
- Bundle builds clean
- Editor renders correctly with all six tabs after deploy

Closes #155 once shipped as v3.0.1.