### PR TITLE
feat: allow live-only configuration without a source

### DIFF
--- a/src/config/normalize.spec.ts
+++ b/src/config/normalize.spec.ts
@@ -289,6 +289,49 @@ describe("Cross-field rules", () => {
   });
 });
 
+describe("Live-only mode (issue #169)", () => {
+  it("live_enabled + live_cameras and no source is accepted", () => {
+    const { config } = normalizeConfig({
+      live_enabled: true,
+      live_cameras: [{ entity: "camera.frontdoor" }],
+    });
+    expect(config.live_enabled).toBe(true);
+    expect(config.entities).toEqual([]);
+    expect(config.media_sources).toEqual([]);
+  });
+
+  it("live_enabled + legacy live_camera_entities and no source is accepted", () => {
+    const { config } = normalizeConfig({
+      live_enabled: true,
+      live_camera_entities: ["camera.frontdoor"],
+    });
+    expect(config.live_enabled).toBe(true);
+    // Legacy key is migrated into the canonical live_cameras array.
+    expect(config.live_cameras?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("live-only mode does not require path_datetime_format", () => {
+    expect(() =>
+      normalizeConfig({
+        live_enabled: true,
+        live_cameras: [{ entity: "camera.frontdoor" }],
+      })
+    ).not.toThrow();
+  });
+
+  it("live_enabled without any live camera still throws (no kiosk fallback)", () => {
+    expect(() => normalizeConfig({ live_enabled: true })).toThrow(/required/);
+  });
+
+  it("live_enabled with a stream URL and no source is accepted", () => {
+    const { config } = normalizeConfig({
+      live_enabled: true,
+      live_stream_urls: [{ url: "rtsp://example/cam", name: "Cam" }],
+    });
+    expect(config.live_enabled).toBe(true);
+  });
+});
+
 describe("Delete gating", () => {
   it("media mode clears delete_service and forces bulk OFF", () => {
     const { config } = normalizeConfig({

--- a/src/config/normalize.ts
+++ b/src/config/normalize.ts
@@ -27,6 +27,7 @@ import { create, StructError } from "superstruct";
 import type { Infer } from "superstruct";
 
 import { KNOWN_FILTERS } from "../data/object-filters";
+import { getStreamEntries } from "../data/live-config";
 import { FRIGATE_URI_PREFIX, hasFrigateConfig } from "../util/frigate";
 import { cameraGalleryCardConfigStruct, type CameraGalleryCardConfigStruct } from "./structs";
 
@@ -795,10 +796,37 @@ function applyDeleteGating(config: CameraGalleryCardConfig): CameraGalleryCardCo
 }
 
 /**
+ * True when `live_enabled` is on and at least one live camera or stream is
+ * wired up, with no sensor/media source configured. Used by
+ * `assertRequiredFields` to allow a kiosk-style live-only card without
+ * tripping the per-source-mode required-field checks (issue #169).
+ *
+ * Inline `live_cameras` check rather than calling `getAllLiveCameraEntities`,
+ * which needs hass state that normalize doesn't have.
+ */
+function isLiveOnlyConfig(config: CameraGalleryCardConfig): boolean {
+  if (config.live_enabled !== true) return false;
+  if (config.entities.length > 0) return false;
+  if (config.media_sources.length > 0) return false;
+  if (getStreamEntries(config).length > 0) return true;
+  const liveCams = Array.isArray(config.live_cameras) ? config.live_cameras : [];
+  return liveCams.some((c) => {
+    if (!c || typeof c !== "object") return false;
+    const entity = typeof c.entity === "string" ? c.entity.trim() : "";
+    const url = typeof c.url === "string" ? c.url.trim() : "";
+    return entity.length > 0 || url.length > 0;
+  });
+}
+
+/**
  * Mode-specific required-field checks. Throws a descriptive Error so the
  * card error overlay surfaces the user's mistake.
  */
 function assertRequiredFields(config: CameraGalleryCardConfig): void {
+  // Live-only kiosk configs (issue #169) skip both the per-source-mode
+  // checks and the path_datetime_format requirement — nothing to group.
+  if (isLiveOnlyConfig(config)) return;
+
   const { source_mode, entities, media_sources } = config;
 
   if (source_mode === "sensor" && !entities.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -5068,7 +5068,14 @@ class CameraGalleryCard extends LitElement {
     const rawItems = base.rawItems;
     const visibleObjectFilters = this._getVisibleObjectFilters();
 
-    if (!rawItems.length) {
+    // Live-only mode (issue #169): no gallery items but a live camera is
+    // configured. We fall through to the normal render so the live view
+    // stays visible — the downstream paths all guard on `filtered.length`
+    // and the live pipeline is independent of `rawItems`. Used again below
+    // to suppress the now-empty toolbar / thumbs strip / filter chips.
+    const liveOnlyView = !rawItems.length && this._hasLiveConfig();
+
+    if (!rawItems.length && !liveOnlyView) {
       if (usingMediaSource && this._mediaClient.isLoading()) {
         return html`<div class="empty">Loading media…</div>`;
       }
@@ -5167,10 +5174,12 @@ class CameraGalleryCard extends LitElement {
     const useDatePicker = showTypeFilter && navigator.maxTouchPoints > 0;
     const isVerticalThumbs = this._isThumbLayoutVertical();
 
-    // DIT IS DE BELANGRIJKE LOGICA: 
-    // showGalleryControls is TRUE als we de gallery/navigatie MOETEN zien.
-    // showGalleryControls is FALSE als click_to_open aan staat én de preview open is, of als live actief is.
-    const showGalleryControls = !this.config?.clean_mode || (!this._previewOpen && !isLive);
+    // Gallery chrome (top toolbar, filter chips, thumbs strip) renders when
+    // it's actually useful:
+    //   - clean_mode + preview/live open → user wants minimal UI
+    //   - live-only view (issue #169)    → no items at all, nothing to do
+    // The live overlay pills sit inside `#live-card-host` and stay either way.
+    const showGalleryControls = !liveOnlyView && (!this.config?.clean_mode || (!this._previewOpen && !isLive));
 
     const rootVars = `
       --cgc-card-radius:10px;


### PR DESCRIPTION
Closes #169.

A wall-kiosk that only needs the live view shouldn't have to fake a sensor
or media-source. After this change, `live_enabled: true` plus at least one
configured camera or stream is a valid card on its own.

### What changed
- Config validation skips the per-source-mode required-field checks
  (and `path_datetime_format`) for live-only configs.
- The "No media found" early return is bypassed when a live camera is
  configured — the live view stays available.
- In that state the gallery toolbar, filter chips and thumbs strip are
  hidden (nothing to do without items).

Pre-existing configs with a sensor or media-source are untouched.

### Test config
```yaml
type: custom:camera-gallery-card
live_enabled: true
live_cameras:
  - entity: camera.frontdoor
start_mode: live
```

### Erik
@ErikBavenstrand mind giving this a spin on your end? Curious if it holds
up with your camera setup.