### PR TITLE
feat(live): snapshot pill — capture current frame as JPG

### DIFF
--- a/src/data/pill-catalog.ts
+++ b/src/data/pill-catalog.ts
@@ -81,6 +81,7 @@ export const LIVE_PILL_CATALOG: readonly PillCatalogEntry[] = [
     icon: "mdi:picture-in-picture-bottom-right",
   },
   { id: "fullscreen", label: "Fullscreen", defaultOrder: 30, icon: "mdi:fullscreen" },
+  { id: "snapshot", label: "Snapshot", defaultOrder: 35, icon: "mdi:camera" },
   { id: "refresh", label: "Refresh stream", defaultOrder: 40, icon: "mdi:refresh" },
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -2232,7 +2232,7 @@ class CameraGalleryCard extends LitElement {
   _captureLiveSnapshot() {
     const video = this._findLiveVideo();
     if (!video || !video.videoWidth || !video.videoHeight) {
-      console.warn("[CGC] snapshot: live video element not ready");
+      this._showSnapshotToast({ kind: "error", text: "Camera not ready" });
       return;
     }
     try {
@@ -2240,25 +2240,91 @@ class CameraGalleryCard extends LitElement {
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
       const ctx = canvas.getContext("2d");
-      if (!ctx) return;
+      if (!ctx) {
+        this._showSnapshotToast({ kind: "error", text: "Snapshot failed (no canvas)" });
+        return;
+      }
       ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
       const cam = this._getEffectiveLiveCamera?.() || "camera";
       const safeName = String(cam).replace(/[^a-z0-9_.-]/gi, "_");
       const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      const filename = `${safeName}_${ts}.jpg`;
       canvas.toBlob((blob) => {
-        if (!blob) return;
+        if (!blob) {
+          // toBlob returns null in two cases worth distinguishing:
+          //   1. canvas was tainted by a cross-origin video — most common
+          //      with go2rtc hosted outside HA's origin.
+          //   2. canvas was simply empty — caught above as "camera not ready".
+          // We can't tell which without a separate getImageData probe, so
+          // surface a generic security message + offer the same blob via
+          // an in-tab fallback (toDataURL works on tainted canvas in some
+          // browsers, but breaks in others — try it).
+          this._showSnapshotToast({
+            kind: "error",
+            text: "Snapshot blocked (cross-origin stream)",
+          });
+          return;
+        }
         const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${safeName}_${ts}.jpg`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        setTimeout(() => URL.revokeObjectURL(url), 2000);
+        try {
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = filename;
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          // No success toast — the download itself is the feedback.
+          setTimeout(() => URL.revokeObjectURL(url), 2000);
+        } catch (err) {
+          console.warn("[CGC] snapshot download failed:", err);
+          this._showSnapshotToast({
+            kind: "error",
+            text: "Download blocked — tap to open",
+            href: url,
+          });
+          // Keep the URL alive until the fallback toast hides.
+          setTimeout(() => URL.revokeObjectURL(url), 6000);
+        }
       }, "image/jpeg", 0.92);
     } catch (err) {
+      // SecurityError fires synchronously on tainted-canvas drawImage in
+      // some engines (Safari). Other engines defer to toBlob's null path.
+      const isSecurity = err && (err.name === "SecurityError" || /tainted|cross-origin/i.test(String(err.message || "")));
+      this._showSnapshotToast({
+        kind: "error",
+        text: isSecurity ? "Snapshot blocked (cross-origin stream)" : "Snapshot failed",
+      });
       console.warn("[CGC] snapshot failed:", err);
     }
+  }
+
+  /**
+   * Tiny in-card toast for snapshot feedback. Renders a chip near the
+   * top of the card that auto-hides after a couple of seconds. Reusable
+   * shape — `kind` drives the colour, `href` makes the toast tappable
+   * (used for the "open in tab" fallback when the download was blocked).
+   */
+  _showSnapshotToast(msg) {
+    this._snapshotToast = msg;
+    this.requestUpdate();
+    if (this._snapshotToastTimer) clearTimeout(this._snapshotToastTimer);
+    this._snapshotToastTimer = setTimeout(() => {
+      this._snapshotToast = null;
+      this.requestUpdate();
+    }, msg.kind === "ok" ? 2200 : 4500);
+  }
+
+  _renderSnapshotToast() {
+    const t = this._snapshotToast;
+    if (!t) return html``;
+    const body = html`<span class="snapshot-toast-text">${t.text}</span>`;
+    return html`
+      <div class="snapshot-toast snapshot-toast--${t.kind}" role="status" aria-live="polite">
+        ${t.href
+          ? html`<a class="snapshot-toast-link" href=${t.href} target="_blank" rel="noopener">${body}</a>`
+          : body}
+      </div>
+    `;
   }
 
   _openImageFullscreen() {
@@ -5417,7 +5483,7 @@ class CameraGalleryCard extends LitElement {
                   : selectedIsVideo
                     ? html`<div id="preview-video-host" class="preview-video-host"></div>`
                     : html`<img class="pimg" src=${selectedUrl} alt="" />`}
-            ${this._hasLiveConfig() ? html`<div id="live-card-host" class="live-card-host${isLive ? '' : ' live-host-hidden'}"></div>` : html``}
+            ${this._hasLiveConfig() ? html`<div id="live-card-host" class="live-card-host${isLive ? '' : ' live-host-hidden'}"></div>${this._renderSnapshotToast()}` : html``}
 
             ${!noResultsForFilter && !isLive && filtered.length > 1 && (this._pillsVisible || this.config?.persistent_controls) ? html`
               <div class="pnav">

--- a/src/index.js
+++ b/src/index.js
@@ -824,6 +824,7 @@ class CameraGalleryCard extends LitElement {
     if (this._bulkHintTimer) clearTimeout(this._bulkHintTimer);
     if (this._scrollPillTimer) { clearTimeout(this._scrollPillTimer); this._scrollPillTimer = null; }
     this._scrollPillVisible = false;
+    if (this._snapshotToastTimer) { clearTimeout(this._snapshotToastTimer); this._snapshotToastTimer = null; }
     // Tear down the PTZ press-and-hold loop — if the card is removed mid-
     // press (camera card replaced, dashboard navigated away), the interval
     // would otherwise outlive the element and (for continuous types) leave
@@ -2232,16 +2233,20 @@ class CameraGalleryCard extends LitElement {
   _captureLiveSnapshot() {
     const video = this._findLiveVideo();
     if (!video || !video.videoWidth || !video.videoHeight) {
-      this._showSnapshotToast({ kind: "error", text: "Camera not ready" });
+      this._showSnapshotToast("Camera not ready");
       return;
     }
+    // Shared error string — re-used by the sync drawImage catch and the
+    // async toBlob === null path, both of which indicate the same root
+    // cause (canvas tainted by a cross-origin stream).
+    const TAINT_MSG = "Snapshot blocked (cross-origin stream)";
     try {
       const canvas = document.createElement("canvas");
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
       const ctx = canvas.getContext("2d");
       if (!ctx) {
-        this._showSnapshotToast({ kind: "error", text: "Snapshot failed (no canvas)" });
+        this._showSnapshotToast("Snapshot failed (no canvas)");
         return;
       }
       ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
@@ -2250,19 +2255,12 @@ class CameraGalleryCard extends LitElement {
       const ts = new Date().toISOString().replace(/[:.]/g, "-");
       const filename = `${safeName}_${ts}.jpg`;
       canvas.toBlob((blob) => {
+        // toBlob returns null when the canvas is tainted by a
+        // cross-origin video. The empty-frame case is caught earlier
+        // via the videoWidth check, so a null here is effectively
+        // always a taint.
         if (!blob) {
-          // toBlob returns null in two cases worth distinguishing:
-          //   1. canvas was tainted by a cross-origin video — most common
-          //      with go2rtc hosted outside HA's origin.
-          //   2. canvas was simply empty — caught above as "camera not ready".
-          // We can't tell which without a separate getImageData probe, so
-          // surface a generic security message + offer the same blob via
-          // an in-tab fallback (toDataURL works on tainted canvas in some
-          // browsers, but breaks in others — try it).
-          this._showSnapshotToast({
-            kind: "error",
-            text: "Snapshot blocked (cross-origin stream)",
-          });
+          this._showSnapshotToast(TAINT_MSG);
           return;
         }
         const url = URL.createObjectURL(blob);
@@ -2277,11 +2275,7 @@ class CameraGalleryCard extends LitElement {
           setTimeout(() => URL.revokeObjectURL(url), 2000);
         } catch (err) {
           console.warn("[CGC] snapshot download failed:", err);
-          this._showSnapshotToast({
-            kind: "error",
-            text: "Download blocked — tap to open",
-            href: url,
-          });
+          this._showSnapshotToast("Download blocked — tap to open", url);
           // Keep the URL alive until the fallback toast hides.
           setTimeout(() => URL.revokeObjectURL(url), 6000);
         }
@@ -2290,28 +2284,27 @@ class CameraGalleryCard extends LitElement {
       // SecurityError fires synchronously on tainted-canvas drawImage in
       // some engines (Safari). Other engines defer to toBlob's null path.
       const isSecurity = err && (err.name === "SecurityError" || /tainted|cross-origin/i.test(String(err.message || "")));
-      this._showSnapshotToast({
-        kind: "error",
-        text: isSecurity ? "Snapshot blocked (cross-origin stream)" : "Snapshot failed",
-      });
+      this._showSnapshotToast(isSecurity ? TAINT_MSG : "Snapshot failed");
       console.warn("[CGC] snapshot failed:", err);
     }
   }
 
   /**
-   * Tiny in-card toast for snapshot feedback. Renders a chip near the
-   * top of the card that auto-hides after a couple of seconds. Reusable
-   * shape — `kind` drives the colour, `href` makes the toast tappable
-   * (used for the "open in tab" fallback when the download was blocked).
+   * In-card error toast for snapshot failures. Auto-hides after 4.5s.
+   * The optional `href` argument makes the toast tappable — used for
+   * the "open in tab" fallback when the browser refused the programmatic
+   * download. Success cases never call this — the OS download is its
+   * own feedback.
    */
-  _showSnapshotToast(msg) {
-    this._snapshotToast = msg;
+  _showSnapshotToast(text, href) {
+    this._snapshotToast = href ? { text, href } : { text };
     this.requestUpdate();
     if (this._snapshotToastTimer) clearTimeout(this._snapshotToastTimer);
     this._snapshotToastTimer = setTimeout(() => {
       this._snapshotToast = null;
+      this._snapshotToastTimer = null;
       this.requestUpdate();
-    }, msg.kind === "ok" ? 2200 : 4500);
+    }, 4500);
   }
 
   _renderSnapshotToast() {
@@ -2319,7 +2312,7 @@ class CameraGalleryCard extends LitElement {
     if (!t) return html``;
     const body = html`<span class="snapshot-toast-text">${t.text}</span>`;
     return html`
-      <div class="snapshot-toast snapshot-toast--${t.kind}" role="status" aria-live="polite">
+      <div class="snapshot-toast snapshot-toast--error" role="status" aria-live="polite">
         ${t.href
           ? html`<a class="snapshot-toast-link" href=${t.href} target="_blank" rel="noopener">${body}</a>`
           : body}

--- a/src/index.js
+++ b/src/index.js
@@ -2217,6 +2217,50 @@ class CameraGalleryCard extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * Capture the current live frame and trigger a download. Draws the
+   * `<video>` element onto an off-screen canvas at its native resolution
+   * and exports a JPG. Filename includes the camera entity + ISO
+   * timestamp so multiple snapshots stay distinct.
+   *
+   * Works through whatever transform the live host has applied (e.g. a
+   * crop transform), because canvas's drawImage(video) samples the
+   * decoded frame bytes — not the rendered DOM. So a cropped live view
+   * still produces a snapshot of the full source frame. If the user
+   * wants the *cropped* image, they should use the OS-level screenshot.
+   */
+  _captureLiveSnapshot() {
+    const video = this._findLiveVideo();
+    if (!video || !video.videoWidth || !video.videoHeight) {
+      console.warn("[CGC] snapshot: live video element not ready");
+      return;
+    }
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const cam = this._getEffectiveLiveCamera?.() || "camera";
+      const safeName = String(cam).replace(/[^a-z0-9_.-]/gi, "_");
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      canvas.toBlob((blob) => {
+        if (!blob) return;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${safeName}_${ts}.jpg`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(url), 2000);
+      }, "image/jpeg", 0.92);
+    } catch (err) {
+      console.warn("[CGC] snapshot failed:", err);
+    }
+  }
+
   _openImageFullscreen() {
     this._imgFsOpen = true;
     try { this._previewVideoEl?.pause(); } catch (_) {}
@@ -3285,6 +3329,11 @@ class CameraGalleryCard extends LitElement {
       case "fullscreen":
         return html`<button class="gallery-pill live-pill-btn" @pointerdown=${(e) => e.stopPropagation()} @click=${(e) => { e.stopPropagation(); this._toggleLiveFullscreen(); }}>
           <ha-icon icon=${document.fullscreenElement || document.webkitFullscreenElement || this._liveFullscreen ? "mdi:fullscreen-exit" : "mdi:fullscreen"}></ha-icon>
+        </button>`;
+
+      case "snapshot":
+        return html`<button class="gallery-pill live-pill-btn" title="Snapshot" @pointerdown=${(e) => e.stopPropagation()} @click=${(e) => { e.stopPropagation(); this._captureLiveSnapshot(); }}>
+          <ha-icon icon="mdi:camera"></ha-icon>
         </button>`;
 
       case "refresh":

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -281,17 +281,18 @@ export const cardStyles = css`
     display: none !important;
   }
 
-  /* Snapshot feedback toast — sits at the top of the preview, fades in
-   * on capture, auto-hides after a couple of seconds. Tappable variant
-   * (anchor wrapped) for the "open in tab" fallback when download is
-   * blocked by the browser. */
+  /* Snapshot error toast — fades in at the top of the preview, auto-
+   * hides after 4.5s. Success cases never render a toast: the browser
+   * download is its own feedback. The tappable variant wraps the text
+   * in an <a> for the "open in tab" fallback when the download was
+   * refused by the browser. */
   .snapshot-toast {
     position: absolute;
     top: 12px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 6;
-    background: rgba(0, 0, 0, 0.72);
+    background: rgba(180, 40, 40, 0.85);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
     color: #fff;
@@ -304,9 +305,6 @@ export const cardStyles = css`
     animation: snapshotToastIn 0.18s ease;
     max-width: 90%;
     text-align: center;
-  }
-  .snapshot-toast--error {
-    background: rgba(180, 40, 40, 0.85);
   }
   .snapshot-toast-link {
     color: inherit;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -281,6 +281,49 @@ export const cardStyles = css`
     display: none !important;
   }
 
+  /* Snapshot feedback toast — sits at the top of the preview, fades in
+   * on capture, auto-hides after a couple of seconds. Tappable variant
+   * (anchor wrapped) for the "open in tab" fallback when download is
+   * blocked by the browser. */
+  .snapshot-toast {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 6;
+    background: rgba(0, 0, 0, 0.72);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 500;
+    padding: 7px 14px;
+    border-radius: 14px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    pointer-events: none;
+    animation: snapshotToastIn 0.18s ease;
+    max-width: 90%;
+    text-align: center;
+  }
+  .snapshot-toast--error {
+    background: rgba(180, 40, 40, 0.85);
+  }
+  .snapshot-toast-link {
+    color: inherit;
+    text-decoration: underline;
+    pointer-events: auto;
+  }
+  @keyframes snapshotToastIn {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -8px);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+  }
+
   .live-grid-tile {
     position: relative;
     background: #000;


### PR DESCRIPTION
Adds a Snapshot pill to the live overlay. Click captures the current `<video>` frame to a canvas and downloads it as `<camera>_<timestamp>.jpg`. Error toast surfaces tainted-canvas / blocked-download cases; success is silent (the OS download is its own feedback).

Pill lives in the editable LIVE_PILL_CATALOG so users can re-order or disable it like the other live pills.