### PR TITLE
feat(controls): toggles to hide live + gallery chevrons

### DIFF
--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -361,6 +361,13 @@ export const cameraGalleryCardConfigStruct = type({
   // ─── Live preview ──────────────────────────────────────────
   live_enabled: defaulted(boolean(), DEFAULT_LIVE_ENABLED),
   live_auto_muted: defaulted(boolean(), DEFAULT_LIVE_AUTO_MUTED),
+  // Show the left/right chevron arrows that switch cameras when ≥2 are
+  // configured. Defaults to on. Disable for a clean kiosk look.
+  live_chevrons_enabled: defaulted(boolean(), true),
+  // Gallery preview navigation chevrons — left/right arrows that walk
+  // through the filtered clip list while the preview is open. Same
+  // default-on / kiosk-off pattern as the live chevrons.
+  gallery_chevrons_enabled: defaulted(boolean(), true),
   // Unified camera list (issue #137). When non-empty, this is the
   // canonical source of truth; the legacy keys below are populated by the
   // pre-migrate step from `live_cameras` (or vice-versa for old configs)

--- a/src/index.js
+++ b/src/index.js
@@ -5478,7 +5478,7 @@ class CameraGalleryCard extends LitElement {
                     : html`<img class="pimg" src=${selectedUrl} alt="" />`}
             ${this._hasLiveConfig() ? html`<div id="live-card-host" class="live-card-host${isLive ? '' : ' live-host-hidden'}"></div>${this._renderSnapshotToast()}` : html``}
 
-            ${!noResultsForFilter && !isLive && filtered.length > 1 && (this._pillsVisible || this.config?.persistent_controls) ? html`
+            ${!noResultsForFilter && !isLive && this.config?.gallery_chevrons_enabled !== false && filtered.length > 1 && (this._pillsVisible || this.config?.persistent_controls) ? html`
               <div class="pnav">
                 <button class="pnavbtn left" ?disabled=${idx <= 0} @click=${(e) => { e.stopPropagation(); this._navPrev(); }}>
                   <ha-icon icon="mdi:chevron-left"></ha-icon>
@@ -5489,7 +5489,7 @@ class CameraGalleryCard extends LitElement {
               </div>
             ` : html``}
 
-            ${isLive && !isGridLayout(this.config, this._liveLayoutOverride) && this._getLiveCameraOptions().length > 1 && (this._pillsVisible || this.config?.persistent_controls) ? html`
+            ${isLive && this.config?.live_chevrons_enabled !== false && !isGridLayout(this.config, this._liveLayoutOverride) && this._getLiveCameraOptions().length > 1 && (this._pillsVisible || this.config?.persistent_controls) ? html`
               <div class="pnav">
                 <button class="pnavbtn left" @pointerdown=${(e) => e.stopPropagation()} @click=${(e) => { e.stopPropagation(); this._navLiveCamera(-1); }}>
                   <ha-icon icon="mdi:chevron-left"></ha-icon>
@@ -8195,6 +8195,17 @@ class CameraGalleryCardEditor extends HTMLElement {
             : "";
       const pillsBody = `
         <div class="row">
+          <div class="row-head">
+            <div>
+              <div class="lbl">Show chevrons</div>
+              <div class="desc">Left/right arrows over the preview to walk through the filtered clip list. Auto-hidden when there's only one clip.</div>
+            </div>
+            <div class="togrow">
+              <label class="cgc-switch"><input type="checkbox" id="gallerychevrons" ${c.gallery_chevrons_enabled !== false ? "checked" : ""}><span class="cgc-track"></span></label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
           <div class="lbl">Mode</div>
           <div class="desc"><code>Overlay</code> floats pills over the preview; <code>Fixed</code> reserves a strip and stretches them across.</div>
           <div class="segwrap" style="margin-top:6px;">
@@ -8685,6 +8696,17 @@ class CameraGalleryCardEditor extends HTMLElement {
           );
         });
       const liveControlsBody = `
+        <div class="row">
+          <div class="row-head">
+            <div>
+              <div class="lbl">Show chevrons</div>
+              <div class="desc">Left/right arrows over the live view to flip between cameras. Auto-hidden if only one camera is configured.</div>
+            </div>
+            <div class="togrow">
+              <label class="cgc-switch"><input type="checkbox" id="livechevrons" ${c.live_chevrons_enabled !== false ? "checked" : ""}><span class="cgc-track"></span></label>
+            </div>
+          </div>
+        </div>
         <div class="row">
           <div class="desc">Camera name sits on the left, action pills on the right — layout is fixed. Drag <code>⠿</code> to reorder the action pills, switch one off to hide it.</div>
         </div>
@@ -11537,6 +11559,16 @@ details summary { user-select: none; }
       this._config = this._stripAlwaysTrueKeys(next);
       this._fire();
       this._scheduleRender();
+    });
+
+    $("livechevrons")?.addEventListener("change", (e) => {
+      // Default true at the struct level → drop the key when on, write
+      // false when off. Keeps YAML minimal.
+      this._set("live_chevrons_enabled", e.target.checked ? undefined : false);
+    });
+
+    $("gallerychevrons")?.addEventListener("change", (e) => {
+      this._set("gallery_chevrons_enabled", e.target.checked ? undefined : false);
     });
 
     // Toolbar buttons — switches map to the underlying show_* keys (BC),

--- a/src/index.js
+++ b/src/index.js
@@ -8098,6 +8098,26 @@ class CameraGalleryCardEditor extends HTMLElement {
       `;
     };
 
+    /**
+     * Toggle-row helper for the "Show chevrons" config flag in both
+     * Gallery and Live tabs. Same shape (row + row-head + label + desc
+     * + switch), only the id, label, and description differ — extracted
+     * so the two callers stay in sync if the row chrome ever changes.
+     */
+    const chevronToggleRow = (id, desc, checked) => `
+      <div class="row">
+        <div class="row-head">
+          <div>
+            <div class="lbl">Show chevrons</div>
+            <div class="desc">${desc}</div>
+          </div>
+          <div class="togrow">
+            <label class="cgc-switch"><input type="checkbox" id="${id}" ${checked ? "checked" : ""}><span class="cgc-track"></span></label>
+          </div>
+        </div>
+      </div>
+    `;
+
     const buildGalleryTabV2 = () => {
       const displayBody = `
         <div class="row">
@@ -8194,17 +8214,11 @@ class CameraGalleryCardEditor extends HTMLElement {
             ? " <em>Ignored in fixed mode</em> — pills always fill the bar."
             : "";
       const pillsBody = `
-        <div class="row">
-          <div class="row-head">
-            <div>
-              <div class="lbl">Show chevrons</div>
-              <div class="desc">Left/right arrows over the preview to walk through the filtered clip list. Auto-hidden when there's only one clip.</div>
-            </div>
-            <div class="togrow">
-              <label class="cgc-switch"><input type="checkbox" id="gallerychevrons" ${c.gallery_chevrons_enabled !== false ? "checked" : ""}><span class="cgc-track"></span></label>
-            </div>
-          </div>
-        </div>
+        ${chevronToggleRow(
+          "gallerychevrons",
+          "Left/right arrows over the preview to walk through the filtered clip list. Auto-hidden when there's only one clip.",
+          c.gallery_chevrons_enabled !== false,
+        )}
         <div class="row">
           <div class="lbl">Mode</div>
           <div class="desc"><code>Overlay</code> floats pills over the preview; <code>Fixed</code> reserves a strip and stretches them across.</div>
@@ -8696,17 +8710,11 @@ class CameraGalleryCardEditor extends HTMLElement {
           );
         });
       const liveControlsBody = `
-        <div class="row">
-          <div class="row-head">
-            <div>
-              <div class="lbl">Show chevrons</div>
-              <div class="desc">Left/right arrows over the live view to flip between cameras. Auto-hidden if only one camera is configured.</div>
-            </div>
-            <div class="togrow">
-              <label class="cgc-switch"><input type="checkbox" id="livechevrons" ${c.live_chevrons_enabled !== false ? "checked" : ""}><span class="cgc-track"></span></label>
-            </div>
-          </div>
-        </div>
+        ${chevronToggleRow(
+          "livechevrons",
+          "Left/right arrows over the live view to flip between cameras. Auto-hidden if only one camera is configured.",
+          c.live_chevrons_enabled !== false,
+        )}
         <div class="row">
           <div class="desc">Camera name sits on the left, action pills on the right — layout is fixed. Drag <code>⠿</code> to reorder the action pills, switch one off to hide it.</div>
         </div>


### PR DESCRIPTION
Two new boolean config knobs:

- \`live_chevrons_enabled\` (default true) — left/right arrows over the live view (camera switch).
- \`gallery_chevrons_enabled\` (default true) — left/right arrows over the gallery preview (prev/next clip).

Set either to \`false\` for a cleaner kiosk look. Editor exposes both as switches under the respective Controls collapsible. Default-on stays out of the YAML; only the explicit \`false\` is persisted.