### PR TITLE
feat(ptz): manual-first per-button entity config + dispatcher fixes

### DIFF
--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -255,6 +255,27 @@ const ptzActions = object({
 });
 
 /**
+ * Per-camera manual button map (the "manual-first" path). Each value is the
+ * full entity id the dispatcher should drive for that action — a `button.*`
+ * for pan/zoom/stop, a `select.*_ptz_preset` for home. Set by the editor's
+ * per-button pickers; an empty/absent key falls back to auto-derivation.
+ *
+ * This is the simple cousin of `actions`: `buttons` is "press this entity",
+ * `actions` is "call this arbitrary service". `actions` still wins when both
+ * are set for the same key.
+ */
+const ptzButtons = object({
+  up: optional(string()),
+  down: optional(string()),
+  left: optional(string()),
+  right: optional(string()),
+  zoom_in: optional(string()),
+  zoom_out: optional(string()),
+  stop: optional(string()),
+  home: optional(string()),
+});
+
+/**
  * Per-camera PTZ config. `type` selects the command dispatcher.
  * `speed` is optional: when absent the dispatcher falls back to the
  * global `live_ptz_speed`. Range is clamped to [1, 9] (the EZVIZ
@@ -283,6 +304,7 @@ const ptzCamera = type({
   button_prefix: optional(string()),
   speed: optional(intInRange(PTZ_SPEED_MIN, PTZ_SPEED_MAX)),
   actions: optional(ptzActions),
+  buttons: optional(ptzButtons),
 });
 
 /** Menu button entry — same strictness rationale as `liveStreamUrlEntry`. */

--- a/src/config/styling-config.spec.ts
+++ b/src/config/styling-config.spec.ts
@@ -163,13 +163,3 @@ describe("genStyleSectionDefaults", () => {
     }
   });
 });
-
-describe("SelectControl.disabledFn", () => {
-  it("bar_position select is gated on controls_mode === 'fixed'", () => {
-    const c = selects().find((s) => s.configKey === "bar_position");
-    expect(c?.disabledFn).toBeDefined();
-    expect(c?.disabledFn?.({ controls_mode: "fixed" })).toBe(true);
-    expect(c?.disabledFn?.({ controls_mode: "overlay" })).toBe(false);
-    expect(c?.disabledFn?.({})).toBe(false);
-  });
-});

--- a/src/data/ptz-scenarios.spec.ts
+++ b/src/data/ptz-scenarios.spec.ts
@@ -1,0 +1,739 @@
+/**
+ * PTZ resolution "scenario lab".
+ *
+ * Exercises the REAL dispatcher (`dispatchPan` / `dispatchAction` /
+ * `detectPtzType`) against fabricated `hass.states` that mirror what the
+ * Home Assistant Reolink integration actually creates — across language
+ * (English vs Dutch) and camera shape (single-channel vs dual-lens).
+ *
+ * Each test asserts the entity the dispatcher *currently* hits. Tests
+ * tagged `BUG:` document behaviour that is wrong today and that the
+ * upcoming button-prefix / zoom-localisation fix is meant to flip. Tests
+ * tagged `OK:` document behaviour that already works and must keep
+ * working. Run with: `npx vitest run src/data/ptz-scenarios.spec.ts`.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import { detectPtzType, detectPtzButtons, dispatchPan, dispatchAction, getPtzConfig } from "./ptz";
+import type { PtzCameraConfig } from "./ptz";
+import type { CameraGalleryCardConfig } from "../config/normalize";
+
+const cfg = (over: Partial<CameraGalleryCardConfig> = {}): CameraGalleryCardConfig =>
+  ({
+    live_ptz_enabled: true,
+    live_ptz_speed: 5,
+    live_ptz_cameras: {},
+    ...over,
+  }) as CameraGalleryCardConfig;
+
+type States = Record<string, unknown>;
+
+/** Dutch / English Reolink PTZ button word per action (slugified name). */
+const WORDS = {
+  en: {
+    up: "up",
+    down: "down",
+    left: "left",
+    right: "right",
+    zoom_in: "zoom_in",
+    zoom_out: "zoom_out",
+    stop: "stop",
+  },
+  nl: {
+    up: "omhoog",
+    down: "omlaag",
+    left: "links",
+    right: "rechts",
+    zoom_in: "inzoomen",
+    zoom_out: "uitzoomen",
+    stop: "stoppen",
+  },
+} as const;
+
+/**
+ * Fabricate the entities a Reolink channel exposes. `stem` is the real
+ * button slug (no stream suffix). `cameraId` is the camera entity (which
+ * DOES carry a localized stream suffix). Buttons live on `stem`, never on
+ * the camera slug — that mismatch is the whole bug.
+ */
+function reolinkChannel(stem: string, cameraId: string, lang: "en" | "nl"): States {
+  const w = WORDS[lang];
+  const s: States = { [cameraId]: { attributes: { friendly_name: cameraId } } };
+  for (const word of Object.values(w)) s[`${stem}_ptz_${word}`] = {};
+  s[`${stem.replace(/^button\./, "select.")}_ptz_preset`] = {
+    attributes: { options: ["Home", "Voordeur"] },
+  };
+  return s;
+}
+
+/** Run one pan dispatch on a fresh recorder; return the [domain,svc,data,target] call. */
+async function pan(
+  states: States,
+  cam: string,
+  ptz: PtzCameraConfig,
+  dir: "up" | "down" | "left" | "right",
+  phase: "start" | "stop" = "start"
+) {
+  const callService = vi.fn().mockResolvedValue(undefined);
+  await dispatchPan({ callService, states }, cam, ptz, dir, phase, 5);
+  return callService.mock.calls[0];
+}
+
+/** Run one zoom/home dispatch on a fresh recorder. */
+async function act(
+  states: States,
+  cam: string,
+  ptz: PtzCameraConfig,
+  action: "zoom_in" | "zoom_out" | "home",
+  phase: "start" | "stop" = "start"
+) {
+  const callService = vi.fn().mockResolvedValue(undefined);
+  await dispatchAction({ callService, states }, cam, ptz, action, phase, 5);
+  return callService.mock.calls[0];
+}
+
+const target = (call: unknown[] | undefined) =>
+  (call?.[3] as { entity_id?: string } | undefined)?.entity_id;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 1 — NL single-channel, NO prefix (the reporter's exact situation)
+//   camera.keuken_vloeiend  +  buttons at button.keuken_ptz_*
+// ───────────────────────────────────────────────────────────────────────────
+describe("NL single-channel, no button_prefix (camera.keuken_vloeiend)", () => {
+  const CAM = "camera.keuken_vloeiend";
+  const states = reolinkChannel("button.keuken", CAM, "nl");
+  const ptz: PtzCameraConfig = { type: "reolink" };
+
+  it("BUG: editor auto-detect fails to recognise the camera as PTZ-capable", () => {
+    // `_vloeiend` is not stripped, so the stop-button probe never finds it.
+    expect(detectPtzType(CAM, { states })).toBeNull();
+  });
+
+  it("BUG: pan targets a non-existent button (keeps the stream suffix)", async () => {
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.keuken_vloeiend_ptz_up");
+    // The real, existing button is button.keuken_ptz_omhoog — never hit.
+    expect(states["button.keuken_ptz_omhoog"]).toBeDefined();
+  });
+
+  it("BUG: stop targets a non-existent button — camera would keep moving", async () => {
+    expect(target(await pan(states, CAM, ptz, "left", "stop"))).toBe(
+      "button.keuken_vloeiend_ptz_stop"
+    );
+  });
+
+  it("BUG: zoom targets a non-existent button", async () => {
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe(
+      "button.keuken_vloeiend_ptz_zoom_in"
+    );
+  });
+
+  it("BUG: home rejects (no select.keuken_vloeiend_ptz_preset)", async () => {
+    await expect(
+      dispatchAction({ callService: vi.fn(), states }, CAM, ptz, "home", "start", 5)
+    ).rejects.toThrow(/No preset options/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 2 — EN single-channel, NO prefix (auto-strip path works… mostly)
+//   camera.keuken_fluent  +  buttons at button.keuken_ptz_*
+// ───────────────────────────────────────────────────────────────────────────
+describe("EN single-channel, no button_prefix (camera.keuken_fluent)", () => {
+  const CAM = "camera.keuken_fluent";
+  const states = reolinkChannel("button.keuken", CAM, "en");
+  const ptz: PtzCameraConfig = { type: "reolink" };
+
+  it("OK: auto-detect works (_fluent is in the strip list)", () => {
+    expect(detectPtzType(CAM, { states })).toBe("reolink");
+  });
+
+  it("OK: pan resolves via the stripped prefix", async () => {
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.keuken_ptz_up");
+  });
+
+  it("OK: stop resolves via the stripped prefix", async () => {
+    expect(target(await pan(states, CAM, ptz, "up", "stop"))).toBe("button.keuken_ptz_stop");
+  });
+
+  it("OK: zoom now resolves via the stripped prefix (zoomButtonEntity fix)", async () => {
+    // Previously targeted the unstripped button.keuken_fluent_ptz_zoom_in;
+    // now probes candidate prefixes and finds the real button.
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe("button.keuken_ptz_zoom_in");
+  });
+
+  it("BUG: home ignores the strip fallback (uses unstripped slug) and rejects", async () => {
+    await expect(
+      dispatchAction({ callService: vi.fn(), states }, CAM, ptz, "home", "start", 5)
+    ).rejects.toThrow(/No preset options/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 3 — NL single-channel WITH button_prefix (the proposed primary fix)
+// ───────────────────────────────────────────────────────────────────────────
+describe("NL single-channel WITH button_prefix=button.keuken", () => {
+  const CAM = "camera.keuken_vloeiend";
+  const states = reolinkChannel("button.keuken", CAM, "nl");
+  const ptz: PtzCameraConfig = { type: "reolink", button_prefix: "button.keuken" };
+
+  it("OK: pan up resolves the localized button", async () => {
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.keuken_ptz_omhoog");
+  });
+  it("OK: pan down resolves the localized button", async () => {
+    expect(target(await pan(states, CAM, ptz, "down"))).toBe("button.keuken_ptz_omlaag");
+  });
+  it("OK: pan left/right resolve", async () => {
+    expect(target(await pan(states, CAM, ptz, "left"))).toBe("button.keuken_ptz_links");
+    expect(target(await pan(states, CAM, ptz, "right"))).toBe("button.keuken_ptz_rechts");
+  });
+  it("OK: stop resolves the localized stop button", async () => {
+    expect(target(await pan(states, CAM, ptz, "up", "stop"))).toBe("button.keuken_ptz_stoppen");
+  });
+  it("OK: home resolves the preset select and picks 'Home'", async () => {
+    const call = await act(states, CAM, ptz, "home");
+    expect(call?.[0]).toBe("select");
+    expect(call?.[1]).toBe("select_option");
+    expect((call?.[2] as { option?: string }).option).toBe("Home");
+    expect(target(call)).toBe("select.keuken_ptz_preset");
+  });
+  it("BUG: zoom still fails — not localized (presses _zoom_in not _inzoomen)", async () => {
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe("button.keuken_ptz_zoom_in");
+    expect(states["button.keuken_ptz_inzoomen"]).toBeDefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 4 — EN single-channel WITH button_prefix (everything works)
+// ───────────────────────────────────────────────────────────────────────────
+describe("EN single-channel WITH button_prefix=button.keuken", () => {
+  const CAM = "camera.keuken_fluent";
+  const states = reolinkChannel("button.keuken", CAM, "en");
+  const ptz: PtzCameraConfig = { type: "reolink", button_prefix: "button.keuken" };
+
+  it("OK: pan / stop / zoom / home all resolve", async () => {
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.keuken_ptz_up");
+    expect(target(await pan(states, CAM, ptz, "up", "stop"))).toBe("button.keuken_ptz_stop");
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe("button.keuken_ptz_zoom_in");
+    expect(target(await act(states, CAM, ptz, "home"))).toBe("select.keuken_ptz_preset");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 5 — Dual-lens, no prefix (mid-string stream token → always breaks)
+//   camera.tuin_vloeiend_lens_0  +  buttons at button.tuin_lens_0_ptz_*
+// ───────────────────────────────────────────────────────────────────────────
+describe("Dual-lens, no button_prefix", () => {
+  it("BUG: NL dual-lens auto-detect fails", () => {
+    const CAM = "camera.tuin_vloeiend_lens_0";
+    const states = reolinkChannel("button.tuin_lens_0", CAM, "nl");
+    expect(detectPtzType(CAM, { states })).toBeNull();
+  });
+  it("BUG: EN dual-lens auto-detect ALSO fails (stream token is mid-string)", () => {
+    const CAM = "camera.tuin_fluent_lens_0";
+    const states = reolinkChannel("button.tuin_lens_0", CAM, "en");
+    expect(detectPtzType(CAM, { states })).toBeNull();
+  });
+  it("BUG: NL dual-lens pan targets non-existent button", async () => {
+    const CAM = "camera.tuin_vloeiend_lens_0";
+    const states = reolinkChannel("button.tuin_lens_0", CAM, "nl");
+    expect(target(await pan(states, CAM, { type: "reolink" }, "up"))).toBe(
+      "button.tuin_vloeiend_lens_0_ptz_up"
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 6 — Dual-lens WITH button_prefix (directions/stop/home fixed, zoom not)
+// ───────────────────────────────────────────────────────────────────────────
+describe("Dual-lens WITH button_prefix=button.tuin_lens_0 (NL)", () => {
+  const CAM = "camera.tuin_vloeiend_lens_0";
+  const states = reolinkChannel("button.tuin_lens_0", CAM, "nl");
+  const ptz: PtzCameraConfig = { type: "reolink", button_prefix: "button.tuin_lens_0" };
+
+  it("OK: pan + stop + home resolve", async () => {
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.tuin_lens_0_ptz_omhoog");
+    expect(target(await pan(states, CAM, ptz, "up", "stop"))).toBe(
+      "button.tuin_lens_0_ptz_stoppen"
+    );
+    expect(target(await act(states, CAM, ptz, "home"))).toBe("select.tuin_lens_0_ptz_preset");
+  });
+  it("BUG: zoom not localized", async () => {
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe("button.tuin_lens_0_ptz_zoom_in");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 7 — Manual per-button override (the safety net) fixes anything
+// ───────────────────────────────────────────────────────────────────────────
+describe("Manual actions override (safety net)", () => {
+  const CAM = "camera.keuken_vloeiend";
+  const states = reolinkChannel("button.keuken", CAM, "nl");
+
+  it("OK: override fixes localized zoom that the built-in dispatcher misses", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      button_prefix: "button.keuken",
+      actions: {
+        zoom_in: {
+          start: { service: "button.press", target: { entity_id: "button.keuken_ptz_inzoomen" } },
+        },
+      },
+    };
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe("button.keuken_ptz_inzoomen");
+  });
+
+  it("OK: override fixes a single renamed direction button without touching the rest", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      button_prefix: "button.keuken",
+      actions: {
+        up: {
+          start: { service: "button.press", target: { entity_id: "button.weird_renamed_up" } },
+        },
+      },
+    };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.weird_renamed_up");
+    // down still uses the prefix-derived localized button
+    expect(target(await pan(states, CAM, ptz, "down"))).toBe("button.keuken_ptz_omlaag");
+  });
+
+  it("OK: malformed override service rejects (surfaced like any dispatcher error)", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      actions: { up: { start: { service: "buttonpress", target: { entity_id: "x" } } } },
+    };
+    await expect(
+      dispatchPan({ callService: vi.fn(), states }, CAM, ptz, "up", "start", 5)
+    ).rejects.toThrow(/Malformed PTZ action service/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 8 — EZVIZ (pulse, button-based): same prefix/locale logic as reolink
+// ───────────────────────────────────────────────────────────────────────────
+describe("EZVIZ type", () => {
+  const CAM = "camera.front_door";
+  const ptz: PtzCameraConfig = { type: "ezviz" };
+
+  it("OK: pan start presses the derived button (no states → English guess)", async () => {
+    expect(target(await pan({}, CAM, ptz, "up"))).toBe("button.front_door_ptz_up");
+  });
+  it("OK: pan start probes localized button when present", async () => {
+    const states = { "button.front_door_ptz_omhoog": {} };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.front_door_ptz_omhoog");
+  });
+  it("OK: pan stop is a no-op (integration has no stop call)", async () => {
+    const callService = vi.fn();
+    await dispatchPan({ callService, states: {} }, CAM, ptz, "up", "stop", 5);
+    expect(callService).not.toHaveBeenCalled();
+  });
+  it("OK: button_prefix override is honoured", async () => {
+    const p: PtzCameraConfig = { type: "ezviz", button_prefix: "button.cam_lobby" };
+    expect(target(await pan({}, CAM, p, "left"))).toBe("button.cam_lobby_ptz_left");
+  });
+  it("OK: zoom is rejected (consumer EZVIZ has no zoom)", async () => {
+    await expect(
+      dispatchAction({ callService: vi.fn(), states: {} }, CAM, ptz, "zoom_in", "start", 5)
+    ).rejects.toThrow(/zoom not supported for type: ezviz/);
+  });
+  it("OK: home is rejected (no home on EZVIZ)", async () => {
+    await expect(
+      dispatchAction({ callService: vi.fn(), states: {} }, CAM, ptz, "home", "start", 5)
+    ).rejects.toThrow(/home not supported for type: ezviz/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 9 — FRIGATE (service-based on the camera entity, no buttons)
+// ───────────────────────────────────────────────────────────────────────────
+describe("FRIGATE type", () => {
+  const CAM = "camera.driveway";
+  const ptz: PtzCameraConfig = { type: "frigate" };
+
+  it("OK: pan move/stop call frigate.ptz on the camera entity", async () => {
+    const start = await pan({}, CAM, ptz, "up");
+    expect(start?.slice(0, 3)).toEqual(["frigate", "ptz", { action: "move", argument: "up" }]);
+    expect(target(start)).toBe(CAM);
+    const stop = await pan({}, CAM, ptz, "up", "stop");
+    expect(stop?.slice(0, 3)).toEqual(["frigate", "ptz", { action: "stop" }]);
+  });
+  it("OK: zoom in/out map to argument in/out", async () => {
+    expect((await act({}, CAM, ptz, "zoom_in"))?.[2]).toEqual({ action: "zoom", argument: "in" });
+    expect((await act({}, CAM, ptz, "zoom_out"))?.[2]).toEqual({ action: "zoom", argument: "out" });
+  });
+  it("OK: home calls preset home", async () => {
+    expect((await act({}, CAM, ptz, "home"))?.[2]).toEqual({ action: "preset", argument: "home" });
+  });
+  it("OK: home on stop phase is a no-op", async () => {
+    const callService = vi.fn();
+    await dispatchAction({ callService, states: {} }, CAM, ptz, "home", "stop", 5);
+    expect(callService).not.toHaveBeenCalled();
+  });
+  it("OK: auto-detect needs the frigate camera attrs (camera_name + client_id) AND the service", () => {
+    // The Frigate integration's camera entity exposes camera_name + client_id.
+    const states = { [CAM]: { attributes: { camera_name: "driveway", client_id: "frigate" } } };
+    const services = { frigate: { ptz: {} } };
+    expect(detectPtzType(CAM, { states, services })).toBe("frigate");
+    expect(detectPtzType(CAM, { states })).toBeNull(); // service missing
+    expect(detectPtzType(CAM, { states: { [CAM]: { attributes: {} } }, services })).toBeNull(); // attrs missing
+    // camera_name without client_id is not enough (avoids false positives)
+    expect(
+      detectPtzType(CAM, { states: { [CAM]: { attributes: { camera_name: "x" } } }, services })
+    ).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 10 — ONVIF (ContinuousMove + speed scaling + diagonal)
+// ───────────────────────────────────────────────────────────────────────────
+describe("ONVIF type", () => {
+  const CAM = "camera.ptz_cam";
+  const ptz: PtzCameraConfig = { type: "onvif" };
+
+  it("OK: pan maps direction to pan/tilt axis with scaled speed", async () => {
+    const up = await pan({}, CAM, ptz, "up");
+    expect(up?.[0]).toBe("onvif");
+    expect(up?.[1]).toBe("ptz");
+    const data = up?.[2] as { move_mode: string; tilt: string; speed: number };
+    expect(data.move_mode).toBe("ContinuousMove");
+    expect(data.tilt).toBe("UP");
+    expect(data.speed).toBeCloseTo(5 / 9, 5);
+    const left = await pan({}, CAM, ptz, "left");
+    expect((left?.[2] as { pan: string }).pan).toBe("LEFT");
+  });
+  it("OK: stop sends move_mode Stop", async () => {
+    expect((await pan({}, CAM, ptz, "up", "stop"))?.[2]).toEqual({ move_mode: "Stop" });
+  });
+  it("OK: per-camera speed override scales (9/9 = 1.0)", async () => {
+    const data = (await pan({}, CAM, { type: "onvif", speed: 9 }, "right"))?.[2] as {
+      speed: number;
+    };
+    expect(data.speed).toBeCloseTo(1, 5);
+  });
+  it("OK: diagonal sets both pan and tilt in one call", async () => {
+    const callService = vi.fn().mockResolvedValue(undefined);
+    await dispatchPan({ callService, states: {} }, CAM, ptz, "up", "start", 5, "right");
+    const data = callService.mock.calls[0]?.[2] as { tilt: string; pan: string };
+    expect(data.tilt).toBe("UP");
+    expect(data.pan).toBe("RIGHT");
+  });
+  it("OK: same-axis secondary is ignored (no overwrite)", async () => {
+    const callService = vi.fn().mockResolvedValue(undefined);
+    await dispatchPan({ callService, states: {} }, CAM, ptz, "left", "start", 5, "right");
+    const data = callService.mock.calls[0]?.[2] as { pan: string };
+    expect(data.pan).toBe("LEFT"); // primary wins, "right" not applied
+  });
+  it("OK: zoom in/out + stop", async () => {
+    expect((await act({}, CAM, ptz, "zoom_in"))?.[2]).toMatchObject({ zoom: "ZOOM_IN" });
+    expect((await act({}, CAM, ptz, "zoom_out"))?.[2]).toMatchObject({ zoom: "ZOOM_OUT" });
+    expect((await act({}, CAM, ptz, "zoom_in", "stop"))?.[2]).toEqual({ move_mode: "Stop" });
+  });
+  it("OK: home goes to preset 0", async () => {
+    expect((await act({}, CAM, ptz, "home"))?.[2]).toEqual({ move_mode: "GotoPreset", preset: 0 });
+  });
+  it("OK: not auto-detectable (must be picked manually)", () => {
+    expect(detectPtzType(CAM, { states: { [CAM]: { attributes: {} } } })).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 11 — Reolink home / preset select edge cases
+// ───────────────────────────────────────────────────────────────────────────
+describe("Reolink home preset edge cases", () => {
+  const CAM = "camera.keuken";
+  const ptz: PtzCameraConfig = { type: "reolink", button_prefix: "button.keuken" };
+  const withOptions = (options: unknown) => ({
+    "select.keuken_ptz_preset": { attributes: { options } },
+  });
+
+  it("picks the option literally named 'Home' (case-insensitive)", async () => {
+    const call = await act(withOptions(["Voordeur", "HOME", "Tuin"]), CAM, ptz, "home");
+    expect((call?.[2] as { option: string }).option).toBe("HOME");
+  });
+  it("falls back to the first option when there is no 'Home'", async () => {
+    const call = await act(withOptions(["Voordeur", "Tuin"]), CAM, ptz, "home");
+    expect((call?.[2] as { option: string }).option).toBe("Voordeur");
+  });
+  it("rejects on an empty options list", async () => {
+    await expect(
+      dispatchAction(
+        { callService: vi.fn(), states: withOptions([]) },
+        CAM,
+        ptz,
+        "home",
+        "start",
+        5
+      )
+    ).rejects.toThrow(/No preset options/);
+  });
+  it("rejects when the preset select entity is missing", async () => {
+    await expect(
+      dispatchAction({ callService: vi.fn(), states: {} }, CAM, ptz, "home", "start", 5)
+    ).rejects.toThrow(/No preset options/);
+  });
+  it("ignores non-string options when choosing", async () => {
+    const call = await act(withOptions([1, "Tuin", null]), CAM, ptz, "home");
+    expect((call?.[2] as { option: string }).option).toBe("Tuin");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 12 — button_prefix normalization
+// ───────────────────────────────────────────────────────────────────────────
+describe("button_prefix normalization", () => {
+  const states = {
+    "button.keuken_ptz_up": {},
+    "select.keuken_ptz_preset": { attributes: { options: ["Home"] } },
+  };
+  it("strips a trailing underscore", async () => {
+    const p: PtzCameraConfig = { type: "reolink", button_prefix: "button.keuken_" };
+    expect(target(await pan(states, "camera.x", p, "up"))).toBe("button.keuken_ptz_up");
+  });
+  it("strips a trailing dot", async () => {
+    const p: PtzCameraConfig = { type: "reolink", button_prefix: "button.keuken." };
+    expect(target(await pan(states, "camera.x", p, "up"))).toBe("button.keuken_ptz_up");
+  });
+  it("derives the select slug from the prefix (strips leading 'button.')", async () => {
+    const p: PtzCameraConfig = { type: "reolink", button_prefix: "button.keuken" };
+    expect(target(await act(states, "camera.anything", p, "home"))).toBe(
+      "select.keuken_ptz_preset"
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 13 — Localized direction resolution across languages
+// ───────────────────────────────────────────────────────────────────────────
+describe("Localized direction probing (multi-language)", () => {
+  const cases: Array<[string, "up" | "down" | "left" | "right", string]> = [
+    ["German hoch", "up", "hoch"],
+    ["German runter", "down", "runter"],
+    ["French haut", "up", "haut"],
+    ["French gauche", "left", "gauche"],
+    ["Spanish abajo", "down", "abajo"],
+    ["Spanish derecha", "right", "derecha"],
+    ["Italian giu", "down", "giu"],
+    ["Norwegian hoyre", "right", "hoyre"],
+  ];
+  for (const [name, dir, word] of cases) {
+    it(`resolves ${name}`, async () => {
+      const states = { [`button.cam_ptz_${word}`]: {} };
+      expect(target(await pan(states, "camera.cam", { type: "reolink" }, dir))).toBe(
+        `button.cam_ptz_${word}`
+      );
+    });
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 14 — ezviz entity-resolution cache (stale entry must not be served)
+// ───────────────────────────────────────────────────────────────────────────
+describe("button-entity resolution cache", () => {
+  const CAM = "camera.cachecam";
+  const ptz: PtzCameraConfig = { type: "ezviz" };
+
+  it("a guess is not cached; a later-appearing entity still resolves", async () => {
+    expect(target(await pan({}, CAM, ptz, "up"))).toBe("button.cachecam_ptz_up"); // guess
+    const states = { "button.cachecam_ptz_omhoog": {} };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.cachecam_ptz_omhoog"); // resolves
+  });
+
+  it("a cached hit is re-validated against current states (stale not served)", async () => {
+    const states = { "button.cachecam2_ptz_omhoog": {} };
+    expect(target(await pan(states, "camera.cachecam2", ptz, "up"))).toBe(
+      "button.cachecam2_ptz_omhoog"
+    );
+    // entity gone → must not keep returning the cached omhoog
+    expect(target(await pan({}, "camera.cachecam2", ptz, "up"))).toBe("button.cachecam2_ptz_up");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 15 — detectPtzType precedence
+// ───────────────────────────────────────────────────────────────────────────
+describe("detectPtzType precedence", () => {
+  it("reolink wins when a stop button exists (even alongside directions)", () => {
+    const states = { "button.cam_ptz_up": {}, "button.cam_ptz_stop": {} };
+    expect(detectPtzType("camera.cam", { states })).toBe("reolink");
+  });
+  it("ezviz when only direction buttons exist (no stop)", () => {
+    expect(detectPtzType("camera.cam", { states: { "button.cam_ptz_up": {} } })).toBe("ezviz");
+  });
+  it("ezviz via localized direction (Dutch) with no stop", () => {
+    expect(detectPtzType("camera.cam", { states: { "button.cam_ptz_omhoog": {} } })).toBe("ezviz");
+  });
+  it("null when nothing matches", () => {
+    expect(detectPtzType("camera.cam", { states: {} })).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 16 — getPtzConfig plumbing
+// ───────────────────────────────────────────────────────────────────────────
+describe("getPtzConfig plumbing", () => {
+  it("returns null when globally disabled", () => {
+    expect(
+      getPtzConfig(
+        cfg({ live_ptz_enabled: false, live_ptz_cameras: { "camera.a": { type: "reolink" } } }),
+        "camera.a"
+      )
+    ).toBeNull();
+  });
+  it("returns null for synthetic stream ids", () => {
+    expect(
+      getPtzConfig(
+        cfg({ live_ptz_cameras: { __cgc_stream_0__: { type: "ezviz" } } }),
+        "__cgc_stream_0__"
+      )
+    ).toBeNull();
+  });
+  it("passes through type, speed, trimmed button_prefix and actions", () => {
+    const c = cfg({
+      live_ptz_cameras: {
+        "camera.a": {
+          type: "reolink",
+          speed: 7,
+          button_prefix: "  button.keuken  ",
+          actions: {
+            up: { start: { service: "button.press", target: { entity_id: "button.x" } } },
+          },
+        },
+      },
+    });
+    expect(getPtzConfig(c, "camera.a")).toEqual({
+      type: "reolink",
+      speed: 7,
+      button_prefix: "button.keuken",
+      actions: { up: { start: { service: "button.press", target: { entity_id: "button.x" } } } },
+    });
+  });
+  it("omits an empty/whitespace-only button_prefix", () => {
+    const c = cfg({ live_ptz_cameras: { "camera.a": { type: "reolink", button_prefix: "   " } } });
+    expect(getPtzConfig(c, "camera.a")).toEqual({ type: "reolink" });
+  });
+  it("passes through the buttons map, trimming and dropping blanks", () => {
+    const c = cfg({
+      live_ptz_cameras: {
+        "camera.a": {
+          type: "reolink",
+          buttons: { up: "  button.x_ptz_up  ", down: "", left: "   ", stop: "button.x_ptz_stop" },
+        },
+      },
+    });
+    expect(getPtzConfig(c, "camera.a")).toEqual({
+      type: "reolink",
+      buttons: { up: "button.x_ptz_up", stop: "button.x_ptz_stop" },
+    });
+  });
+  it("omits the buttons key entirely when every value is blank", () => {
+    const c = cfg({ live_ptz_cameras: { "camera.a": { type: "reolink", buttons: { up: "  " } } } });
+    expect(getPtzConfig(c, "camera.a")).toEqual({ type: "reolink" });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 17 — manual `buttons` map is honoured (manual-first path)
+// ───────────────────────────────────────────────────────────────────────────
+describe("Manual buttons map", () => {
+  const CAM = "camera.keuken_vloeiend";
+  const states = {
+    ...reolinkChannel("button.keuken", CAM, "nl"),
+    "select.custom_preset": { attributes: { options: ["Home", "Voordeur"] } },
+  };
+
+  it("presses the explicit pan / stop / zoom entities", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      buttons: { up: "button.custom_up", stop: "button.custom_stop", zoom_in: "button.custom_zin" },
+    };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.custom_up");
+    expect(target(await pan(states, CAM, ptz, "up", "stop"))).toBe("button.custom_stop");
+    expect(target(await act(states, CAM, ptz, "zoom_in"))).toBe("button.custom_zin");
+  });
+
+  it("uses the explicit home select entity", async () => {
+    const ptz: PtzCameraConfig = { type: "reolink", buttons: { home: "select.custom_preset" } };
+    const call = await act(states, CAM, ptz, "home");
+    expect(target(call)).toBe("select.custom_preset");
+    expect((call?.[2] as { option: string }).option).toBe("Home");
+  });
+
+  it("buttons win over auto-derivation even when button_prefix is set", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      button_prefix: "button.keuken",
+      buttons: { up: "button.override_up" },
+    };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.override_up");
+    // a key NOT in buttons still falls back to the prefix-derived localized one
+    expect(target(await pan(states, CAM, ptz, "down"))).toBe("button.keuken_ptz_omlaag");
+  });
+
+  it("a free-form actions override still wins over the buttons map", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      buttons: { up: "button.from_buttons" },
+      actions: {
+        up: { start: { service: "button.press", target: { entity_id: "button.from_actions" } } },
+      },
+    };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.from_actions");
+  });
+
+  it("a blank buttons value falls through to auto-derivation", async () => {
+    const ptz: PtzCameraConfig = {
+      type: "reolink",
+      button_prefix: "button.keuken",
+      buttons: { up: "   " },
+    };
+    expect(target(await pan(states, CAM, ptz, "up"))).toBe("button.keuken_ptz_omhoog");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Scenario 18 — detectPtzButtons (engine behind the editor "Detect" button)
+// ───────────────────────────────────────────────────────────────────────────
+describe("detectPtzButtons", () => {
+  it("NL single-channel: finds localized dirs + stop + home, leaves zoom blank", () => {
+    const CAM = "camera.keuken_vloeiend";
+    const states = reolinkChannel("button.keuken", CAM, "nl");
+    expect(detectPtzButtons(CAM, { states })).toEqual({
+      up: "button.keuken_ptz_omhoog",
+      down: "button.keuken_ptz_omlaag",
+      left: "button.keuken_ptz_links",
+      right: "button.keuken_ptz_rechts",
+      stop: "button.keuken_ptz_stoppen",
+      home: "select.keuken_ptz_preset",
+      // no zoom_in/zoom_out — NL zoom buttons (_inzoomen) aren't English-probed
+    });
+  });
+
+  it("EN single-channel: finds everything including zoom", () => {
+    const CAM = "camera.keuken_fluent";
+    const states = reolinkChannel("button.keuken", CAM, "en");
+    expect(detectPtzButtons(CAM, { states })).toEqual({
+      up: "button.keuken_ptz_up",
+      down: "button.keuken_ptz_down",
+      left: "button.keuken_ptz_left",
+      right: "button.keuken_ptz_right",
+      zoom_in: "button.keuken_ptz_zoom_in",
+      zoom_out: "button.keuken_ptz_zoom_out",
+      stop: "button.keuken_ptz_stop",
+      home: "select.keuken_ptz_preset",
+    });
+  });
+
+  it("NL dual-lens: recovers the stem by stripping the mid-string stream token", () => {
+    const CAM = "camera.tuin_vloeiend_lens_0";
+    const states = reolinkChannel("button.tuin_lens_0", CAM, "nl");
+    expect(detectPtzButtons(CAM, { states })).toMatchObject({
+      up: "button.tuin_lens_0_ptz_omhoog",
+      stop: "button.tuin_lens_0_ptz_stoppen",
+      home: "select.tuin_lens_0_ptz_preset",
+    });
+  });
+
+  it("returns {} when no PTZ buttons exist for the camera", () => {
+    expect(detectPtzButtons("camera.doorbell", { states: { "camera.doorbell": {} } })).toEqual({});
+  });
+});

--- a/src/data/ptz.spec.ts
+++ b/src/data/ptz.spec.ts
@@ -198,7 +198,8 @@ describe("detectPtzType", () => {
   it("picks frigate only when the camera itself is Frigate-managed AND the service exists", () => {
     expect(
       detectPtzType("camera.x", {
-        states: { "camera.x": { attributes: { frigate_camera_name: "x" } } },
+        // Frigate's camera entity exposes camera_name + client_id.
+        states: { "camera.x": { attributes: { camera_name: "x", client_id: "frigate" } } },
         services: { frigate: { ptz: {} } },
       })
     ).toBe("frigate");
@@ -227,7 +228,7 @@ describe("detectPtzType", () => {
       detectPtzType("camera.x", {
         states: {
           "button.x_ptz_stop": {},
-          "camera.x": { attributes: { frigate_camera_name: "x" } },
+          "camera.x": { attributes: { camera_name: "x", client_id: "frigate" } },
         },
         services: { frigate: { ptz: {} } },
       })

--- a/src/data/ptz.ts
+++ b/src/data/ptz.ts
@@ -122,6 +122,24 @@ export interface PtzActions {
   home?: { start: PtzServiceCall };
 }
 
+/**
+ * Manual per-action entity map (the "manual-first" path). Each value is the
+ * exact entity the dispatcher drives: a `button.*` for pan/zoom/stop, a
+ * `select.*_ptz_preset` for home. Filled by the editor's per-button pickers
+ * (and its Detect helper). An absent key falls back to auto-derivation;
+ * `actions` (free-form service call) still wins over this.
+ */
+export interface PtzButtons {
+  up?: string;
+  down?: string;
+  left?: string;
+  right?: string;
+  zoom_in?: string;
+  zoom_out?: string;
+  stop?: string;
+  home?: string;
+}
+
 /** Resolved per-camera PTZ config (struct-narrowed shape). */
 export interface PtzCameraConfig {
   type: PtzType;
@@ -146,6 +164,11 @@ export interface PtzCameraConfig {
    * types don't cover (Foscam, Tapo without ONVIF, custom scripts).
    */
   actions?: PtzActions;
+  /**
+   * Manual per-action entity map. Pressed/selected directly when set,
+   * before any auto-derivation. `actions` still takes precedence.
+   */
+  buttons?: PtzButtons;
 }
 
 /** Minimal hass surface — only what `dispatchPan` uses. */
@@ -195,6 +218,18 @@ const EZVIZ_DIRECTION_SUFFIXES: Record<PtzDirection, readonly string[]> = {
   right: ["right", "rechts", "naar_rechts", "derecha", "droite", "destra", "hoyre", "dreapta"],
 };
 
+/** All keys of `PtzButtons`, used for safe iteration over untyped config. */
+const PTZ_BUTTON_KEYS = [
+  "up",
+  "down",
+  "left",
+  "right",
+  "zoom_in",
+  "zoom_out",
+  "stop",
+  "home",
+] as const;
+
 /**
  * Return the per-camera PTZ entry, or `null` when:
  *   - the global `live_ptz_enabled` is off,
@@ -225,6 +260,17 @@ export function getPtzConfig(
     // pass through. `exactOptionalPropertyTypes`-safe because callers
     // only read keys that are present.
     out.actions = entry.actions as PtzActions;
+  }
+  if (entry.buttons && typeof entry.buttons === "object") {
+    // Keep only non-empty, trimmed entity ids so a blank field left behind
+    // by the editor doesn't shadow auto-derivation with an empty string.
+    const src = entry.buttons as Record<string, unknown>;
+    const buttons: PtzButtons = {};
+    for (const key of PTZ_BUTTON_KEYS) {
+      const v = src[key];
+      if (typeof v === "string" && v.trim() !== "") buttons[key] = v.trim();
+    }
+    if (Object.keys(buttons).length > 0) out.buttons = buttons;
   }
   return out;
 }
@@ -263,6 +309,17 @@ function getActionOverride(
   key: PtzNamedAction
 ): { start: PtzServiceCall; stop?: PtzServiceCall } | null {
   return ptz.actions?.[key] ?? null;
+}
+
+/**
+ * The user-set entity for one action from the manual `buttons` map, or
+ * `undefined` when unset/blank — caller then falls through to built-in
+ * auto-derivation. `getPtzConfig` already trims/drops blanks, but we
+ * re-guard here so direct callers (tests, future paths) stay safe.
+ */
+function explicitButton(ptz: PtzCameraConfig, key: keyof PtzButtons): string | undefined {
+  const v = ptz.buttons?.[key];
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : undefined;
 }
 
 /**
@@ -424,14 +481,16 @@ export function detectPtzType(
   // in the editor just because Frigate-the-integration is installed.
   //
   // Frigate: only when the camera entity itself is a Frigate-managed
-  //   camera (attribute `frigate_camera_name`) AND `frigate.ptz` exists.
+  //   camera AND `frigate.ptz` exists. The Frigate integration's camera
+  //   entity exposes `camera_name` + `client_id` attributes (there is no
+  //   `frigate_camera_name`); the pair together is the Frigate signature.
   // ONVIF: cannot be reliably detected from `hass.states` alone (the
   //   camera entity attributes don't expose PTZ capability), so we skip
   //   auto-detect and require the user to pick "ONVIF" manually.
-  const camState = hass.states?.[cameraEntityId] as
-    | { attributes?: Record<string, unknown> }
-    | undefined;
-  const isFrigate = !!camState?.attributes && "frigate_camera_name" in camState.attributes;
+  const attrs = (
+    hass.states?.[cameraEntityId] as { attributes?: Record<string, unknown> } | undefined
+  )?.attributes;
+  const isFrigate = !!attrs && "camera_name" in attrs && "client_id" in attrs;
   if (isFrigate && hass.services?.["frigate"] && "ptz" in hass.services["frigate"]) {
     return "frigate";
   }
@@ -461,6 +520,116 @@ function reolinkStopEntity(
   // direction helpers: if nothing exists, surface a recognisable
   // "entity not found" error.
   return `${prefixes[0]}_ptz_stop`;
+}
+
+/**
+ * Resolve the Reolink zoom button (`_ptz_zoom_in` / `_ptz_zoom_out`). Probes
+ * each candidate prefix against hass.states so substream / NVR cameras whose
+ * buttons live on a stripped slug resolve correctly — the direction helpers
+ * already do this; zoom historically didn't and targeted the unstripped
+ * prefix. Falls back to the canonical prefix when nothing matches. Zoom
+ * button names aren't localised by the integration the way directions are,
+ * so there's no per-language probing here — non-English installs use the
+ * manual `buttons` map instead.
+ */
+function zoomButtonEntity(
+  cameraEntityId: string,
+  buttonPrefix: string | undefined,
+  hassStates: Readonly<Record<string, unknown>> | undefined,
+  action: PtzZoom
+): string {
+  const prefixes = candidateButtonPrefixes(cameraEntityId, buttonPrefix);
+  if (hassStates) {
+    for (const p of prefixes) {
+      const cand = `${p}_ptz_${action}`;
+      if (cand in hassStates) return cand;
+    }
+  }
+  return `${prefixes[0]}_ptz_${action}`;
+}
+
+/**
+ * Stream-quality tokens the Reolink integration appends to camera entity ids
+ * (localised at entity creation) which the PTZ *button* entities do NOT
+ * carry. Used to recover the button stem from a camera id regardless of UI
+ * language or stream/lens position.
+ */
+const STREAM_QUALITY_TOKENS = [
+  "sub",
+  "main",
+  "clear",
+  "fluent",
+  "balanced",
+  "vloeiend",
+  "helder",
+  "gebalanceerd", // nl
+  "klar",
+  "fluessig",
+  "fluid", // de
+  "clair",
+  "fluide",
+  "equilibre", // fr
+  "claro",
+  "fluido",
+  "equilibrado", // es
+] as const;
+
+/**
+ * Best-effort recovery of the `button.<stem>` slug a camera's PTZ buttons
+ * live on. Tries the camera base as-is, then with each known stream-quality
+ * token removed (anywhere in the slug — covers `_vloeiend` mid-string in
+ * dual-lens ids). Returns the first stem under which any `_ptz_*` button
+ * actually exists, else `null`.
+ */
+function detectButtonStem(
+  cameraEntityId: string,
+  states: Readonly<Record<string, unknown>>
+): string | null {
+  const base = cameraEntityId.replace(/^camera\./, "");
+  const candidates = [base];
+  for (const t of STREAM_QUALITY_TOKENS) {
+    const re = new RegExp(`_${t}(?=_|$)`);
+    if (re.test(base)) candidates.push(base.replace(re, ""));
+  }
+  const keys = Object.keys(states);
+  for (const c of candidates) {
+    const pre = `button.${c}`;
+    if (keys.some((k) => k.startsWith(`${pre}_ptz_`))) return pre;
+  }
+  return null;
+}
+
+/**
+ * Resolve the concrete PTZ entities for a camera by probing hass.states —
+ * the engine behind the editor's "Detect buttons" action. Returns only
+ * entities that actually exist, so the editor can pre-fill the manual
+ * `buttons` map and leave the rest blank for the user to pick. Handles
+ * localised direction / stop names and stream-suffixed / dual-lens camera
+ * ids. Zoom is matched on the English slug only (the integration doesn't
+ * localise it), so a non-English zoom button stays unfilled by design.
+ */
+export function detectPtzButtons(
+  cameraEntityId: string,
+  hass: { states?: Readonly<Record<string, unknown>> }
+): PtzButtons {
+  const states = hass?.states;
+  if (!states) return {};
+  const stem = detectButtonStem(cameraEntityId, states);
+  if (!stem) return {};
+  const out: PtzButtons = {};
+  for (const dir of PTZ_DIRECTIONS) {
+    const e = ezvizButtonEntity(cameraEntityId, dir, stem, states);
+    if (e in states) out[dir] = e;
+  }
+  const stop = reolinkStopEntity(cameraEntityId, stem, states);
+  if (stop && stop in states) out.stop = stop;
+  for (const z of ["zoom_in", "zoom_out"] as const) {
+    const e = `${stem}_ptz_${z}`;
+    if (e in states) out[z] = e;
+  }
+  const sel = `select.${stem.replace(/^button\./, "")}_ptz_preset`;
+  if (sel in states) out.home = sel;
+  return out;
 }
 
 /** What `joystickResolve` returns per pointer frame. */
@@ -615,7 +784,9 @@ export function dispatchPan(
     // no-op at the service layer; the card-side interval clearing handles
     // the actual "stop pulsing" behaviour.
     if (phase === "stop") return Promise.resolve(undefined);
-    const entityId = ezvizButtonEntity(cameraEntityId, direction, ptz.button_prefix, hass.states);
+    const entityId =
+      explicitButton(ptz, direction) ??
+      ezvizButtonEntity(cameraEntityId, direction, ptz.button_prefix, hass.states);
     // `target.entity_id` is the modern HA shape; the button-based EZVIZ
     // integration was added in the same generation that made `target` canonical.
     return hass.callService("button", "press", {}, { entity_id: entityId });
@@ -627,13 +798,17 @@ export function dispatchPan(
     // (start) or Stop (stop) under the hood, so this card just needs to
     // press the right button per phase.
     if (phase === "stop") {
-      const stopId = reolinkStopEntity(cameraEntityId, ptz.button_prefix, hass.states);
+      const stopId =
+        explicitButton(ptz, "stop") ??
+        reolinkStopEntity(cameraEntityId, ptz.button_prefix, hass.states);
       if (!stopId) return Promise.resolve(undefined);
       return hass.callService("button", "press", {}, { entity_id: stopId });
     }
     // Reolink direction buttons share the same naming pattern as EZVIZ,
-    // so we lean on the same suffix-probing helper.
-    const entityId = ezvizButtonEntity(cameraEntityId, direction, ptz.button_prefix, hass.states);
+    // so we lean on the same suffix-probing helper (unless explicitly set).
+    const entityId =
+      explicitButton(ptz, direction) ??
+      ezvizButtonEntity(cameraEntityId, direction, ptz.button_prefix, hass.states);
     return hass.callService("button", "press", {}, { entity_id: entityId });
   }
 
@@ -722,7 +897,9 @@ export function dispatchAction(
       // Prefer an option literally named "Home" (case-insensitive); else
       // fall back to the first option in the list — that's the standard
       // home slot in PTZ firmware.
-      const selectEntity = `select.${cameraBaseSlug(cameraEntityId, ptz.button_prefix)}_ptz_preset`;
+      const selectEntity =
+        explicitButton(ptz, "home") ??
+        `select.${cameraBaseSlug(cameraEntityId, ptz.button_prefix)}_ptz_preset`;
       const state = hass.states?.[selectEntity] as
         | { attributes?: { options?: unknown } }
         | undefined;
@@ -767,12 +944,16 @@ export function dispatchAction(
     // Reolink exposes button.<base>_ptz_zoom_in / _zoom_out alongside the
     // direction buttons. Stop = same shared ptz_stop button.
     if (phase === "stop") {
-      const stopId = reolinkStopEntity(cameraEntityId, ptz.button_prefix, hass.states);
+      const stopId =
+        explicitButton(ptz, "stop") ??
+        reolinkStopEntity(cameraEntityId, ptz.button_prefix, hass.states);
       if (!stopId) return Promise.resolve(undefined);
       return hass.callService("button", "press", {}, { entity_id: stopId });
     }
-    const prefix = candidateButtonPrefixes(cameraEntityId, ptz.button_prefix)[0];
-    return hass.callService("button", "press", {}, { entity_id: `${prefix}_ptz_${action}` });
+    const entityId =
+      explicitButton(ptz, action) ??
+      zoomButtonEntity(cameraEntityId, ptz.button_prefix, hass.states, action);
+    return hass.callService("button", "press", {}, { entity_id: entityId });
   }
   if (ptz.type === "frigate") {
     if (phase === "stop") {

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,7 @@ import {
 import { WebRtcMicClient } from "./data/webrtc-mic";
 import {
   detectPtzType,
+  detectPtzButtons,
   dispatchAction as ptzDispatchAction,
   dispatchPan as ptzDispatchPan,
   getPtzConfig,
@@ -9121,10 +9122,18 @@ class CameraGalleryCardEditor extends HTMLElement {
               <span>Show all cameras (manual selection for ONVIF / non-detected setups)</span>
             </div>
           `;
+          // Autocomplete pools for the manual per-button pickers: only the
+          // PTZ-relevant entities, so reboot/SD/siren buttons don't clutter.
+          const ptzAllEntities = this._hass?.states ? Object.keys(this._hass.states) : [];
+          const ptzButtonOpts = ptzAllEntities.filter((e) => /^button\..*_ptz_/.test(e)).sort();
+          const ptzSelectOpts = ptzAllEntities.filter((e) => /^select\..*_ptz_preset$/.test(e)).sort();
+          const ptzDatalists =
+            `<datalist id="ptz-button-list">${ptzButtonOpts.map((o) => `<option value="${o.replace(/"/g, "&quot;")}"></option>`).join("")}</datalist>` +
+            `<datalist id="ptz-select-list">${ptzSelectOpts.map((o) => `<option value="${o.replace(/"/g, "&quot;")}"></option>`).join("")}</datalist>`;
           if (visibleCams.length === 0) {
             return `<div class="desc" style="margin-top:10px;font-style:italic;opacity:0.7;">No PTZ-capable cameras detected. Add a camera that exposes PTZ button entities (EZVIZ, Reolink) or that supports frigate.ptz, and it'll show up here. Or flip the toggle below to pick a type manually.</div>${showAllToggle}`;
           }
-          return `<div style="display:flex;flex-direction:column;gap:10px;margin-top:10px;">
+          return ptzDatalists + `<div style="display:flex;flex-direction:column;gap:10px;margin-top:10px;">
             ${visibleCams.map((entId) => {
               const friendly = String(this._hass?.states?.[entId]?.attributes?.friendly_name || entId).trim();
               const cfgEntry = ptzMap[entId];
@@ -9146,6 +9155,18 @@ class CameraGalleryCardEditor extends HTMLElement {
                       <option value="frigate" ${cfgEntry.type === "frigate" ? "selected" : ""}>Frigate — continuous</option>
                       <option value="onvif" ${cfgEntry.type === "onvif" ? "selected" : ""}>ONVIF — continuous</option>
                     </select>
+                    ${((cfgEntry.type || "ezviz") === "ezviz" || cfgEntry.type === "reolink") ? `
+                    <button type="button" class="actionbtn ptz-detect-btn" data-ptz-cam="${entId.replace(/"/g,"&quot;")}" style="align-self:flex-start;margin-top:2px;">Detect buttons</button>
+                    ${[["up","Up","mdi:arrow-up"],["down","Down","mdi:arrow-down"],["left","Left","mdi:arrow-left"],["right","Right","mdi:arrow-right"],["zoom_in","Zoom in","mdi:magnify-plus-outline"],["zoom_out","Zoom out","mdi:magnify-minus-outline"],["stop","Stop","mdi:stop"],["home","Home","mdi:home-outline"]].map(([bk,blbl,bicon]) => {
+                      const bval = (cfgEntry.buttons && typeof cfgEntry.buttons === "object" && typeof cfgEntry.buttons[bk] === "string") ? cfgEntry.buttons[bk] : "";
+                      const blist = bk === "home" ? "ptz-select-list" : "ptz-button-list";
+                      return `<div style="display:flex;align-items:center;gap:8px;" title="${blbl}">
+                        <ha-icon icon="${bicon}" aria-label="${blbl}" style="--mdc-icon-size:18px;width:18px;height:18px;flex:none;opacity:0.7;"></ha-icon>
+                        <input type="text" class="ed-input ptz-cam-button" data-ptz-cam="${entId.replace(/"/g,"&quot;")}" data-ptz-key="${bk}" list="${blist}" value="${bval.replace(/"/g,"&quot;")}" placeholder="auto" autocomplete="off" spellcheck="false" style="flex:1;min-width:0;font-size:0.82em;" />
+                      </div>`;
+                    }).join("")}
+                    <div class="desc" style="margin-top:2px;">Leave blank to auto-detect. Pick from the list — only PTZ buttons are suggested (Home picks a <code>select…_ptz_preset</code>).</div>
+                    ` : `<div class="desc" style="margin-top:2px;">Service-based type — no buttons needed.</div>`}
                   </div>
                   ` : ""}
                 </div>
@@ -12771,6 +12792,42 @@ details summary { user-select: none; }
           ...(cur || { presets: [] }),
           type,
         }));
+      });
+    });
+
+    // Manual per-button entity pickers. `change` (not `input`) so the
+    // re-render fires on blur/commit, not on every keystroke — keeps the
+    // cursor put while typing. Blank clears the key (→ auto-derivation).
+    const _mergeButtons = (cur, patch) => {
+      const entry = { ...(cur || { type: "ezviz" }) };
+      const buttons = {
+        ...(entry.buttons && typeof entry.buttons === "object" ? entry.buttons : {}),
+        ...patch,
+      };
+      for (const k of Object.keys(buttons)) {
+        if (typeof buttons[k] !== "string" || buttons[k].trim() === "") delete buttons[k];
+        else buttons[k] = buttons[k].trim();
+      }
+      if (Object.keys(buttons).length > 0) entry.buttons = buttons;
+      else delete entry.buttons;
+      return entry;
+    };
+
+    this.shadowRoot.querySelectorAll(".ptz-cam-button").forEach((el) => {
+      el.addEventListener("change", (e) => {
+        const camId = el.dataset.ptzCam;
+        const key = el.dataset.ptzKey;
+        if (!camId || !key) return;
+        _setPtzCameraEntry(camId, (cur) => _mergeButtons(cur, { [key]: String(e.target.value || "") }));
+      });
+    });
+
+    this.shadowRoot.querySelectorAll(".ptz-detect-btn").forEach((el) => {
+      el.addEventListener("click", () => {
+        const camId = el.dataset.ptzCam;
+        if (!camId || !this._hass) return;
+        const found = detectPtzButtons(camId, { states: this._hass.states });
+        _setPtzCameraEntry(camId, (cur) => _mergeButtons(cur, found));
       });
     });
 


### PR DESCRIPTION
## Summary
- Add a per-camera `buttons` map (`up`/`down`/`left`/`right`/`zoom_in`/`zoom_out`/`stop`/`home`) so PTZ entities can be set explicitly — the manual-first path. The editor renders per-button entity pickers (icon labels + PTZ-filtered autocomplete) for `reolink`/`ezviz`, with a **Detect** helper (`detectPtzButtons`) that probes localized / stream-suffixed entities. Service-based types (`frigate`/`onvif`) show no button fields.
- Dispatcher honors the `buttons` map after `actions`, before auto-derivation.
- Fix Frigate auto-detect: match `camera_name` + `client_id` (the real Frigate camera attributes) instead of the non-existent `frigate_camera_name` — Frigate cameras now auto-detect as PTZ-capable.
- Fix Reolink zoom auto-derive to probe stripped prefixes (substream / NVR cameras).
- Remove an orphaned `styling-config` test left over from the v1→v2 editor migration.

## Why
Auto-detection assumed English entity slugs, so localized installs silently failed — e.g. a Dutch Reolink (`camera.keuken_vloeiend` → `button.keuken_ptz_omhoog`) was never matched, and there was no in-editor way to fix it. Manual-first pickers + Detect close that gap, and the buttons map composes with the existing `button_prefix` / `actions` escape hatches.

## Test plan
- [x] `npm run check` green — typecheck, **841 tests**, lint, build
- [x] New `src/data/ptz-scenarios.spec.ts` covers dispatch + detect across languages (EN/NL/DE/FR/ES), single- and dual-lens cameras, and all four dispatcher types
- [x] Manually validated on hardware: EZVIZ (real, button-based) moves; Reolink (button rig); Frigate + ONVIF service dispatch confirmed reaching the integration with the correct payload