### PR TITLE
refactor(live): compact camera switcher

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3582,19 +3582,7 @@ class CameraGalleryCard extends LitElement {
         @click=${() => this._closeLivePicker()}
       ></div>
 
-      <div class="live-picker" @click=${(e) => e.stopPropagation()}>
-        <div class="live-picker-head">
-          <div class="live-picker-title">Select camera</div>
-          <button
-            class="live-picker-close"
-            @click=${() => this._closeLivePicker()}
-            title="Close"
-            aria-label="Close"
-          >
-            <ha-icon icon="mdi:close"></ha-icon>
-          </button>
-        </div>
-
+      <div class="live-picker cam-picker" @click=${(e) => e.stopPropagation()}>
         <div class="live-picker-list">
           ${cams.map((cam) => {
             const isOn = cam === activeCam;

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -716,11 +716,6 @@ export const cardStyles = css`
         }
       }
     }
-    & .live-picker-item-entity {
-      font-size: 11px;
-      font-weight: 500;
-      opacity: 0.55;
-    }
     & .live-picker-check {
       --ha-icon-size: 22px;
       --mdc-icon-size: var(--ha-icon-size);
@@ -728,6 +723,40 @@ export const cardStyles = css`
       height: var(--ha-icon-size);
       color: var(--primary-color, #4da3ff);
       flex: 0 0 auto;
+    }
+  }
+
+  /* Compact camera switcher (variant A): no header, no entity-id subtitle,
+     tighter rows. Scoped to .cam-picker so the shared date picker
+     (.live-picker.date-picker, which keeps its header) is unaffected. */
+  .live-picker.cam-picker {
+    width: min(74%, 320px);
+    grid-template-rows: minmax(0, 1fr);
+
+    & .live-picker-item {
+      padding: 11px 14px;
+    }
+    & .live-picker-item-left ha-icon {
+      --ha-icon-size: 18px;
+    }
+    /* Name + entity id inline on one row; name keeps its width, the
+       small grey entity id truncates first if the row runs out of space. */
+    & .live-picker-item-name {
+      flex-direction: row;
+      align-items: baseline;
+      gap: 8px;
+    }
+    & .live-picker-item-name span:first-child {
+      font-size: 14px;
+      font-weight: 700;
+      flex: 0 0 auto;
+    }
+    & .live-picker-item-entity {
+      font-size: 11px;
+      font-weight: 500;
+      opacity: 0.5;
+      flex: 0 1 auto;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- Slim down the live-view camera switcher: drop the **"Select camera" header + close button** (dismiss via backdrop tap or by picking a camera), and tighten the rows so the sheet is roughly half the height.
- Keep the entity id, but render it **small/grey inline after the friendly name** instead of as a full subtitle line.
- Scope everything to a new `.cam-picker` modifier so the **date picker** — which shares the `.live-picker` styles — keeps its header and layout untouched.

## Test plan
- [x] `typecheck` + **841 tests** + `build` green
- [x] Verified on device: camera switcher is compact (name + small grey entity id, check on the active row); tap-outside closes; **date picker unchanged**