### PR TITLE
fix(editor): stop section overflow clipping search dropdowns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11375,6 +11375,13 @@ class CameraGalleryCardEditor extends HTMLElement {
           overflow: hidden;
           background: var(--ed-row-bg);
         }
+        /* An open search dropdown (.suggestions) is absolutely positioned and
+         * floats below its input — the section's overflow:hidden (there to clip
+         * rounded corners) would cut it off. Lift the clip only while a
+         * dropdown is open so it can spill over the next section. */
+        .style-section:has(.suggestions:not([hidden])) {
+          overflow: visible;
+        }
 
         .style-section-head {
           display: flex;


### PR DESCRIPTION
## Summary
- The editor's `.style-section` cards use `overflow: hidden` to clip their rounded corners, which also cut off the absolutely-positioned `.suggestions` autocomplete dropdowns once they extended past the section's bottom edge (camera picker, gallery entity/media-source pickers, and the menu-button entity/icon fields).
- Lift the clip only while a dropdown is open, via `.style-section:has(.suggestions:not([hidden]))`, so the list can float over the following section. Rounded-corner clipping stays intact whenever no dropdown is open.

## Test plan
- [x] Editor → Live → expand "Cameras in picker" → focus the search field: the camera list shows fully instead of being cut off at the section border.
- [x] Same for the Gallery entity / media-source pickers and the Menu buttons entity/icon fields.
- [x] With no dropdown open, the section's rounded corners still clip normally.

`:has()` is supported by the HA companion app WebView (iOS 15.4+ / modern Android WebView).