### PR TITLE
feat(live): configurable talk button shape + radar talking indicator

### DIFF
--- a/src/config/structs.ts
+++ b/src/config/structs.ts
@@ -449,6 +449,11 @@ export const cameraGalleryCardConfigStruct = type({
   // presets; style and opacity are hard-coded for a consistent look.
   live_mic_waveform_enabled: defaulted(boolean(), true),
   live_mic_waveform_sensitivity: defaulted(enums(["low", "medium", "high"]), "medium"),
+  // Talkback shape: full-width `bar` (default, key omitted) or a compact
+  // round `button`. `live_mic_button_position` only applies to the button
+  // shape; `center` is the default and is dropped by the editor.
+  live_mic_shape: optional(enums(["bar", "button"])),
+  live_mic_button_position: optional(enums(["left", "center", "right"])),
 
   // ─── Live PTZ (pan/tilt + presets) ─────────────────────────
   // Per-camera map keyed by camera entity id; values configure the

--- a/src/index.js
+++ b/src/index.js
@@ -2806,6 +2806,21 @@ class CameraGalleryCard extends LitElement {
       ? `${label} (${state})`
       : `Push-to-talk (${state})`;
 
+    // Round button uses expanding radar rings (not the bar's waveform) as the
+    // "talking" indicator — they emanate past the user's fingertip during
+    // push-to-talk, so feedback stays visible while the button is pressed.
+    // Needs overflow:visible so the rings aren't clipped to the 44px circle;
+    // they paint before the tint so the on-button portion reads as a glow.
+    const overflow = isButton ? "visible" : "hidden";
+    const radarRings =
+      isButton && state === "active"
+        ? html`
+            <span class="mic-talkback-ring" aria-hidden="true"></span>
+            <span class="mic-talkback-ring" aria-hidden="true" style="animation-delay:0.66s;"></span>
+            <span class="mic-talkback-ring" aria-hidden="true" style="animation-delay:1.33s;"></span>
+          `
+        : html``;
+
     return html`
       <div
         class="mic-talkback-bar mic-talkback-${shape} ${cls}"
@@ -2813,14 +2828,15 @@ class CameraGalleryCard extends LitElement {
         tabindex="0"
         aria-label=${ariaLabel}
         title=${isButton ? label : ""}
-        style="position:absolute;${position};${placement};${sizeStyle}font-size:14px;display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;letter-spacing:0.02em;background:${bg};box-shadow:inset 0 1px 0 rgba(255,255,255,0.14);user-select:none;-webkit-user-select:none;touch-action:none;z-index:5;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%);text-shadow:0 1px 2px rgba(0,0,0,0.5);overflow:hidden;"
+        style="position:absolute;${position};${placement};${sizeStyle}font-size:14px;display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;letter-spacing:0.02em;background:${bg};box-shadow:inset 0 1px 0 rgba(255,255,255,0.14);user-select:none;-webkit-user-select:none;touch-action:none;z-index:5;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%);text-shadow:0 1px 2px rgba(0,0,0,0.5);overflow:${overflow};"
         @pointerdown=${this._onMicPointerDown}
         @pointerup=${this._onMicPointerUp}
         @pointercancel=${this._onMicPointerUp}
         @pointerleave=${this._onMicPointerUp}
       >
+        ${radarRings}
         <span class="mic-talkback-tint" aria-hidden="true" style="position:absolute;inset:0;border-radius:inherit;background:var(--cgc-talkback-bg, var(--cgc-pill-bg, #000));opacity:calc(var(--cgc-talkback-opacity, var(--cgc-bar-opacity, 30)) / 100);pointer-events:none;"></span>
-        ${this.config?.live_mic_waveform_enabled === false ? html`` : html`<canvas class="mic-wave" aria-hidden="true" style="position:absolute;inset:0;width:100%;height:100%;opacity:${state === "active" ? 1 : 0};transition:opacity 150ms ease-out;pointer-events:none;z-index:1;"></canvas>`}
+        ${isButton || this.config?.live_mic_waveform_enabled === false ? html`` : html`<canvas class="mic-wave" aria-hidden="true" style="position:absolute;inset:0;width:100%;height:100%;opacity:${state === "active" ? 1 : 0};transition:opacity 150ms ease-out;pointer-events:none;z-index:1;"></canvas>`}
         <ha-icon icon=${icon} style="--mdc-icon-size:${isButton ? 22 : 18}px;width:${isButton ? 22 : 18}px;height:${isButton ? 22 : 18}px;display:inline-flex;align-items:center;justify-content:center;line-height:1;position:relative;z-index:2;"></ha-icon>
         ${isButton ? html`` : html`<span style="position:relative;z-index:2;">${label}</span>`}
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -2781,13 +2781,39 @@ class CameraGalleryCard extends LitElement {
       this.config?.bar_position === "bottom"
         ? "top:12px;bottom:auto"
         : "bottom:12px;top:auto";
+
+    // Shape: full-width bar (default) or compact round button. The button
+    // shares the bar's tint, blur and state colors so themes carry over;
+    // only the geometry and visible label differ.
+    const shape = this.config?.live_mic_shape === "button" ? "button" : "bar";
+    const isButton = shape === "button";
+
+    let position;
+    if (isButton) {
+      const pos = this.config?.live_mic_button_position;
+      if (pos === "left") position = "left:12px;right:auto;transform:none";
+      else if (pos === "right") position = "left:auto;right:12px;transform:none";
+      else position = "left:50%;right:auto;transform:translateX(-50%)";
+    } else {
+      position = "left:12px;right:12px";
+    }
+
+    const sizeStyle = isButton
+      ? "width:44px;height:44px;padding:0;border-radius:50%;gap:0;"
+      : "min-height:38px;height:38px;padding:0 16px;border-radius:14px;gap:10px;";
+
+    const ariaLabel = isButton
+      ? `${label} (${state})`
+      : `Push-to-talk (${state})`;
+
     return html`
       <div
-        class="mic-talkback-bar ${cls}"
+        class="mic-talkback-bar mic-talkback-${shape} ${cls}"
         role="button"
         tabindex="0"
-        aria-label=${`Push-to-talk (${state})`}
-        style="position:absolute;left:12px;right:12px;${placement};min-height:38px;height:38px;padding:0 16px;font-size:14px;display:flex;align-items:center;justify-content:center;gap:10px;border-radius:14px;color:#fff;font-weight:600;letter-spacing:0.02em;background:${bg};box-shadow:inset 0 1px 0 rgba(255,255,255,0.14);user-select:none;-webkit-user-select:none;touch-action:none;z-index:5;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%);text-shadow:0 1px 2px rgba(0,0,0,0.5);overflow:hidden;"
+        aria-label=${ariaLabel}
+        title=${isButton ? label : ""}
+        style="position:absolute;${position};${placement};${sizeStyle}font-size:14px;display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;letter-spacing:0.02em;background:${bg};box-shadow:inset 0 1px 0 rgba(255,255,255,0.14);user-select:none;-webkit-user-select:none;touch-action:none;z-index:5;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%);text-shadow:0 1px 2px rgba(0,0,0,0.5);overflow:hidden;"
         @pointerdown=${this._onMicPointerDown}
         @pointerup=${this._onMicPointerUp}
         @pointercancel=${this._onMicPointerUp}
@@ -2795,8 +2821,8 @@ class CameraGalleryCard extends LitElement {
       >
         <span class="mic-talkback-tint" aria-hidden="true" style="position:absolute;inset:0;border-radius:inherit;background:var(--cgc-talkback-bg, var(--cgc-pill-bg, #000));opacity:calc(var(--cgc-talkback-opacity, var(--cgc-bar-opacity, 30)) / 100);pointer-events:none;"></span>
         ${this.config?.live_mic_waveform_enabled === false ? html`` : html`<canvas class="mic-wave" aria-hidden="true" style="position:absolute;inset:0;width:100%;height:100%;opacity:${state === "active" ? 1 : 0};transition:opacity 150ms ease-out;pointer-events:none;z-index:1;"></canvas>`}
-        <ha-icon icon=${icon} style="--mdc-icon-size:18px;width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;line-height:1;position:relative;z-index:2;"></ha-icon>
-        <span style="position:relative;z-index:2;">${label}</span>
+        <ha-icon icon=${icon} style="--mdc-icon-size:${isButton ? 22 : 18}px;width:${isButton ? 22 : 18}px;height:${isButton ? 22 : 18}px;display:inline-flex;align-items:center;justify-content:center;line-height:1;position:relative;z-index:2;"></ha-icon>
+        ${isButton ? html`` : html`<span style="position:relative;z-index:2;">${label}</span>`}
       </div>
     `;
   }
@@ -6218,6 +6244,7 @@ const CGC_CONFIG_KEY_ORDER = [
   "live_enabled", "live_auto_muted", "live_cameras", "live_layout",
   "live_grid_labels", "live_stream_urls", "live_go2rtc_url",
   "live_mic_mode", "live_mic_audio_processing",
+  "live_mic_shape", "live_mic_button_position",
   "live_mic_waveform_enabled", "live_mic_waveform_sensitivity",
   "live_mic_ice_servers", "live_mic_force_relay",
   "live_ptz_enabled", "live_ptz_position", "live_ptz_speed", "live_ptz_cameras",
@@ -8932,6 +8959,33 @@ class CameraGalleryCardEditor extends HTMLElement {
             <button class="seg ${(this._config.live_mic_mode || "toggle") === "toggle" ? "on" : ""}" data-livemicmode="toggle">Toggle</button>
             <button class="seg ${this._config.live_mic_mode === "ptt" ? "on" : ""}" data-livemicmode="ptt">Push-to-talk</button>
           </div>
+        </div>
+        <div class="row">
+          ${(() => {
+            const shape = this._config.live_mic_shape === "button" ? "button" : "bar";
+            const pos = this._config.live_mic_button_position || "center";
+            const segShape = (val, label) =>
+              `<button class="seg ${shape === val ? "on" : ""}" data-livemicshape="${val}">${label}</button>`;
+            const segPos = (val, label) =>
+              `<button class="seg ${pos === val ? "on" : ""}" data-livemicbtnpos="${val}">${label}</button>`;
+            return `
+            <div class="lbl">Shape</div>
+            <div class="desc"><code>Bar</code> spans the full preview width. <code>Button</code> shows a compact round mic button.</div>
+            <div class="segwrap">
+              ${segShape("bar",    "Bar")}
+              ${segShape("button", "Button")}
+            </div>
+            ${shape === "button" ? `
+            <div style="margin-top:10px;">
+              <div class="lbl">Button position</div>
+              <div class="segwrap">
+                ${segPos("left",   "Left")}
+                ${segPos("center", "Center")}
+                ${segPos("right",  "Right")}
+              </div>
+            </div>
+            ` : ``}`;
+          })()}
         </div>
         <div class="row">
           <div class="lbl">Audio processing</div>
@@ -12676,6 +12730,39 @@ details summary { user-select: none; }
           delete n.live_mic_mode;
           this._config = this._stripAlwaysTrueKeys(n);
           this._fire();
+        }
+        this._scheduleRender();
+      });
+    });
+
+    // Talkback shape (bar vs round button). "bar" is the default and not
+    // persisted; switching to "button" stores both shape and position so
+    // the YAML stays minimal until the user opts into the round shape.
+    this.shadowRoot.querySelectorAll("[data-livemicshape]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const shape = btn.dataset.livemicshape;
+        if (shape === "button") {
+          this._set("live_mic_shape", "button");
+        } else {
+          const n = { ...this._config };
+          delete n.live_mic_shape;
+          delete n.live_mic_button_position;
+          this._config = this._stripAlwaysTrueKeys(n);
+          this._fire();
+        }
+        this._scheduleRender();
+      });
+    });
+    this.shadowRoot.querySelectorAll("[data-livemicbtnpos]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const pos = btn.dataset.livemicbtnpos;
+        if (pos === "center") {
+          const n = { ...this._config };
+          delete n.live_mic_button_position;
+          this._config = this._stripAlwaysTrueKeys(n);
+          this._fire();
+        } else {
+          this._set("live_mic_button_position", pos);
         }
         this._scheduleRender();
       });

--- a/src/index.js
+++ b/src/index.js
@@ -8976,8 +8976,8 @@ class CameraGalleryCardEditor extends HTMLElement {
               ${segShape("button", "Button")}
             </div>
             ${shape === "button" ? `
-            <div style="margin-top:10px;">
-              <div class="lbl">Button position</div>
+            <div style="margin-top:14px;">
+              <div class="lbl" style="margin-bottom:8px;">Button position</div>
               <div class="segwrap">
                 ${segPos("left",   "Left")}
                 ${segPos("center", "Center")}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -413,6 +413,35 @@ export const cardStyles = css`
     }
   }
 
+  /* Round talk button "talking" indicator: expanding radar rings that
+     emanate past the button edge (overflow:visible on the button), so the
+     feedback stays visible past the user's fingertip during push-to-talk.
+     Three staggered rings; per-ring animation-delay is set inline. */
+  .mic-talkback-ring {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 2px solid rgba(220, 38, 38, 0.85);
+    pointer-events: none;
+    animation: cgc-mic-radar 2s ease-out infinite;
+  }
+  @keyframes cgc-mic-radar {
+    0% {
+      transform: scale(1);
+      opacity: 0.8;
+    }
+    100% {
+      transform: scale(1.9);
+      opacity: 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .mic-talkback-ring {
+      animation: none;
+      opacity: 0;
+    }
+  }
+
   .live-picker-backdrop {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
## Summary

Adds a compact **round talk button** as an alternative to the full-width talkback bar for the live mic backchannel, plus a fitting "talking" indicator for the new shape.

## Changes

- **Shape option** — new `live_mic_shape` (`bar` | `button`) with editor segmented control. `bar` stays the default and is not persisted.
- **Button position** — `live_mic_button_position` (`left` | `center` | `right`), only shown when shape is `button`; `center` is the default and dropped from YAML.
- **Radar talking indicator** — the bar's waveform doesn't read well on a 44px circle, so the button uses three expanding radar rings instead. They emanate past the button edge (`overflow:visible`) so feedback stays visible past the user's fingertip during push-to-talk. Rings show only while `active` and are disabled under `prefers-reduced-motion`.
- **Struct validation** — `live_mic_shape` / `live_mic_button_position` added to the config struct with enum validation, matching the rest of the `live_mic_*` keys.

## Config

```yaml
live_mic_shape: button          # default: bar
live_mic_button_position: right  # default: center (button shape only)
```

## Notes

- Bar shape is untouched — geometry, waveform, and theming behave exactly as before.
- The shape/position keys are `optional` so the default (bar) keeps the YAML minimal.

## Test plan

- [x] `npm run build` clean
- [x] Bar shape: unchanged appearance + waveform
- [x] Button shape: round 44px, left/center/right positions
- [x] Push-to-talk: radar rings visible around/past the finger
- [x] Reduced-motion: no ring animation