### PR TITLE
fix(media): hide empty day folders so the gallery never strands on an empty day (#191)

### DIFF
--- a/src/data/item-pipeline.spec.ts
+++ b/src/data/item-pipeline.spec.ts
@@ -281,6 +281,27 @@ describe("ItemPipelineClient.getBaseList", () => {
     expect(pipeline.getBaseList().activeDay).toBe("2026-05-12");
   });
 
+  it("active day skips an empty leading calendar day (issue #191)", () => {
+    const dt = (y: number, m: number, d: number): number => new Date(y, m - 1, d).getTime();
+    // Items only on the 12th and 10th; the media calendar also lists the 13th
+    // — a freshly-created current-day folder with no recordings yet. The
+    // gallery must default to the newest day that holds media, not the empty
+    // calendar-newest day.
+    const sensor = makeSensorClient([{ src: "/a" }, { src: "/b" }]);
+    const media = makeMediaClient([], { "/a": dt(2026, 5, 10), "/b": dt(2026, 5, 12) }, [
+      "2026-05-13",
+      "2026-05-12",
+      "2026-05-10",
+    ]);
+    const pipeline = new ItemPipelineClient(
+      defaultOpts({ sensorClient: sensor, mediaClient: media })
+    );
+    const base = pipeline.getBaseList();
+    expect(base.newestDay).toBe("2026-05-13"); // calendar newest (empty)
+    expect(base.activeDay).toBe("2026-05-12"); // newest day WITH items
+    expect(base.dayFiltered.map((x) => x.src)).toEqual(["/b"]);
+  });
+
   it("re-sorts when getSortOrder() flips", () => {
     // Same day so the day filter doesn't trim — we're testing sort direction.
     const dt = (y: number, m: number, d: number, h: number): number =>

--- a/src/data/item-pipeline.ts
+++ b/src/data/item-pipeline.ts
@@ -258,7 +258,15 @@ export class ItemPipelineClient {
     const allWithDay = sortItemsByTime(rawItems, sortOrder);
     const days = this.getAllDays(allWithDay);
     const newestDay = days[0] ?? null;
-    const activeDay = selectedDay ?? newestDay;
+    // Default to the newest day that actually has loaded items rather than the
+    // newest calendar day. A discovered-but-empty leading day (e.g. a freshly
+    // created current-day folder with no recordings yet — issue #191) would
+    // otherwise strand the gallery on a "No media for this day" screen. An
+    // explicit user selection is always honoured.
+    const daysWithItems = new Set<string>();
+    for (const x of allWithDay) if (x.dayKey) daysWithItems.add(x.dayKey);
+    const newestWithItems = days.find((d) => daysWithItems.has(d)) ?? newestDay;
+    const activeDay = selectedDay ?? newestWithItems;
 
     const dayFiltered: BaseListEntry[] = !activeDay
       ? allWithDay

--- a/src/data/media-walker.spec.ts
+++ b/src/data/media-walker.spec.ts
@@ -569,6 +569,56 @@ describe("MediaSourceClient.ensureLoaded", () => {
     expect(items[0]?.id).toBe(`${root}/20260502/120030.mp4`);
   });
 
+  it("prunes a discovered-but-empty day folder from the calendar (issue #191)", async () => {
+    // A freshly-created current-day folder is discovered but holds no media.
+    // It must not survive in the calendar (navigation / picker would land on a
+    // "No media for this day" dead-end); the gallery loads the older day that
+    // actually has media instead.
+    const root = "media-source://x";
+    const dir = (id: string, title: string, children: unknown[]): unknown => ({
+      title,
+      media_class: "directory",
+      media_content_type: "directory",
+      media_content_id: id,
+      can_play: false,
+      can_expand: true,
+      thumbnail: null,
+      children,
+    });
+    const file = (id: string, title: string): unknown => ({
+      title,
+      media_class: "video",
+      media_content_type: "video/mp4",
+      media_content_id: id,
+      can_play: true,
+      can_expand: false,
+      thumbnail: null,
+      children: [],
+    });
+    hass.registerWs("media_source/browse_media", (p) => {
+      const id = String(p["media_content_id"]);
+      if (id === root) {
+        return dir(root, "x", [
+          dir(`${root}/20260603`, "20260603", []), // empty current-day folder
+          dir(`${root}/20260601`, "20260601", []),
+        ]);
+      }
+      if (id === `${root}/20260603`) return dir(id, "20260603", []); // browses empty
+      if (id === `${root}/20260601`) {
+        return dir(id, "20260601", [file(`${root}/20260601/120030.mp4`, "120030.mp4")]);
+      }
+      return null;
+    });
+
+    client.load(baseConfig({ media_sources: [root], path_datetime_format: "YYYYMMDD/HHmmss.mp4" }));
+    await client.ensureLoaded();
+
+    // The empty 2026-06-03 folder is gone; only the day with media remains.
+    expect(client.getDays()).toEqual(["2026-06-01"]);
+    expect(client.state.dayCache.has("2026-06-03")).toBe(false);
+    expect((client.state.dayCache.get("2026-06-01") ?? []).length).toBe(1);
+  });
+
   it("clears the calendar + day caches when media_sources changes (review A1)", () => {
     const a = "media-source://media_source/local/a";
     const b = "media-source://media_source/local/b";

--- a/src/data/media-walker.ts
+++ b/src/data/media-walker.ts
@@ -1150,14 +1150,25 @@ export class MediaSourceClient {
         this.state.dayCache = byDayItems;
         this._refreshList();
       } else {
-        // Layouts B/C — lazy. Auto-load the most-recent day so the gallery
-        // isn't empty on first render. Older days load on user navigation.
-        const newest = discovery.calendar.days[0];
-        if (newest) {
-          // Snapshot the calendar so a concurrent config change can't make
-          // _loadDayInternal write empty results for a day from the OLD
-          // calendar (review finding A6).
-          await this._loadDayInternal(newest, discovery.calendar, fmt, browseFn, gen);
+        // Layouts B/C — lazy. Auto-load the most-recent day that actually has
+        // media so the gallery isn't empty on first render. A freshly-created
+        // current-day folder is discovered as the newest calendar day but holds
+        // no recordings yet (issue #191) — keeping it would let navigation / the
+        // date picker land on a "No media for this day" dead-end. _loadDayInternal
+        // prunes any probed day that browses to no media, so leading empty days
+        // drop out of the calendar as we look for the newest one that holds
+        // media; they reappear once a later discovery finds media in them.
+        // Capped so a pathological all-empty tree can't browse forever. Older
+        // days load lazily on navigation.
+        const cal = discovery.calendar;
+        const MAX_EMPTY_SKIP = 10;
+        for (let i = 0; i < cal.days.length && i < MAX_EMPTY_SKIP; i++) {
+          const day = cal.days[i];
+          if (!day) continue;
+          await this._loadDayInternal(day, cal, fmt, browseFn, gen);
+          if (this._isStale(gen)) return;
+          const loaded = this.state.dayCache.get(day);
+          if (loaded && loaded.length > 0) break;
         }
         if (this._isStale(gen)) return;
         this._refreshList();
@@ -1285,14 +1296,40 @@ export class MediaSourceClient {
     if (this._isStale(gen)) return;
     this._sortDayItemsInPlace(items);
     this.state.dayCache.set(dayKey, items);
-    // Defer the (potentially hundreds of KB) JSON.stringify off the
-    // render-critical path. The user-visible state is already updated; the
-    // localStorage write only matters for the *next* page load. `ric` runs
-    // in browser idle time after paint; `setTimeout` is the fallback for
-    // hosts (older Safari) without rIC.
-    if (cacheKey) deferLsWrite(cacheKey, items);
+    if (items.length === 0) {
+      // Issue #191: a discovered day folder that browses to no media is an
+      // empty day. Drop it from the calendar so the picker / day-stepper never
+      // surface a "No media for this day" dead-end. Prune-as-you-go — this runs
+      // for the active day and its prefetched neighbours, so empty days vanish
+      // a step ahead of navigation without browsing the whole tree up front.
+      // (In combined mode a day with sensor items survives: the pipeline
+      // re-derives it from item dayKeys via mergeKnownDays.)
+      this._dropDayFromCalendar(dayKey);
+    } else if (cacheKey) {
+      // Defer the (potentially hundreds of KB) JSON.stringify off the
+      // render-critical path. The user-visible state is already updated; the
+      // localStorage write only matters for the *next* page load. `ric` runs
+      // in browser idle time after paint; `setTimeout` is the fallback for
+      // hosts (older Safari) without rIC.
+      deferLsWrite(cacheKey, items);
+    }
     this._refreshList();
     this._fireChange();
+  }
+
+  /** Remove a now-known-empty day from the calendar so navigation and the date
+   *  picker never offer it (issue #191). No-op when the day isn't present. */
+  private _dropDayFromCalendar(dayKey: string): void {
+    const cal = this.state.calendar;
+    if (!cal.days.includes(dayKey) && !cal.byDay.has(dayKey)) return;
+    const byDay = new Map<string, readonly CalendarEntry[]>();
+    for (const [d, v] of cal.byDay) if (d !== dayKey) byDay.set(d, v);
+    this.state.calendar = { byDay, days: cal.days.filter((d) => d !== dayKey) };
+    this.state.dayCache.delete(dayKey);
+    const fmt = this._getCompiledPathFormat();
+    const calCacheKey =
+      fmt && fmt.directoryDepth >= 1 ? this._calendarCacheKey(this.state.roots, fmt) : null;
+    if (calCacheKey) saveCalendarToStorage(calCacheKey, this.state.calendar);
   }
 
   /** Canonical signature of a path-format. Both `_dayCacheKey` and

--- a/src/index.js
+++ b/src/index.js
@@ -5350,7 +5350,10 @@ class CameraGalleryCard extends LitElement {
     const dayIdx = currentForNav ? days.indexOf(currentForNav) : -1;
     const canPrev = dayIdx >= 0 && dayIdx < days.length - 1;
     const canNext = dayIdx > 0;
-    const isToday = currentForNav === newestDay;
+    // Highlight "Today" only when the active day is the literal current date,
+    // not merely the newest day with media (issue #191: with empty current-day
+    // folders pruned, the newest day is often an earlier date).
+    const isToday = currentForNav === dayKeyFromMs(Date.now());
 
     const sp = parseServiceParts(this.config?.delete_service);
     const fsp = parseServiceParts(this.config?.frigate_delete_service);


### PR DESCRIPTION
Fixes #191.

## Problem
When a media-source day folder is discovered but holds no media — typically a freshly-created current-day folder with no recordings yet — it became the newest calendar day. The gallery defaulted there and showed "No media for this day". With a live camera configured the gallery controls were suppressed entirely (live-only view), leaving no way back to a day that actually has media.

## Fix
- **Walker** (`media-walker.ts`): probe the newest days until one holds media; any probed day that browses to no media is pruned from the calendar (`days` + `byDay` + caches). Prune-as-you-go — this also runs for the active day's prefetched neighbours — so empty days vanish a step ahead of navigation and never appear in the day picker, without browsing the whole tree up front. They reappear automatically once a later discovery finds media in them.
- **Pipeline** (`item-pipeline.ts`): default the active day to the newest day that has loaded items (defensive net for cached/transient calendars). An explicit selection is still honoured.
- **Editor** (`index.js`): highlight "Today" only on the literal current date, not merely the newest day with media.

## Tests
Adds unit coverage for the calendar prune (walker) and the empty-day skip (pipeline). Full suite green.