### PR TITLE
fix(thumbnails): keep card width stable under grid-layout (#185)

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1618,6 +1618,13 @@ export const cardStyles = css`
       gap: var(--cgc-thumb-gap, 12px);
       margin-top: 0;
       margin-bottom: 0;
+      /* Bug #185: under custom:grid-layout an auto-sized column sizes the card
+       * to its max-content, and the strip's full width would blow the card out.
+       * width:0 zeroes the max-content contribution so the column is driven by
+       * the preview instead; min-width:100% stretches the strip back to the
+       * column at layout time, leaving overflow-x to scroll. */
+      width: 0;
+      min-width: 100%;
       overflow-x: auto;
       overflow-y: hidden;
       -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Fixes #185.

Under `custom:grid-layout` an auto-sized column sizes the card to its **max-content**. The horizontal thumbnail strip's full width (all thumbnails laid out) then blows the card out beyond its column — visible in the browser (Grid layout-card) but not the app (Vertical layout-card), exactly as reported.

**Fix:** on `.tthumbs.horizontal`, `width: 0` zeroes the strip's max-content contribution so the grid column is driven by the preview instead; `min-width: 100%` stretches the strip back to the column at layout time, leaving `overflow-x` to scroll.

Net 7 lines on a single selector. The `.tthumbs-wrap` uses a percentage width and is unaffected.

**Verified** on a 2-tab `custom:grid-layout` / `custom:vertical-layout` repro with 6/50/100 thumbnails: before → card blows out; after → card stays at preview width and the strip scrolls, matching the vertical layout.